### PR TITLE
fix: health check path

### DIFF
--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -289,7 +289,7 @@ func getPodTemplateSpec(service types.Service, cfg *types.Config) v1.PodTemplate
 
 		probeHandler := v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{
-				Path: "/",
+				Path: getAPIPath(service.Name),
 				Port: intstr.FromString(podPortName),
 			},
 		}


### PR DESCRIPTION
# Changes

- Changed the exposed service health check path from `/` to `/system/services/<service-name>/exposed`, fixing the deployment error caused by the wrong path to the exposed service.