### PR TITLE
Add schedulable resources systems/status.

### DIFF
--- a/pkg/handlers/status.go
+++ b/pkg/handlers/status.go
@@ -150,6 +150,11 @@ func getNodesInfo(kubeClientset kubernetes.Interface, clusterInfo *types.StatusI
 	if err != nil {
 		return nil, err
 	}
+	// Retrieve all pods to calculate requests per node
+	pods, err := kubeClientset.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
 
 	nodeInfoMap := make(map[string]*NodeInfoWithAllocatable)
 	var totalGPUs int64 = 0
@@ -170,6 +175,18 @@ func getNodesInfo(kubeClientset kubernetes.Interface, clusterInfo *types.StatusI
 			gpuVal, _ := gpuQty.AsInt64()
 			gpu_alloc = gpuVal
 			totalGPUs += gpuVal
+		}
+
+		// Calculate CPU and Memory Requests by summing the pods of the node
+		var cpu_request int64 = 0
+		var mem_request int64 = 0
+		for _, pod := range pods.Items {
+			if pod.Spec.NodeName == nodeName && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
+				for _, container := range pod.Spec.Containers {
+					cpu_request += container.Resources.Requests.Cpu().MilliValue()
+					mem_request += container.Resources.Requests.Memory().Value()
+				}
+			}
 		}
 
 		// 2. Status
@@ -200,12 +217,14 @@ func getNodesInfo(kubeClientset kubernetes.Interface, clusterInfo *types.StatusI
 			NodeDetail: types.NodeDetail{
 				Name: nodeName,
 				CPU: types.NodeResource{
-					CapacityCores: cpu_alloc, // Use CapacityCores
-					UsageCores:    0,         // Will be updated in getMetricsInfo
+					CapacityCores: cpu_alloc,   // Use CapacityCores
+					UsageCores:    0,           // Will be updated in getMetricsInfo
+					RequestCores:  cpu_request, // Request CapacityCores
 				},
 				Memory: types.NodeResource{
 					CapacityBytes: memory_alloc, // Use CapacityBytes
 					UsageBytes:    0,            // Will be updated in getMetricsInfo
+					RequestBytes:  mem_request,  // Request CapacityBytes
 				},
 				GPU:         gpu_alloc,
 				IsInterlink: checkIfInterLinkNode(node),
@@ -237,6 +256,12 @@ func getMetricsInfo(kubeClientset kubernetes.Interface, metricsClientset version
 	var cpu_max_free int64 = 0
 	var memory_free_total int64 = 0
 	var memory_max_free int64 = 0
+
+	var cpu_schedulable_total int64 = 0
+	var cpu_max_schedulable int64 = 0
+	var memory_schedulable_total int64 = 0
+	var memory_max_schedulable int64 = 0
+
 	var number_nodes int64 = 0
 
 	var nodeDetailList []types.NodeDetail
@@ -260,6 +285,13 @@ func getMetricsInfo(kubeClientset kubernetes.Interface, metricsClientset version
 			cpu_node_free := cpu_alloc - cpu_usage_milli
 			memory_node_free := memory_alloc - memory_usage_bytes
 
+			// Request capacity
+			cpu_req := nodeInfo.NodeDetail.CPU.RequestCores
+			mem_req := nodeInfo.NodeDetail.Memory.RequestBytes
+
+			cpu_node_sched := cpu_alloc - cpu_req
+			memory_node_sched := memory_alloc - mem_req
+
 			// Update NodeDetail with usage metrics (Use UsageCores and UsageBytes)
 			nodeInfo.NodeDetail.CPU.UsageCores = cpu_usage_milli
 			nodeInfo.NodeDetail.Memory.UsageBytes = memory_usage_bytes
@@ -275,6 +307,15 @@ func getMetricsInfo(kubeClientset kubernetes.Interface, metricsClientset version
 				memory_max_free = memory_node_free
 			}
 
+			cpu_schedulable_total += cpu_node_sched
+			if cpu_max_schedulable < cpu_node_sched {
+				cpu_max_schedulable = cpu_node_sched
+			}
+			memory_schedulable_total += memory_node_sched
+			if memory_max_schedulable < memory_node_sched {
+				memory_max_schedulable = memory_node_sched
+			}
+
 			// Add to the final list
 			nodeDetailList = append(nodeDetailList, nodeInfo.NodeDetail)
 		}
@@ -286,8 +327,13 @@ func getMetricsInfo(kubeClientset kubernetes.Interface, metricsClientset version
 
 	clusterInfo.Cluster.Metrics.CPU.TotalFreeCores = cpu_free_total
 	clusterInfo.Cluster.Metrics.CPU.MaxFreeOnNodeCores = cpu_max_free
+	clusterInfo.Cluster.Metrics.CPU.TotalSchedulableCores = cpu_schedulable_total
+	clusterInfo.Cluster.Metrics.CPU.MaxSchedulableOnNodeCores = cpu_max_schedulable
+
 	clusterInfo.Cluster.Metrics.Memory.TotalFreeBytes = memory_free_total
 	clusterInfo.Cluster.Metrics.Memory.MaxFreeOnNodeBytes = memory_max_free
+	clusterInfo.Cluster.Metrics.Memory.TotalSchedulableBytes = memory_schedulable_total
+	clusterInfo.Cluster.Metrics.Memory.MaxSchedulableOnNodeBytes = memory_max_schedulable
 
 	return nil
 }

--- a/pkg/types/status.go
+++ b/pkg/types/status.go
@@ -39,13 +39,17 @@ type ClusterMetrics struct {
 }
 
 type CPUMetrics struct {
-	TotalFreeCores     int64 `json:"total_free_cores"`
-	MaxFreeOnNodeCores int64 `json:"max_free_on_node_cores"`
+	TotalFreeCores            int64 `json:"total_free_cores"`
+	MaxFreeOnNodeCores        int64 `json:"max_free_on_node_cores"`
+	TotalSchedulableCores     int64 `json:"total_schedulable_cores"`
+	MaxSchedulableOnNodeCores int64 `json:"total_schedulable_on_node_cores"`
 }
 
 type MemoryMetrics struct {
-	TotalFreeBytes     int64 `json:"total_free_bytes"`
-	MaxFreeOnNodeBytes int64 `json:"max_free_on_node_bytes"`
+	TotalFreeBytes            int64 `json:"total_free_bytes"`
+	MaxFreeOnNodeBytes        int64 `json:"max_free_on_node_bytes"`
+	TotalSchedulableBytes     int64 `json:"total_schedulable_bytes"`
+	MaxSchedulableOnNodeBytes int64 `json:"max_schedulable_on_node_bytes"`
 }
 
 type GPUMetrics struct {
@@ -65,8 +69,10 @@ type NodeDetail struct {
 type NodeResource struct {
 	CapacityCores int64 `json:"capacity_cores,omitempty"`
 	UsageCores    int64 `json:"usage_cores,omitempty"`
+	RequestCores  int64 `json:"request_cores,omitempty"`
 	CapacityBytes int64 `json:"capacity_bytes,omitempty"`
 	UsageBytes    int64 `json:"usage_bytes,omitempty"`
+	RequestBytes  int64 `json:"request_bytes,omitempty"`
 }
 
 type NodeConditionSimple struct {


### PR DESCRIPTION
Fixes #

## Proposed Changes

This pull request enhances the cluster metrics and node resource reporting by adding tracking for resource requests and schedulable resources. The changes improve visibility into how much CPU and memory is requested by pods on each node, and introduce new metrics that reflect the schedulable (allocatable minus requested) resources at both node and cluster levels.

Resource request tracking:

* Added calculation of CPU and memory requests per node by summing the resource requests of all non-terminated pods assigned to each node in `getNodesInfo`. These values are now included in the `NodeResource` struct as `RequestCores` and `RequestBytes`. 

Schedulable resource metrics:

* Introduced new metrics in `getMetricsInfo` to track schedulable CPU and memory (allocatable minus requested) for each node and aggregated for the cluster. These are exposed as `TotalSchedulableCores`, `MaxSchedulableOnNodeCores`, `TotalSchedulableBytes`, and `MaxSchedulableOnNodeBytes` in the `ClusterMetrics` struct. 
These additions provide a more accurate picture of resource availability and usage, supporting better scheduling and capacity planning.