### PR TITLE
MinIO bucket management fixed when isolation_level is set 

### DIFF
--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -130,40 +130,46 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 
 			ownerOnList := false
 
-			if len(service.AllowedUsers) > 0 {
-				path := strings.Trim(service.Input[0].Path, "/")
-				splitPath := strings.SplitN(path, "/", 2)
-				// If AllowedUsers is empty don't add uid
-				service.Labels["uid"] = full_uid[:10]
-				var userBucket string
-				for _, u := range service.AllowedUsers {
-					// Check if the uid's from allowed_users have and asociated MinIO user
-					// and create it if not
-					if !mc.UserExists(u) {
-						sk, _ := auth.GenerateRandomKey(8)
-						cmuErr := minIOAdminClient.CreateMinIOUser(u, sk)
-						if cmuErr != nil {
-							log.Printf("error creating MinIO user for user %s: %v", u, cmuErr)
+			if len(service.AllowedUsers) > 0 && strings.ToUpper(service.IsolationLevel) == types.IsolationLevelUser {
+				for _, in := range service.Input {
+					_, provName := getProviderInfo(in.Provider)
+
+					// Only allow input from MinIO and dCache
+					if provName == types.MinIOName {
+						path := strings.Trim(in.Path, "/")
+						splitPath := strings.SplitN(path, "/", 2)
+						// If AllowedUsers is empty don't add uid
+						service.Labels["uid"] = full_uid[:10]
+						var userBucket string
+						for _, u := range service.AllowedUsers {
+							// Check if the uid's from allowed_users have and asociated MinIO user
+							// and create it if not
+							if !mc.UserExists(u) {
+								sk, _ := auth.GenerateRandomKey(8)
+								cmuErr := minIOAdminClient.CreateMinIOUser(u, sk)
+								if cmuErr != nil {
+									log.Printf("error creating MinIO user for user %s: %v", u, cmuErr)
+								}
+								csErr := mc.CreateSecretForOIDC(u, sk)
+								if csErr != nil {
+									log.Printf("error creating secret for user %s: %v", u, csErr)
+								}
+							}
+							// Fill the list of private buckets to be used on users buckets isolation
+							// Check the uid of the owner is on the allowed_users list
+							if u == service.Owner {
+								ownerOnList = true
+							}
+							// Fill the list of private buckets to create
+							userBucket = splitPath[0] + "-" + u[:10]
+							service.BucketList = append(service.BucketList, userBucket)
 						}
-						csErr := mc.CreateSecretForOIDC(u, sk)
-						if csErr != nil {
-							log.Printf("error creating secret for user %s: %v", u, csErr)
+
+						if !ownerOnList {
+							service.AllowedUsers = append(service.AllowedUsers, uid)
 						}
 					}
-					// Fill the list of private buckets to be used on users buckets isolation
-					// Check the uid of the owner is on the allowed_users list
-					if u == service.Owner {
-						ownerOnList = true
-					}
-					// Fill the list of private buckets to create
-					userBucket = splitPath[0] + "-" + u[:10]
-					service.BucketList = append(service.BucketList, userBucket)
 				}
-
-				if !ownerOnList {
-					service.AllowedUsers = append(service.AllowedUsers, uid)
-				}
-
 			}
 		}
 		if len(service.Environment.Secrets) > 0 {
@@ -364,7 +370,7 @@ func createBuckets(service *types.Service, cfg *types.Config, minIOAdminClient *
 			Visibility:   service.Visibility,
 			Owner:        service.Owner})
 		// Create buckets for services with isolation level
-		if strings.ToUpper(service.IsolationLevel) == "USER" && len(service.BucketList) > 0 {
+		if strings.ToUpper(service.IsolationLevel) == types.IsolationLevelUser && len(service.BucketList) > 0 {
 			for i, b := range service.BucketList {
 				// Create a bucket for each allowed user if allowed_users is not empty
 				err = minIOAdminClient.CreateS3PathWithWebhook(s3Client, []string{b, folderKey}, service.GetMinIOWebhookARN(), false)
@@ -434,7 +440,7 @@ func createBuckets(service *types.Service, cfg *types.Config, minIOAdminClient *
 				}
 			}
 
-			if strings.ToUpper(service.IsolationLevel) == "USER" && len(service.BucketList) > 0 {
+			if strings.ToUpper(service.IsolationLevel) == types.IsolationLevelUser && len(service.BucketList) > 0 {
 				for _, b := range service.BucketList {
 					err := minIOAdminClient.CreateS3Path(s3Client, []string{b, folderKey}, true)
 					if err != nil && !isUpdate {

--- a/pkg/handlers/delete_test.go
+++ b/pkg/handlers/delete_test.go
@@ -63,7 +63,7 @@ func TestMakeDeleteHandler(t *testing.T) {
 		Output: []types.StorageIOConfig{
 			{Provider: "minio." + types.DefaultProvider, Path: "/output"},
 		},
-		IsolationLevel: "USER",
+		IsolationLevel: types.IsolationLevelUser,
 		AllowedUsers:   []string{"somelonguid1@egi.eu"},
 		StorageProviders: &types.StorageProviders{
 			MinIO: map[string]*types.MinIOProvider{types.DefaultProvider: {

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -39,6 +40,7 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 		var provName string
 		var newService types.Service
 		var uid string
+		var mc *auth.MultitenancyConfig
 		if err := c.ShouldBindJSON(&newService); err != nil {
 			c.String(http.StatusBadRequest, fmt.Sprintf("The service specification is not valid: %v", err))
 			return
@@ -66,6 +68,7 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 
 		if !isAdminUser {
 			uid, err = auth.GetUIDFromContext(c)
+
 			if err != nil {
 				c.String(http.StatusInternalServerError, fmt.Sprintln("Couldn't get UID from context"))
 			}
@@ -73,6 +76,11 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 			if oldService.Owner != uid {
 				c.String(http.StatusForbidden, "User %s doesn't have permision to modify this service", uid)
 				return
+			}
+			mc, err = auth.GetMultitenancyConfigFromContext(c)
+
+			if err != nil {
+				c.String(http.StatusInternalServerError, fmt.Sprintln("Couldn't get UID from context"))
 			}
 
 			// Set the owner on the new service definition
@@ -92,24 +100,79 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 				}
 			}
 		}
-		if len(newService.Environment.Secrets) > 0 {
-			if utils.SecretExists(newService.Name, cfg.ServicesNamespace, back.GetKubeClientset()) {
-				secretsErr := utils.UpdateSecretData(newService.Name, cfg.ServicesNamespace, newService.Environment.Secrets, back.GetKubeClientset())
-				if secretsErr != nil {
-					c.String(http.StatusInternalServerError, "error updating asociated secret: %v", secretsErr)
-				}
-			} else {
-				secretsErr := utils.CreateSecret(newService.Name, cfg.ServicesNamespace, newService.Environment.Secrets, back.GetKubeClientset())
-				if secretsErr != nil {
-					c.String(http.StatusInternalServerError, "error adding asociated secret: %v", secretsErr)
+
+		minIOAdminClient, _ := utils.MakeMinIOAdminClient(cfg)
+		s3Client := cfg.MinIOProvider.GetS3Client()
+		fmt.Println(newService)
+		if newService.IsolationLevel == types.IsolationLevelUser && len(newService.AllowedUsers) > 0 {
+			// new bucket list
+			ownerOnList := false
+			full_uid := auth.FormatUID(uid)
+			for _, in := range newService.Input {
+				_, provName := getProviderInfo(in.Provider)
+
+				// Only allow input from MinIO
+				if provName == types.MinIOName {
+					path := strings.Trim(in.Path, "/")
+					splitPath := strings.SplitN(path, "/", 2)
+					// If AllowedUsers is empty don't add uid
+					newService.Labels["uid"] = full_uid[:10]
+					var userBucket string
+					for _, u := range newService.AllowedUsers {
+						// Check if the uid's from allowed_users have and asociated MinIO user
+						// and create it if not
+						if mc != nil && !mc.UserExists(u) {
+							sk, _ := auth.GenerateRandomKey(8)
+							cmuErr := minIOAdminClient.CreateMinIOUser(u, sk)
+							if cmuErr != nil {
+								log.Printf("error creating MinIO user for user %s: %v", u, cmuErr)
+							}
+							csErr := mc.CreateSecretForOIDC(u, sk)
+							if csErr != nil {
+								log.Printf("error creating secret for user %s: %v", u, csErr)
+							}
+						}
+						// Fill the list of private buckets to be used on users buckets isolation
+						// Check the uid of the owner is on the allowed_users list
+						if u == newService.Owner {
+							ownerOnList = true
+						}
+						// Fill the list of private buckets to create
+						userBucket = splitPath[0] + "-" + u[:10]
+						newService.BucketList = append(newService.BucketList, userBucket)
+					}
+
+					if !ownerOnList {
+						newService.AllowedUsers = append(newService.AllowedUsers, uid)
+					}
+					/// Create
 				}
 			}
 		}
 
-		minIOAdminClient, _ := utils.MakeMinIOAdminClient(cfg)
+		if oldService.IsolationLevel == types.IsolationLevelUser && len(oldService.BucketList) != 0 {
+			for _, bucket := range oldService.BucketList {
+				if !slices.Contains(newService.BucketList, bucket) {
+					// Disable input notifications for service bucket
+					if err := disableInputNotifications(s3Client, oldService.GetMinIOWebhookARN(), bucket); err != nil {
+						log.Printf("Error disabling MinIO input notifications for service \"%s\": %v\n", oldService.Name, err)
+					}
+
+					err := DeleteMinIOBuckets(s3Client, minIOAdminClient, utils.MinIOBucket{
+						BucketPath:   bucket,
+						Visibility:   utils.PRIVATE,
+						AllowedUsers: []string{},
+						Owner:        oldService.Owner,
+					})
+					if err != nil {
+						fmt.Errorf("error while removing MinIO bucket %v", err)
+					}
+				}
+			}
+		}
 
 		// If isolation level was USER delete all private buckets
-		if strings.ToUpper(oldService.IsolationLevel) == "USER" && strings.ToUpper(newService.IsolationLevel) == "USER" {
+		if strings.ToUpper(oldService.IsolationLevel) == types.IsolationLevelUser && strings.ToUpper(newService.IsolationLevel) == types.IsolationLevelUser {
 			// TODO add/remove users buckets
 		}
 

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -103,6 +103,10 @@ const (
 
 	// ReSchedulerLabelKey label key to enable/disable the ReScheduler
 	ReSchedulerLabelKey = "oscar_rescheduler"
+
+	IsolationLevelUser = "USER"
+
+	IsolationLevelService = "SERVICE"
 )
 
 // YAMLMarshal package-level yaml marshal function


### PR DESCRIPTION
## Fixes

- Adapted isolation_level implementation to the new bucket management definition
- Fixed list_buckets error: HTTP error 403 when listing for user without buckets due to empty policy
