### PR TITLE
Onedata & Kubernetes integration

### DIFF
--- a/src/providers/onpremises/clients/__init__.py
+++ b/src/providers/onpremises/clients/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 
-__all__ = ['kaniko','eventgateway','minio','openfaas', 'onedata']
+__all__ = ['kaniko','eventgateway','minio','openfaas', 'onedata', 'kubernetes']

--- a/src/providers/onpremises/clients/__init__.py
+++ b/src/providers/onpremises/clients/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 
-__all__ = ['kaniko','eventgateway','minio','openfaas']
+__all__ = ['kaniko','eventgateway','minio','openfaas', 'onedata']

--- a/src/providers/onpremises/clients/kaniko.py
+++ b/src/providers/onpremises/clients/kaniko.py
@@ -16,39 +16,18 @@
 import src.utils as utils
 import os
 import stat
-import requests
 import logging
-import time
 
 class KanikoClient():
 
-    jobs_path = "/apis/batch/v1/namespaces/kaniko-builds/jobs"
-    
+    namespace = 'kaniko-builds'
+
     def __init__(self, function_args):
         self.registry_name = utils.get_environment_variable("DOCKER_REGISTRY")
         self.function_args = function_args
         self.function_image_folder = utils.join_paths("/pv/kaniko-builds", utils.get_random_uuid4_str())
         self.root_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
         self.job_name = "{0}-build-job".format(function_args['name'])
-        # Get k8s api host and port
-        self.kubernetes_service_host = utils.get_environment_variable("KUBERNETES_SERVICE_HOST")
-        if not self.kubernetes_service_host:
-            self.kubernetes_service_host = "kubernetes.default"
-        self.kubernetes_service_port = utils.get_environment_variable("KUBERNETES_SERVICE_PORT")
-        if not self.kubernetes_service_port:
-            self.kubernetes_service_port = "443"
-        # Get k8s api token
-        self.token = utils.read_file("/var/run/secrets/kubernetes.io/serviceaccount/token")
-        # Get k8s api certs 
-        if os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"):
-            self.cert_verify = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        else:
-            self.cert_verify = False
-        self.jobs_url = "https://{0}:{1}{2}".format(self.kubernetes_service_host, self.kubernetes_service_port, self.jobs_path)
-
-    @utils.lazy_property
-    def auth_header(self):
-        return {'Authorization': 'Bearer ' + self.token}
 
     def copy_dockerfile(self):
         # Get function Dockerfile paths
@@ -59,7 +38,7 @@ class KanikoClient():
             with open(func_dockerfile_dest_path, 'w') as f_out:
                 for line in f_in:
                     f_out.write(line.replace("FROM ubuntu", "FROM {0}".format(self.function_args['image'])))
-                    
+
     def download_binaries(self):
         # Download latest fwatchdog binary and set exec permissions
         utils.download_github_asset('openfaas', 'faas', 'fwatchdog', self.function_image_folder)
@@ -72,7 +51,7 @@ class KanikoClient():
         supervisor_path = os.path.join(self.function_image_folder, 'supervisor')
         supervisor_st = os.stat(supervisor_path)
         os.chmod(supervisor_path, supervisor_st.st_mode | stat.S_IEXEC)
-        
+
     def copy_user_script(self):
         utils.create_file_with_content(utils.join_paths(self.function_image_folder, "user_script.sh"),
                                        utils.base64_to_utf8_string(self.function_args['script']))       
@@ -90,25 +69,6 @@ class KanikoClient():
         # Delete all the temporal files created for the image creation
         utils.delete_folder(self.function_image_folder)
 
-    def wait_until_build_finishes(self):
-        while True:
-            r = requests.get("{0}/{1}".format(self.jobs_url, self.job_name), verify=self.cert_verify, headers=self.auth_header)
-            if r.status_code != 200:
-                logging.error("Error obtaining {0} info - {1}\n{2}".format(self.job_name, str(r.status_code), str(r.content)))
-                break
-            job = r.json()
-            if utils.is_value_in_dict(job['status'], 'succeeded') and utils.is_value_in_dict(job['spec'], 'completions'):
-                if job['status']['succeeded'] >= job['spec']['completions']:
-                    # Delete succeeded job
-                    self.delete_job()
-                    break
-            if utils.is_value_in_dict(job['status'], 'failed') and utils.is_value_in_dict(job['spec'], 'backoffLimit'):
-                if job['status']['failed'] >= job['spec']['backoffLimit']:
-                    logging.error("{0} failed! See pod logs for details.".format(self.job_name))
-                    break
-            time.sleep(5)
-
-
     def create_job_definition(self):
         self.registry_image_id = "{0}/{1}".format(self.registry_name, self.function_args['name'])
         job = {
@@ -116,7 +76,7 @@ class KanikoClient():
             'kind': 'Job',
             'metadata': {
                 'name': self.job_name,
-                'namespace': 'kaniko-builds',
+                'namespace': self.namespace,
             },
             'spec': {
                 'template': {
@@ -156,24 +116,14 @@ class KanikoClient():
         }
         return job
 
-    def delete_job(self):
-        r = requests.delete("{0}/{1}".format(self.jobs_url, self.job_name), 
-                            verify=self.cert_verify, 
-                            headers=self.auth_header,
-                            params={'propagationPolicy': 'Background'})
-        if r.status_code not in [200, 202]:
-            logging.error("Error deleting {0} - {1}\n{2}".format(self.job_name, str(r.status_code), str(r.content)))
-
-    def create_and_push_docker_image(self):
+    def create_and_push_docker_image(self, kubernetes_client):
         # Copy/create function required files
         self.copy_required_files()    
         # Build the docker image       
         job = self.create_job_definition()
         # Send request to the k8s api
-        r = requests.post(self.jobs_url, json=job, verify=self.cert_verify, headers=self.auth_header)
-        if r.status_code not in [200, 201, 202]:
-            logging.error("Error creating {0} - {1}\n{2}".format(self.job_name, str(r.status_code), str(r.content)))
+        kubernetes_client.create_job(job, self.job_name, self.namespace)
         # Wait until build finishes
-        self.wait_until_build_finishes()
+        kubernetes_client.wait_job(self.job_name, self.namespace, delete=True)
         # Avoid storing unnecessary files
         self.delete_image_files()

--- a/src/providers/onpremises/clients/kubernetes.py
+++ b/src/providers/onpremises/clients/kubernetes.py
@@ -1,0 +1,126 @@
+# OSCAR - On-premises Serverless Container-aware ARchitectures
+# Copyright (C) GRyCAP - I3M - UPV
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import src.utils as utils
+import os
+import time
+import logging
+import requests
+
+class KubernetesClient():
+
+    jobs_path = '/apis/batch/v1/namespaces/{0}/jobs'
+    deployments_path = '/apis/apps/v1/namespaces/{0}/deployments'
+
+    def __init__(self):
+        # Get k8s api host and port
+        self.kubernetes_service_host = utils.get_environment_variable('KUBERNETES_SERVICE_HOST')
+        if not self.kubernetes_service_host:
+            self.kubernetes_service_host = 'kubernetes.default'
+        self.kubernetes_service_port = utils.get_environment_variable('KUBERNETES_SERVICE_PORT')
+        if not self.kubernetes_service_port:
+            self.kubernetes_service_port = '443'
+        # Get k8s api token
+        self.kube_token = utils.read_file('/var/run/secrets/kubernetes.io/serviceaccount/token')
+        # Get k8s api certs 
+        if os.path.isfile('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'):
+            self.cert_verify = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        else:
+            self.cert_verify = False
+
+    @utils.lazy_property
+    def auth_header(self):
+        return {'Authorization': 'Bearer ' + self.kube_token}
+
+    def create_job(self, definition, name, namespace):
+        jobs_path = self.jobs_path.format(namespace)
+        url = 'https://{0}:{1}{2}'.format(self.kubernetes_service_host, self.kubernetes_service_port, jobs_path)
+        try:
+            r = requests.post(url, json=definition, verify=self.cert_verify, headers=self.auth_header)
+            if r.status_code not in [200, 201, 202]:
+                raise Exception("Error creating job {0} - {1}\n{2}".format(name, str(r.status_code), str(r.content)))
+        except Exception as e:
+            logging.error(e)
+
+    def delete_job(self, name, namespace):
+        jobs_path = self.jobs_path.format(namespace)
+        url = 'https://{0}:{1}{2}/{3}'.format(self.kubernetes_service_host, self.kubernetes_service_port, jobs_path, name)
+        params = {'propagationPolicy': 'Background'}
+        try:
+            r = requests.delete(url, verify=self.cert_verify, headers=self.auth_header, params=params)
+            if r.status_code not in [200, 202]:
+                raise Exception("Error deleting {0} - {1}\n{2}".format(name, str(r.status_code), str(r.content)))
+        except Exception as e:
+            logging.error(e)
+
+    def wait_job(self, name, namespace, delete=False, sleep=5):
+        jobs_path = self.jobs_path.format(namespace)
+        url = 'https://{0}:{1}{2}/{3}'.format(self.kubernetes_service_host, self.kubernetes_service_port, jobs_path, name)
+        while True:
+            try:
+                r = requests.get(url, verify=self.cert_verify, headers=self.auth_header)
+                if r.status_code != 200:
+                    raise Exception('Error obtaining {0} info - {1}\n{2}'.format(name, str(r.status_code), str(r.content)))
+                job = r.json()
+                if utils.is_value_in_dict(job['status'], 'succeeded') and utils.is_value_in_dict(job['spec'], 'completions'):
+                    if job['status']['succeeded'] >= job['spec']['completions']:
+                        # Delete succeeded jobs if delete=True
+                        if delete: self.delete_job(name, namespace)
+                        break
+                if utils.is_value_in_dict(job['status'], 'failed') and utils.is_value_in_dict(job['spec'], 'backoffLimit'):
+                    if job['status']['failed'] >= job['spec']['backoffLimit']:
+                        logging.error('{0} failed! See pod logs for details'.format(name))
+                        break
+                time.sleep(sleep)
+            except Exception as e:
+                logging.error(e)
+                break
+
+    def create_deployment(self, definition, name, namespace):
+        deployments_path = self.deployments_path.format(namespace)
+        url = 'https://{0}:{1}{2}'.format(self.kubernetes_service_host, self.kubernetes_service_port, deployments_path)
+        try:
+            r = requests.post(url, json=definition, verify=self.cert_verify, headers=self.auth_header)
+            if r.status_code not in [200, 201, 202]:
+                raise Exception('Error creating deployment {0} - {1}\n{2}'.format(name, str(r.status_code), str(r.content)))
+        except Exception as e:
+            logging.error(e)
+
+    def delete_deployment(self, name, namespace):
+        deployments_path = self.deployments_path.format(namespace)
+        url = 'https://{0}:{1}{2}/{3}'.format(self.kubernetes_service_host, self.kubernetes_service_port, deployments_path, name)
+        try:
+            r = requests.delete(url, verify=self.cert_verify, headers=self.auth_header)
+            if r.status_code not in [200, 202]:
+                raise Exception("Error deleting {0} - {1}\n{2}".format(name, str(r.status_code), str(r.content)))
+        except Exception as e:
+            logging.error(e)
+
+    def get_deployment_envvars(self, name, namespace):
+        deployments_path = self.deployments_path.format(namespace)
+        url = 'https://{0}:{1}{2}/{3}'.format(self.kubernetes_service_host, self.kubernetes_service_port, deployments_path, name)
+        try:
+            r = requests.get(url, verify=self.cert_verify, headers=self.auth_header)
+            if r.status_code != 200:
+                raise Exception('Error reading deployment {0} - {1}\n{2}'.format(name, str(r.status_code), str(r.content)))
+            deploy = r.json()
+            if len(deploy['spec']['template']['spec']['containers']) > 1:
+                logging.warning('The function have more than one container. Getting environment variables from the first one')
+            container_info = deploy['spec']['template']['spec']['containers'][0]
+            envvars = container_info['env'] if 'env' in container_info else []
+            return envvars
+        except Exception as e:
+            logging.error(e)
+            return []

--- a/src/providers/onpremises/clients/onedata.py
+++ b/src/providers/onpremises/clients/onedata.py
@@ -166,6 +166,10 @@ class OnedataClient():
                                     {
                                         'name': 'ONEDATA_SPACE_FOLDER',
                                         'value': self.get_output_bucket_name()
+                                    },
+                                    {
+                                        'name': 'ONETRIGGER_WEBHOOK',
+                                        'value': 'http://event-gateway:4000/{0}'.format(self.function_name)
                                     }
                                 ]
                             }

--- a/src/providers/onpremises/clients/onedata.py
+++ b/src/providers/onpremises/clients/onedata.py
@@ -126,11 +126,24 @@ class OnedataClient():
             'kind': 'Deployment',
             'metadata': {
                 'name': '{0}-onetrigger'.format(self.function_name),
-                'namespace': 'oscar'
+                'namespace': 'oscar',
+                'labels': {
+                    'app': '{0}-onetrigger'.format(self.function_name)
+                }
             },
             'spec': {
+                'selector': {
+                    'matchLabels': {
+                        'app': '{0}-onetrigger'.format(self.function_name)
+                    }
+                },
                 'replicas': 1,
                 'template': {
+                    'metadata': {
+                        'labels': {
+                            'app': '{0}-onetrigger'.format(self.function_name)
+                        }
+                    },
                     'spec': {
                         'containers': [
                             {

--- a/src/providers/onpremises/clients/onedata.py
+++ b/src/providers/onpremises/clients/onedata.py
@@ -46,7 +46,7 @@ class OnedataClient():
             self.cert_verify = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         else:
             self.cert_verify = False
-        self.jobs_url = "https://{0}:{1}{2}".format(self.kubernetes_service_host, self.kubernetes_service_port, self.deployments_path)
+        self.deployments_url = "https://{0}:{1}{2}".format(self.kubernetes_service_host, self.kubernetes_service_port, self.deployments_path)
 
     @utils.lazy_property
     def kube_auth_header(self):
@@ -161,11 +161,8 @@ class OnedataClient():
                 }
             }
         }
-        url = '{0}:{1}{2}'.format(self.kubernetes_service_host,
-                                  self.kubernetes_service_port,
-                                  self.deployments_path)
         try:
-            r = requests.post(url, json=deploy, headers=self.kube_auth_header, verify=self.cert_verify)
+            r = requests.post(self.deployments_url, json=deploy, headers=self.kube_auth_header, verify=self.cert_verify)
             if r.status_code in [200, 201, 202]:
                 logging.info('Deployment "{0}" created successfully'.format(deploy['metadata']['name']))
             else:
@@ -174,10 +171,7 @@ class OnedataClient():
             logging.error('Unable to deploy OneTrigger. Error: {0}'.format(e))
 
     def delete_onetrigger_deploy(self):
-        url = '{0}:{1}{2}/{3}-onetrigger'.format(self.kubernetes_service_host,
-                                  self.kubernetes_service_port,
-                                  self.deployments_path,
-                                  self.function_name)
+        url = '{0}/{1}-onetrigger'.format(self.deployments_url, self.function_name)
         try:
             r = requests.delete(url, headers=self.kube_auth_header, verify=self.cert_verify)
             if r.status_code in [200, 202]:

--- a/src/providers/onpremises/clients/onedata.py
+++ b/src/providers/onpremises/clients/onedata.py
@@ -184,4 +184,4 @@ class OnedataClient():
         kubernetes_client.create_deployment(deploy, self.function_name, self.namespace)
 
     def delete_onetrigger_deploy(self, kubernetes_client):
-        kubernetes_client.delete_deployment(self.function_name, self.namespace)
+        kubernetes_client.delete_deployment('{0}-onetrigger'.format(self.function_name), self.namespace)

--- a/src/providers/onpremises/clients/onedata.py
+++ b/src/providers/onpremises/clients/onedata.py
@@ -165,7 +165,7 @@ class OnedataClient():
                                     },
                                     {
                                         'name': 'ONEDATA_SPACE_FOLDER',
-                                        'value': self.get_output_bucket_name()
+                                        'value': '{0}-in'.format(self.function_name)
                                     },
                                     {
                                         'name': 'ONETRIGGER_WEBHOOK',

--- a/src/providers/onpremises/clients/onedata.py
+++ b/src/providers/onpremises/clients/onedata.py
@@ -1,0 +1,188 @@
+# OSCAR - On-premises Serverless Container-aware ARchitectures
+# Copyright (C) GRyCAP - I3M - UPV
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import src.utils as utils
+import os
+import logging
+import requests
+
+class OnedataClient():
+
+    deployments_path = "/apis/apps/v1/namespaces/oscar/deployments"
+    cdmi_path = '/cdmi/'
+    cdmi_version_header = {'X-CDMI-Specification-Version': '1.1.1'}
+    cdmi_container_header = {'Content-Type': 'application/cdmi-container'}
+    
+    def __init__(self, function_args):
+        self.function_name = function_args['name']
+        if 'envVars' in function_args and 'OUTPUT_BUCKET' in function_args['envVars']:    
+            self.output_bucket = function_args['envVars']['OUTPUT_BUCKET'].strip('/ ')
+        self.oneprovider_host = function_args['envVars']['ONEPROVIDER_HOST']
+        self.onedata_access_token = function_args['envVars']['ONEDATA_ACCESS_TOKEN']
+        self.onedata_space = function_args['envVars']['ONEDATA_SPACE'].strip('/ ')
+        # Get k8s api host and port
+        self.kubernetes_service_host = utils.get_environment_variable("KUBERNETES_SERVICE_HOST")
+        if not self.kubernetes_service_host:
+            self.kubernetes_service_host = "kubernetes.default"
+        self.kubernetes_service_port = utils.get_environment_variable("KUBERNETES_SERVICE_PORT")
+        if not self.kubernetes_service_port:
+            self.kubernetes_service_port = "443"
+        # Get k8s api token
+        self.kube_token = utils.read_file("/var/run/secrets/kubernetes.io/serviceaccount/token")
+        # Get k8s api certs 
+        if os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"):
+            self.cert_verify = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        else:
+            self.cert_verify = False
+        self.jobs_url = "https://{0}:{1}{2}".format(self.kubernetes_service_host, self.kubernetes_service_port, self.deployments_path)
+
+    @utils.lazy_property
+    def kube_auth_header(self):
+        return {'Authorization': 'Bearer ' + self.kube_token}
+
+    @utils.lazy_property
+    def onedata_auth_header(self):
+        return {'X-Auth-Token': self.onedata_access_token}
+
+    def folder_exists(self, folder_name):
+        folder_name = '{0}/'.format(folder_name.strip('/ '))
+        url = 'https://{0}{1}{2}?children'.format(self.oneprovider_host, self.cdmi_path, self.onedata_space)
+        headers = {**self.cdmi_version_header, **self.onedata_auth_header}
+        try:
+            r = requests.get(url, headers=headers)
+            if r.status_code == 200:
+                if folder_name in r.json()['children']:
+                    return True
+        except Exception as e:
+            logging.warning('Cannot check if folder "{0}" exists. Error: {1}'.format(folder_name, e))
+            return False
+        return False
+
+    def create_input_folder(self):
+        self.create_folder('{0}-in'.format(self.function_name))
+
+    def create_output_folder(self):
+        if not hasattr(self, 'output_bucket'):
+            self.create_folder('{0}-out'.format(self.function_name))
+
+    def create_folder(self, folder_name):
+        url = 'https://{0}{1}{2}/{3}/'.format(self.oneprovider_host, self.cdmi_path, self.onedata_space, folder_name)
+        headers = {**self.cdmi_version_header, **self.cdmi_container_header, **self.onedata_auth_header}
+        try:
+            r = requests.put(url, headers=headers)
+            if r.status_code in [201, 202]:
+                logging.info('Folder "{0}" created successfully in space "{1}"'.format(folder_name, self.onedata_space))
+            else:
+                raise Exception(r.status_code)
+        except Exception as e:
+            logging.warning('Unable to create folder "{0}". Error: {1}'.format(folder_name, e))
+
+    def delete_input_folder(self):
+        self.delete_folder('{0}-in'.format(self.function_name))
+
+    def delete_output_folder(self):
+        self.delete_folder('{0}-out'.format(self.function_name))                    
+
+    def delete_folder(self, folder_name):
+        url = 'https://{0}{1}{2}/{3}/'.format(self.oneprovider_host, self.cdmi_path, self.onedata_space, folder_name)
+        headers = {**self.cdmi_version_header, **self.onedata_auth_header}
+        try:
+            r = requests.delete(url, headers=headers)
+            if r.status_code == 204:
+                logging.info('Folder "{0}" deleted successfully in space "{1}"'.format(folder_name, self.onedata_space))
+            else:
+                raise Exception(r.status_code)
+        except Exception as e:
+            logging.warning('Unable to delete folder "{0}". Error: {1}'.format(folder_name, e))
+
+    def get_output_bucket_name(self):
+        return self.output_bucket if hasattr(self, 'output_bucket') else '{0}-out'.format(self.function_name)
+    
+    def get_oneprovider_host(self):
+        return self.oneprovider_host
+
+    def get_onedata_access_token(self):
+        return self.onedata_access_token
+    
+    def get_onedata_space(self):
+        return self.onedata_space
+
+    def deploy_onetrigger(self):
+        # K8s deployment object
+        deploy = {
+            'apiVersion': 'apps/v1',
+            'kind': 'Deployment',
+            'metadata': {
+                'name': '{0}-onetrigger'.format(self.function_name),
+                'namespace': 'oscar'
+            },
+            'spec': {
+                'replicas': 1,
+                'template': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'onetrigger',
+                                'image': 'grycap/onetrigger:latest',
+                                'imagePullPolicy': 'Always',
+                                'env': [
+                                    {
+                                        'name': 'ONEPROVIDER_HOST',
+                                        'value': self.get_oneprovider_host()
+                                    },
+                                    {
+                                        'name': 'ONEDATA_ACCESS_TOKEN',
+                                        'value': self.get_onedata_access_token()
+                                    },
+                                    {
+                                        'name': 'ONEDATA_SPACE',
+                                        'value': self.get_onedata_space()
+                                    },
+                                    {
+                                        'name': 'ONEDATA_SPACE_FOLDER',
+                                        'value': self.get_output_bucket_name()
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        url = '{0}:{1}{2}'.format(self.kubernetes_service_host,
+                                  self.kubernetes_service_port,
+                                  self.deployments_path)
+        try:
+            r = requests.post(url, json=deploy, headers=self.kube_auth_header, verify=self.cert_verify)
+            if r.status_code in [200, 201, 202]:
+                logging.info('Deployment "{0}" created successfully'.format(deploy['metadata']['name']))
+            else:
+                raise Exception(r.status_code)
+        except Exception as e:
+            logging.error('Unable to deploy OneTrigger. Error: {0}'.format(e))
+
+    def delete_onetrigger_deploy(self):
+        url = '{0}:{1}{2}/{3}-onetrigger'.format(self.kubernetes_service_host,
+                                  self.kubernetes_service_port,
+                                  self.deployments_path,
+                                  self.function_name)
+        try:
+            r = requests.delete(url, headers=self.kube_auth_header, verify=self.cert_verify)
+            if r.status_code in [200, 202]:
+                logging.info('Deployment "{0}-onetrigger" deleted successfully'.format(self.function_name))
+            else:
+                raise Exception(r.status_code)
+        except Exception as e:
+            logging.error('Unable to delete deployment "{0}-onetrigger". Error: {1}'.format(self.function_name, e))


### PR DESCRIPTION
- Check if Onedata credentials are defined in a function in order to:
  - Create input & output folders when new function is created
  - Delete input & output folders if `deleteBuckets` is passed to remove method
  - Deploy OneTrigger to send file events
  - Delete OneTrigger deployments
- Externalize Kubernetes related methods to a new class called `KubernetesClient` with ability to:
  - Create & delete jobs
  - Wait for a job
  - Create & delete deployments
  - Get environment variables from deployments