### PR TITLE
fix: disable Kubernetes service links in OSCAR service pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ IMAGE_TAG ?= devel
 NAMESPACE ?= oscar
 DEPLOYMENT ?= $(IMAGE_NAME)
 BUILD_CONTEXT ?= ../oscar
+KUBECTL ?= kubectl
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+KUBE_CONTEXT_ARG := $(if $(KUBE_CONTEXT),--context $(KUBE_CONTEXT),)
 
 help:
 	@echo "Available targets:"
@@ -15,6 +17,9 @@ help:
 	@echo "  push     - Push image $(IMAGE) to registry"
 	@echo "  rollout  - Restart Kubernetes deployment $(DEPLOYMENT) in namespace $(NAMESPACE)"
 	@echo "  deploy   - Build, push, and rollout (default pipeline)"
+	@echo ""
+	@echo "Optional variables:"
+	@echo "  KUBE_CONTEXT - Kubernetes context to use for rollout"
 
 build:
 	docker build -t $(IMAGE) $(BUILD_CONTEXT)
@@ -23,6 +28,6 @@ push: build
 	docker push $(IMAGE)
 
 rollout:
-	kubectl rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)
+	$(KUBECTL) $(KUBE_CONTEXT_ARG) rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)
 
 deploy: push rollout

--- a/pkg/backends/resources/expose_test.go
+++ b/pkg/backends/resources/expose_test.go
@@ -96,6 +96,16 @@ func TestCreateExposeWithIngressAndAuth(t *testing.T) {
 	if _, err := client.AppsV1().Deployments(svc.Namespace).Get(context.TODO(), getDeploymentName(svc.Name), metav1.GetOptions{}); err != nil {
 		t.Fatalf("expected deployment to exist: %v", err)
 	}
+	deployment, err := client.AppsV1().Deployments(svc.Namespace).Get(context.TODO(), getDeploymentName(svc.Name), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected deployment to exist: %v", err)
+	}
+	if deployment.Spec.Template.Spec.EnableServiceLinks == nil {
+		t.Fatal("expected deployment pod spec to set EnableServiceLinks")
+	}
+	if *deployment.Spec.Template.Spec.EnableServiceLinks {
+		t.Fatal("expected deployment pod spec to disable service links")
+	}
 
 	if _, err := client.AutoscalingV1().HorizontalPodAutoscalers(svc.Namespace).Get(context.TODO(), getHPAName(svc.Name), metav1.GetOptions{}); err != nil {
 		t.Fatalf("expected hpa to exist: %v", err)

--- a/pkg/handlers/job_test.go
+++ b/pkg/handlers/job_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 
 	testclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/grycap/oscar/v3/pkg/backends"
 	"github.com/grycap/oscar/v3/pkg/types"
+	batchv1 "k8s.io/api/batch/v1"
 )
 
 func TestMakeJobHandler(t *testing.T) {
@@ -40,5 +42,20 @@ func TestMakeJobHandler(t *testing.T) {
 	}
 	if actions[0].GetVerb() != "create" || actions[0].GetResource().Resource != "jobs" {
 		t.Errorf("Expected create job action but got %v", actions[0])
+	}
+
+	createAction, ok := actions[0].(k8stesting.CreateAction)
+	if !ok {
+		t.Fatalf("expected create action, got %T", actions[0])
+	}
+	job, ok := createAction.GetObject().(*batchv1.Job)
+	if !ok {
+		t.Fatalf("expected job object, got %T", createAction.GetObject())
+	}
+	if job.Spec.Template.Spec.EnableServiceLinks == nil {
+		t.Fatal("expected job pod spec to set EnableServiceLinks")
+	}
+	if *job.Spec.Template.Spec.EnableServiceLinks {
+		t.Fatal("expected job pod spec to disable service links")
 	}
 }

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -352,8 +352,10 @@ func (service *Service) ToPodSpec(cfg *Config) (*v1.PodSpec, error) {
 		return nil, err
 	}
 
+	enableServiceLinks := false
 	podSpec := &v1.PodSpec{
-		ImagePullSecrets: SetImagePullSecrets(service.ImagePullSecrets),
+		ImagePullSecrets:   SetImagePullSecrets(service.ImagePullSecrets),
+		EnableServiceLinks: &enableServiceLinks,
 		Containers: []v1.Container{
 			{
 				Name:            ContainerName,

--- a/pkg/types/service_test.go
+++ b/pkg/types/service_test.go
@@ -348,6 +348,13 @@ func TestToPodSpec(t *testing.T) {
 					t.Errorf("unexpected error: %v", err)
 				}
 
+				if podSpec.EnableServiceLinks == nil {
+					t.Fatal("expected EnableServiceLinks to be set")
+				}
+				if *podSpec.EnableServiceLinks {
+					t.Fatal("expected EnableServiceLinks to be false")
+				}
+
 				if len(podSpec.Containers[0].Command) != 1 {
 					t.Fatalf("expected a single command entry, got %d", len(podSpec.Containers[0].Command))
 				}


### PR DESCRIPTION
Fixes: https://github.com/grycap/issue-tracker/issues/93

This change addresses the environment variable visibility across services for the user by disabling Kubernetes service link injection for OSCAR-managed pods.

OSCAR was generating PodSpec objects without explicitly setting enableServiceLinks, so Kubernetes defaulted it to true and injected *_SERVICE_HOST, *_SERVICE_PORT, and related variables for services in the same namespace. That caused services, including exposed deployments like Notebooks and asynchronous jobs, to see environment variables unrelated to their own runtime context.

The fix sets EnableServiceLinks=false in the shared pod spec builder at pkg/types/service.go. Because exposed services and async jobs already reuse that base PodSpec, the change propagates automatically to both deployment and job workloads without widening the scope of the patch.

The PR also adds targeted test coverage to verify the setting is preserved in:

- the base service pod spec
- exposed service deployments
- async job templates

