### PR TITLE
fix: preserve service token on service updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ IMAGE_TAG ?= devel
 NAMESPACE ?= oscar
 DEPLOYMENT ?= $(IMAGE_NAME)
 BUILD_CONTEXT ?= ../oscar
+KUBECTL ?= kubectl
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+KUBE_CONTEXT_ARG := $(if $(KUBE_CONTEXT),--context $(KUBE_CONTEXT),)
 
 help:
 	@echo "Available targets:"
@@ -15,6 +17,9 @@ help:
 	@echo "  push     - Push image $(IMAGE) to registry"
 	@echo "  rollout  - Restart Kubernetes deployment $(DEPLOYMENT) in namespace $(NAMESPACE)"
 	@echo "  deploy   - Build, push, and rollout (default pipeline)"
+	@echo ""
+	@echo "Optional variables:"
+	@echo "  KUBE_CONTEXT - Kubernetes context to use for rollout"
 
 build:
 	docker build -t $(IMAGE) $(BUILD_CONTEXT)
@@ -23,6 +28,6 @@ push: build
 	docker push $(IMAGE)
 
 rollout:
-	kubectl rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)
+	$(KUBECTL) $(KUBE_CONTEXT_ARG) rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)
 
 deploy: push rollout

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -92,6 +92,10 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 			return
 		}
 
+		if oldService.Token != "" {
+			newService.Token = oldService.Token
+		}
+
 		serviceNamespace := oldService.Namespace
 		if serviceNamespace == "" {
 			serviceNamespace = cfg.ServicesNamespace

--- a/pkg/handlers/update_test.go
+++ b/pkg/handlers/update_test.go
@@ -109,6 +109,9 @@ func TestMakeUpdateHandler(t *testing.T) {
 	if back.UpdatedService == nil {
 		t.Fatal("expected backend to receive updated service, got nil")
 	}
+	if back.UpdatedService.Token != svc.Token {
+		t.Fatalf("expected service token to be preserved on update, got %q", back.UpdatedService.Token)
+	}
 	if strings.Contains(back.UpdatedService.Script, "\r") {
 		t.Fatalf("expected script without CR characters, got %q", back.UpdatedService.Script)
 	}


### PR DESCRIPTION
PUT /system/services was regenerating the service token even for updates unrelated to invocation auth, such as RAM changes. For services triggered asynchronously from MinIO, that left the existing webhook configured with the old token while OSCAR expected the new one, so uploads to the input bucket stopped triggering executions. This PR preserves the existing token during service updates and adds test coverage to prevent regressions in the update flow.

Fixes: https://github.com/grycap/issue-tracker/issues/328