### PR TITLE
006 workspaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 	metricsSources := metrics.DefaultSources(cfg, back, kubeClientset)
 	metricsAgg := &metrics.Aggregator{Sources: metricsSources}
 	metricsGroup := r.Group("/system/metrics", auth.GetAuthMiddleware(cfg, kubeClientset))
-	//metricsGroup.GET("", handlers.MakeMetricsSummaryHandler(metricsAgg))
+	metricsGroup.GET("", handlers.MakeMetricsSummaryHandler(metricsAgg))
 	metricsGroup.GET("/breakdown", handlers.MakeMetricsBreakdownHandler(metricsAgg))
 	metricsGroup.GET("/:serviceName", handlers.MakeMetricValueHandler(metricsAgg))
 	// Quotas


### PR DESCRIPTION
This pull request re-enables the main endpoint for retrieving a summary of system metrics by uncommenting the relevant route registration in `main.go`. This change restores the `/system/metrics` endpoint, allowing clients to access metrics summaries as intended.

**Metrics API changes:**

* Re-enabled the `/system/metrics` endpoint by uncommenting the registration of the summary handler in `main.go`, making the metrics summary accessible again.
