### PR TITLE
Included additional default hosts in the OpenAPI spec

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,6 +3,6 @@
 OSCAR exposes a secure REST API available at the Kubernetes master's node IP
 through an ingress. This API has been described following the
 [OpenAPI Specification](https://www.openapis.org/) and it can be
-consulted bellow.
+consulted below.
 
 !!swagger api.yaml!!

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -605,4 +605,6 @@ tags:
   - name: health
 servers:
   - url: 'https://localhost'
-    description: ''
+    description: 'Local testing'
+  - url: 'https://inference.cloud.ai4eosc.eu'
+    description: 'AI4EOSC's OSCAR cluster'


### PR DESCRIPTION
## Proposed Changes
 - Include AI4EOSC's default endpoint for easier usage  from the OpenAPI page
 - Minor errata fix