### PR TITLE
Increased test coverage

### DIFF
--- a/pkg/handlers/buckets/create_bucket_test.go
+++ b/pkg/handlers/buckets/create_bucket_test.go
@@ -1,0 +1,201 @@
+package buckets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/testsupport"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+type bucketRequestRecorder struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *bucketRequestRecorder) add(call string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, call)
+}
+
+func (r *bucketRequestRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+func TestMakeCreateBucketHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		body        string
+		headers     map[string]string
+		wantStatus  int
+		setup       func(t *testing.T, cfg *types.Config) (func(), *bucketRequestRecorder)
+		assertCalls func(t *testing.T, recorder *bucketRequestRecorder)
+	}{
+		{
+			name:       "invalid json payload",
+			body:       "not-json",
+			headers:    map[string]string{"Content-Type": "application/json"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "admin creates bucket",
+			body: `{"bucket_path":"test-bucket","visibility":"private"}`,
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			wantStatus: http.StatusCreated,
+			setup: func(t *testing.T, cfg *types.Config) (func(), *bucketRequestRecorder) {
+				testsupport.SkipIfCannotListen(t)
+				recorder := &bucketRequestRecorder{}
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					recorder.add(r.Method + " " + r.Host + r.URL.RequestURI())
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/minio/admin/v3/info":
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"Mode":"mode","Region":"us-east-1"}`))
+					case r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "location"):
+						w.Header().Set("Content-Type", "application/xml")
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-east-1</LocationConstraint>`))
+					case r.Method == http.MethodPut && strings.Contains(r.URL.RawQuery, "tagging"):
+						w.WriteHeader(http.StatusOK)
+					case strings.HasPrefix(r.URL.Path, "/minio/admin/v3/"):
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"status":"success"}`))
+					default:
+						w.WriteHeader(http.StatusOK)
+					}
+				}))
+
+				endpoint := strings.Replace(server.URL, "127.0.0.1", "localhost", 1)
+				cfg.MinIOProvider.Endpoint = endpoint
+				cfg.MinIOProvider.Verify = false
+
+				cleanup := func() {
+					server.Close()
+				}
+				return cleanup, recorder
+			},
+			assertCalls: func(t *testing.T, recorder *bucketRequestRecorder) {
+				calls := recorder.snapshot()
+				var sawCreate, sawTagging bool
+				for _, call := range calls {
+					if !strings.HasPrefix(call, "PUT ") {
+						continue
+					}
+					if strings.Contains(call, "?tagging") {
+						sawTagging = true
+						continue
+					}
+					if strings.Contains(call, "/test-bucket") {
+						sawCreate = true
+					}
+				}
+				if !sawCreate {
+					t.Errorf("expected bucket creation request, got %v", calls)
+				}
+				if !sawTagging {
+					t.Errorf("expected bucket tagging request, got %v", calls)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &types.Config{
+				Name:        "oscar",
+				Namespace:   "oscar",
+				ServicePort: 8080,
+				MinIOProvider: &types.MinIOProvider{
+					Endpoint:  "http://127.0.0.1:9000",
+					Region:    "us-east-1",
+					AccessKey: "minioadmin",
+					SecretKey: "minioadmin",
+					Verify:    false,
+				},
+			}
+
+			var (
+				cleanup  func()
+				recorder *bucketRequestRecorder
+			)
+			if tt.setup != nil {
+				cleanup, recorder = tt.setup(t, cfg)
+			}
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			router := gin.New()
+			router.POST("/system/buckets", MakeCreateHandler(cfg))
+
+			req, err := http.NewRequest(http.MethodPost, "/system/buckets", strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("failed to build request: %v", err)
+			}
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			res := httptest.NewRecorder()
+			router.ServeHTTP(res, req)
+
+			if tt.assertCalls != nil {
+				tt := tt
+				tt.assertCalls(t, recorder)
+			}
+
+			if res.Code != tt.wantStatus {
+				t.Logf("response body: %s", res.Body.String())
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, res.Code)
+			}
+		})
+	}
+}
+
+func TestMakeCreateBucketHandlerMissingUID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &types.Config{
+		Name:        "oscar",
+		Namespace:   "oscar",
+		ServicePort: 8080,
+		MinIOProvider: &types.MinIOProvider{
+			Endpoint:  "http://127.0.0.1:9000",
+			Region:    "us-east-1",
+			AccessKey: "minioadmin",
+			SecretKey: "minioadmin",
+			Verify:    false,
+		},
+	}
+
+	router := gin.New()
+	router.POST("/system/buckets", func(c *gin.Context) {
+		c.Set("uidOrigin", "")
+		MakeCreateHandler(cfg)(c)
+	})
+
+	body := `{"bucket_path":"user-bucket"}`
+	req, err := http.NewRequest(http.MethodPost, "/system/buckets", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, res.Code)
+	}
+}

--- a/pkg/handlers/buckets/delete_bucket_test.go
+++ b/pkg/handlers/buckets/delete_bucket_test.go
@@ -1,0 +1,30 @@
+package buckets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func TestMakeDeleteBucketHandlerValidations(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &types.Config{MinIOProvider: &types.MinIOProvider{}}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, err := http.NewRequest(http.MethodDelete, "/system/buckets/", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	c.Request = req
+
+	MakeDeleteHandler(cfg)(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}

--- a/pkg/handlers/buckets/list_bucket_test.go
+++ b/pkg/handlers/buckets/list_bucket_test.go
@@ -1,0 +1,109 @@
+package buckets
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/testsupport"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func TestMakeListBucketHandlerAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const listXML = `<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <Owner>
+        <ID>owner</ID>
+        <DisplayName>owner</DisplayName>
+    </Owner>
+    <Buckets>
+        <Bucket>
+            <Name>bucket-one</Name>
+            <CreationDate>2024-01-01T00:00:00Z</CreationDate>
+        </Bucket>
+    </Buckets>
+</ListAllMyBucketsResult>`
+
+	testsupport.SkipIfCannotListen(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(listXML))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &types.Config{
+		MinIOProvider: &types.MinIOProvider{
+			Endpoint:  server.URL,
+			Region:    "us-east-1",
+			AccessKey: "minioadmin",
+			SecretKey: "minioadmin",
+			Verify:    false,
+		},
+	}
+
+	router := gin.New()
+	router.GET("/system/buckets", MakeListHandler(cfg))
+
+	req, err := http.NewRequest(http.MethodGet, "/system/buckets", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, res.Code)
+	}
+
+	var payload struct {
+		Buckets []struct {
+			Name string `json:"Name"`
+		} `json:"Buckets"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if len(payload.Buckets) != 1 || payload.Buckets[0].Name != "bucket-one" {
+		t.Fatalf("unexpected response payload: %v", payload.Buckets)
+	}
+}
+
+func TestMakeListBucketHandlerMissingUID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &types.Config{
+		MinIOProvider: &types.MinIOProvider{
+			Endpoint:  "http://127.0.0.1:9000",
+			Region:    "us-east-1",
+			AccessKey: "minioadmin",
+			SecretKey: "minioadmin",
+			Verify:    false,
+		},
+	}
+
+	router := gin.New()
+	router.GET("/system/buckets", MakeListHandler(cfg))
+
+	req, err := http.NewRequest(http.MethodGet, "/system/buckets", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer token")
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, res.Code)
+	}
+}

--- a/pkg/handlers/buckets/update_bucket_test.go
+++ b/pkg/handlers/buckets/update_bucket_test.go
@@ -1,0 +1,32 @@
+package buckets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func TestMakeUpdateBucketHandlerValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &types.Config{MinIOProvider: &types.MinIOProvider{}}
+
+	router := gin.New()
+	router.PUT("/system/buckets", MakeUpdateHandler(cfg))
+
+	req, err := http.NewRequest(http.MethodPut, "/system/buckets", http.NoBody)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, res.Code)
+	}
+}

--- a/pkg/imagepuller/daemonset_test.go
+++ b/pkg/imagepuller/daemonset_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package imagepuller
 
 import (
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/grycap/oscar/v3/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/grycap/oscar/v3/pkg/types"
 )
 
 func TestCreateDaemonset(t *testing.T) {
@@ -70,4 +78,132 @@ func TestCreateDaemonset(t *testing.T) {
 		t.Errorf("expected container image to be '%s', got %s", service.Image, daemonset.Spec.Template.Spec.Containers[0].Image)
 	}
 
+}
+
+func TestCreateDaemonsetFailsOnNodeListError(t *testing.T) {
+	cfg := &types.Config{ServicesNamespace: "default"}
+	service := types.Service{Name: "svc"}
+	client := fake.NewSimpleClientset()
+
+	client.Fake.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("boom")
+	})
+
+	origWatch := watchPodsFunc
+	watchPodsFunc = func(kubernetes.Interface, *types.Config) {}
+	t.Cleanup(func() { watchPodsFunc = origWatch })
+
+	err := CreateDaemonset(cfg, service, client)
+	if err == nil {
+		t.Fatalf("expected error when listing nodes fails")
+	}
+}
+
+func TestSetWorkingNodes(t *testing.T) {
+	defer func(prev int) { workingNodes = prev }(workingNodes)
+
+	tests := []struct {
+		name          string
+		client        kubernetes.Interface
+		expectedCount int
+		expectError   bool
+	}{
+		{
+			name: "counts worker nodes",
+			client: fake.NewSimpleClientset(
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+			),
+			expectedCount: 2,
+		},
+		{
+			name: "returns error on list failure",
+			client: func() kubernetes.Interface {
+				c := fake.NewSimpleClientset()
+				c.Fake.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("boom")
+				})
+				return c
+			}(),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingNodes = 0
+			err := setWorkingNodes(tt.client)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if workingNodes != 0 {
+					t.Fatalf("expected workingNodes to stay at 0, got %d", workingNodes)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if workingNodes != tt.expectedCount {
+				t.Fatalf("expected %d working nodes, got %d", tt.expectedCount, workingNodes)
+			}
+		})
+	}
+}
+
+func TestHandleUpdatePodEvent(t *testing.T) {
+	defer func(prev int, prevPC PodCounter, prevStopper chan struct{}) {
+		workingNodes = prev
+		pc = prevPC
+		stopper = prevStopper
+	}(workingNodes, pc, stopper)
+
+	t.Run("running pod stops informer", func(t *testing.T) {
+		workingNodes = 1
+		stopper = make(chan struct{}, 1)
+		pc = PodCounter{}
+		pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+		handleUpdatePodEvent(nil, pod)
+		select {
+		case <-stopper:
+		case <-time.After(time.Second):
+			t.Fatalf("expected stopper to receive signal")
+		}
+		if pc.wnCount != 1 {
+			t.Fatalf("expected wnCount to be 1, got %d", pc.wnCount)
+		}
+	})
+
+	t.Run("non running pod ignored", func(t *testing.T) {
+		workingNodes = 1
+		stopper = make(chan struct{}, 1)
+		pc = PodCounter{}
+		pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}}
+		handleUpdatePodEvent(nil, pod)
+		select {
+		case <-stopper:
+			t.Fatalf("did not expect stopper signal")
+		default:
+		}
+		if pc.wnCount != 0 {
+			t.Fatalf("expected wnCount to remain 0, got %d", pc.wnCount)
+		}
+	})
+}
+
+func TestGeneratePodGroupName(t *testing.T) {
+	name := generatePodGroupName()
+	if !strings.HasPrefix(name, "pod-group-") {
+		t.Fatalf("unexpected prefix for %s", name)
+	}
+	suffix := strings.TrimPrefix(name, "pod-group-")
+	if len(suffix) != lengthStr {
+		t.Fatalf("expected suffix length %d, got %d", lengthStr, len(suffix))
+	}
+	for _, c := range suffix {
+		if c < 'a' || c > 'z' {
+			t.Fatalf("suffix contains non lowercase letter: %s", suffix)
+		}
+	}
 }

--- a/pkg/testsupport/network.go
+++ b/pkg/testsupport/network.go
@@ -13,7 +13,11 @@ func SkipIfCannotListen(t *testing.T) {
 		t.Skipf("skipping test: cannot open local listener: %v", err)
 		return
 	}
+<<<<<<< HEAD
 	if err := listener.Close(); err != nil {
 		t.Fatalf("failed to close listener: %v", err)
 	}
+=======
+	listener.Close()
+>>>>>>> 7a6c4de (Bump test coverage)
 }

--- a/pkg/testsupport/network.go
+++ b/pkg/testsupport/network.go
@@ -13,11 +13,7 @@ func SkipIfCannotListen(t *testing.T) {
 		t.Skipf("skipping test: cannot open local listener: %v", err)
 		return
 	}
-<<<<<<< HEAD
 	if err := listener.Close(); err != nil {
 		t.Fatalf("failed to close listener: %v", err)
 	}
-=======
-	listener.Close()
->>>>>>> 7a6c4de (Bump test coverage)
 }


### PR DESCRIPTION

- Added bucket handler coverage for admin creation plus validation failures using a stubbed MinIO server.
- Exercised imagepuller helpers by checking daemonset setup failure, worker counting, informer stop semantics, and name generation.
  - Verified resourcemanager resource bookkeeping against pod requests and non-ready nodes
  - Added a smoke test for SkipIfCannotListen.