### PR TITLE
Experimental inference handler(proxy) for Kserve service routing

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,6 +144,8 @@ func main() {
 	syncBack, ok := back.(types.SyncBackend)
 	if cfg.ServerlessBackend != "" && ok {
 		r.POST("/run/:serviceName", auth.GetLoggerMiddleware(), handlers.MakeRunHandler(cfg, syncBack))
+		r.POST("/inference/:serviceName/*path", handlers.MakeInferenceHandler(cfg, syncBack))
+		r.GET("/inference/:serviceName/*path", handlers.MakeInferenceHandler(cfg, syncBack))
 	}
 
 	// System info path

--- a/main.go
+++ b/main.go
@@ -144,8 +144,8 @@ func main() {
 	syncBack, ok := back.(types.SyncBackend)
 	if cfg.ServerlessBackend != "" && ok {
 		r.POST("/run/:serviceName", auth.GetLoggerMiddleware(), handlers.MakeRunHandler(cfg, syncBack))
-		r.POST("/inference/:serviceName/*path", handlers.MakeInferenceHandler(cfg, syncBack))
-		r.GET("/inference/:serviceName/*path", handlers.MakeInferenceHandler(cfg, syncBack))
+		r.POST("/inference/:serviceName/*path", auth.GetAuthMiddleware(cfg, kubeClientset), handlers.MakeInferenceHandler(cfg, syncBack))
+		r.GET("/inference/:serviceName/*path", auth.GetAuthMiddleware(cfg, kubeClientset), handlers.MakeInferenceHandler(cfg, syncBack))
 	}
 
 	// System info path

--- a/pkg/handlers/inference.go
+++ b/pkg/handlers/inference.go
@@ -1,0 +1,46 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func MakeInferenceHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fmt.Println("making call")
+		serviceName := c.Param("serviceName")
+		proxy := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				// Set the request Host parameter to avoid issues in the redirection
+				// related issue: https://github.com/golang/go/issues/7682
+				host := fmt.Sprintf("%s.%s", serviceName, "kserve-test.svc.cluster.local")
+				req.Host = host
+
+				req.URL.Scheme = "http"
+				req.URL.Host = host
+				req.URL.Path = c.Param("path")
+			},
+		}
+		proxy.ServeHTTP(c.Writer, c.Request)
+	}
+}

--- a/pkg/handlers/inference.go
+++ b/pkg/handlers/inference.go
@@ -27,7 +27,6 @@ import (
 
 func MakeInferenceHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		fmt.Println("making call")
 		serviceName := c.Param("serviceName")
 		proxy := &httputil.ReverseProxy{
 			Director: func(req *http.Request) {


### PR DESCRIPTION
This pull request introduces a new inference proxy endpoint to the API, allowing POST and GET requests to be forwarded to underlying inference services.

New inference endpoint and reverse proxy:

* Added new POST and GET routes at `/inference/:serviceName/*path` in `main.go`, protected by authentication middleware, to support inference requests.
* Implemented `MakeInferenceHandler` in `pkg/handlers/inference.go`, which uses a reverse proxy to forward incoming requests to the appropriate backend service based on the `serviceName` parameter. The proxy rewrites the host and path to target the correct service within the cluster. 

NOTE: At the moment Kserve services MUST be in `kserve-test` namespace