### PR TITLE
fix: respect KUBE_CONTEXT in deploy rollout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ IMAGE_TAG ?= devel
 NAMESPACE ?= oscar
 DEPLOYMENT ?= $(IMAGE_NAME)
 BUILD_CONTEXT ?= ../oscar
+KUBECTL ?= kubectl
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+KUBE_CONTEXT_ARG := $(if $(KUBE_CONTEXT),--context $(KUBE_CONTEXT),)
 
 help:
 	@echo "Available targets:"
@@ -15,6 +17,9 @@ help:
 	@echo "  push     - Push image $(IMAGE) to registry"
 	@echo "  rollout  - Restart Kubernetes deployment $(DEPLOYMENT) in namespace $(NAMESPACE)"
 	@echo "  deploy   - Build, push, and rollout (default pipeline)"
+	@echo ""
+	@echo "Optional variables:"
+	@echo "  KUBE_CONTEXT - Kubernetes context to use for rollout"
 
 build:
 	docker build -t $(IMAGE) $(BUILD_CONTEXT)
@@ -23,6 +28,6 @@ push: build
 	docker push $(IMAGE)
 
 rollout:
-	kubectl rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)
+	$(KUBECTL) $(KUBE_CONTEXT_ARG) rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)
 
 deploy: push rollout


### PR DESCRIPTION
make deploy KUBE_CONTEXT=... was failing in the rollout step because the Makefile invoked kubectl without forwarding the requested Kubernetes context. That caused kubectl to fall back to the default local endpoint at http://localhost:8080.

This change updates Makefile so the rollout target uses --context $(KUBE_CONTEXT) when provided, and adds a short help entry documenting the optional variable. This keeps the change scoped to deployment ergonomics without altering build or push behavior.