### PR TITLE
feat: inject OSCAR service metadata env vars

### DIFF
--- a/docs/exposed-services.md
+++ b/docs/exposed-services.md
@@ -40,6 +40,8 @@ Once the service is deployed, you can check if it was created correctly by makin
 https://{oscar_endpoint}/system/services/{service_name}/exposed/{path_resource} 
 ```
 
+For exposed services, OSCAR sets `OSCAR_SERVICE_BASE_PATH` in the container environment with the base path `/system/services/{service_name}/exposed`. The full list of OSCAR-managed environment variables is documented in [FDL](fdl.md#envvarsmap).
+
 Notice that if you get a `502 Bad Gateway` error, it is most likely because the specified port on the service does not match the API port.
 
 Additional options can be defined in the "expose" section of the FDL (some previously mentioned), such as:

--- a/docs/fdl.md
+++ b/docs/fdl.md
@@ -196,6 +196,16 @@ storage_providers:
 |`variables` </br> *map[string]string* | Map to define the environment variables that will be available in the service container |
 |`secrets` </br> *map[string]string* | Map to define the secret environment variables that will be available in the service container |
 
+OSCAR also injects a small set of reserved environment variables in every service container:
+
+| Variable | Description |
+|----------|-------------|
+| `OSCAR_SERVICE_NAME` | Service name. |
+| `OSCAR_SERVICE_TOKEN` | Generated OSCAR service token. |
+| `OSCAR_SERVICE_BASE_PATH` | Base exposed path, for example `/system/services/{service_name}/exposed`. It is an empty string for non-exposed services. |
+
+These variables are managed by OSCAR and are available in addition to the user-defined entries declared in `environment.variables`.
+
 ## StorageProviders
 
 | Field                                                            | Description                                                                                                                                    |

--- a/docs/oscar-service.md
+++ b/docs/oscar-service.md
@@ -13,6 +13,12 @@ is in charge of:
 - Upload the content of the output folder accessible via the `TMP_OUTPUT_DIR`
     environment variable.
 
+In addition to the runtime variables managed by the FaaS Supervisor, OSCAR also
+injects service metadata variables in every container, such as
+`OSCAR_SERVICE_NAME`, `OSCAR_SERVICE_TOKEN` and `OSCAR_SERVICE_BASE_PATH`.
+Their canonical definition is documented in the [FDL environment
+variables section](fdl.md#envvarsmap).
+
 
 
 ### FaaS Supervisor

--- a/examples/expose_services/openclaw/README.md
+++ b/examples/expose_services/openclaw/README.md
@@ -28,8 +28,7 @@ This deploys `openclaw-volume` with:
 The startup script now assumes:
 
 - persistence is handled by the managed volume mounted at `/data`
-- FDL environment variables are propagated correctly
-- only the OSCAR service token may need to be read from `/oscar/config/function_config.yaml`
+- OSCAR injects service metadata through environment variables such as `OSCAR_SERVICE_TOKEN`
 
 ## Access exposed UI
 

--- a/examples/expose_services/openclaw/openclawscript.sh
+++ b/examples/expose_services/openclaw/openclawscript.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ] && [ -f "/oscar/config/function_config.yaml" ]; then
-  OPENCLAW_GATEWAY_TOKEN="$(awk -F': ' '/^token:/ {print $2; exit}' /oscar/config/function_config.yaml | tr -d '"' || true)"
+if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ] && [ -n "${OSCAR_SERVICE_TOKEN:-}" ]; then
+  OPENCLAW_GATEWAY_TOKEN="${OSCAR_SERVICE_TOKEN}"
   export OPENCLAW_GATEWAY_TOKEN
 fi
 

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -90,6 +90,15 @@ const (
 	// JobUUIDVariable name used by the environment variable of the job UUID
 	JobUUIDVariable = "JOB_UUID"
 
+	// OscarServiceNameEnvVar exposes the OSCAR service name inside the container.
+	OscarServiceNameEnvVar = "OSCAR_SERVICE_NAME"
+
+	// OscarServiceTokenEnvVar exposes the OSCAR service token inside the container.
+	OscarServiceTokenEnvVar = "OSCAR_SERVICE_TOKEN"
+
+	// OscarServiceBasePathEnvVar exposes the OSCAR service base path inside the container.
+	OscarServiceBasePathEnvVar = "OSCAR_SERVICE_BASE_PATH"
+
 	// OpenfaasZeroScalingLabel label to enable zero scaling in OpenFaaS functions
 	//OpenfaasZeroScalingLabel = "com.openfaas.scale.zero"
 
@@ -422,6 +431,9 @@ func (service *Service) ToPodSpec(cfg *Config) (*v1.PodSpec, error) {
 		})
 	}
 
+	// Add OSCAR-managed environment variables
+	addServiceMetadataEnvVars(podSpec, service)
+
 	// Add the required environment variables for the watchdog
 	addWatchdogEnvVars(podSpec, cfg, service)
 
@@ -571,12 +583,43 @@ func addWatchdogEnvVars(p *v1.PodSpec, cfg *Config, service *Service) {
 	}
 }
 
+func addServiceMetadataEnvVars(p *v1.PodSpec, service *Service) {
+	requiredEnvVars := []v1.EnvVar{
+		{
+			Name:  OscarServiceNameEnvVar,
+			Value: service.Name,
+		},
+		{
+			Name:  OscarServiceTokenEnvVar,
+			Value: service.Token,
+		},
+		{
+			Name:  OscarServiceBasePathEnvVar,
+			Value: service.GetExposedBasePath(),
+		},
+	}
+
+	for i, cont := range p.Containers {
+		if cont.Name == ContainerName {
+			p.Containers[i].Env = append(p.Containers[i].Env, requiredEnvVars...)
+		}
+	}
+}
+
 // GetSupervisorPath returns the appropriate supervisor path
 func (service *Service) GetSupervisorPath() string {
 	if service.Alpine {
 		return fmt.Sprintf("%s/%s/%s", VolumePath, AlpineDirectory, SupervisorName)
 	}
 	return fmt.Sprintf("%s/%s", VolumePath, SupervisorName)
+}
+
+// GetExposedBasePath returns the OSCAR exposed-service base path or an empty string.
+func (service *Service) GetExposedBasePath() string {
+	if service == nil || service.Expose.APIPort == 0 {
+		return ""
+	}
+	return fmt.Sprintf("/system/services/%s/exposed", service.Name)
 }
 
 // HasReplicas checks if the service has replicas defined

--- a/pkg/types/service_test.go
+++ b/pkg/types/service_test.go
@@ -25,6 +25,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func envVarsToMap(envVars []v1.EnvVar) map[string]string {
+	values := make(map[string]string, len(envVars))
+	for _, envVar := range envVars {
+		values[envVar.Name] = envVar.Value
+	}
+	return values
+}
+
 var (
 	testService Service = Service{
 		Name:      "testname",
@@ -335,6 +343,7 @@ func TestToPodSpec(t *testing.T) {
 			// Assign resources from scenario
 			svc.Memory = s.memory
 			svc.CPU = s.cpu
+			svc.Token = "test-token"
 			//svc.ImagePullSecrets = []string{"testcred"}
 
 			podSpec, err := svc.ToPodSpec(&testConfig)
@@ -353,6 +362,16 @@ func TestToPodSpec(t *testing.T) {
 				}
 				if podSpec.Containers[0].Command[0] != fmt.Sprintf("%s/%s", VolumePath, WatchdogName) {
 					t.Fatalf("expected command to be supervisor path %s, got %s", fmt.Sprintf("%s/%s", VolumePath, WatchdogName), podSpec.Containers[0].Command[0])
+				}
+				envVars := envVarsToMap(podSpec.Containers[0].Env)
+				if envVars[OscarServiceNameEnvVar] != svc.Name {
+					t.Fatalf("expected %s to be %q, got %q", OscarServiceNameEnvVar, svc.Name, envVars[OscarServiceNameEnvVar])
+				}
+				if envVars[OscarServiceTokenEnvVar] != svc.Token {
+					t.Fatalf("expected %s to be %q, got %q", OscarServiceTokenEnvVar, svc.Token, envVars[OscarServiceTokenEnvVar])
+				}
+				if envVars[OscarServiceBasePathEnvVar] != "" {
+					t.Fatalf("expected %s to be empty for non-exposed service, got %q", OscarServiceBasePathEnvVar, envVars[OscarServiceBasePathEnvVar])
 				}
 
 			}
@@ -402,6 +421,43 @@ func TestHasReplicas(t *testing.T) {
 	}
 }
 
+func TestGetExposedBasePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		service *Service
+		want    string
+	}{
+		{
+			name:    "nil service",
+			service: nil,
+			want:    "",
+		},
+		{
+			name:    "non exposed service",
+			service: &Service{Name: "demo"},
+			want:    "",
+		},
+		{
+			name: "exposed service",
+			service: &Service{
+				Name: "demo",
+				Expose: Expose{
+					APIPort: 8080,
+				},
+			},
+			want: "/system/services/demo/exposed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.service.GetExposedBasePath(); got != tt.want {
+				t.Fatalf("expected exposed base path %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestGetVolumePVCName(t *testing.T) {
 	svc := Service{Name: "demo"}
 	expected := "demo"
@@ -429,6 +485,7 @@ func TestToPodSpecWithVolume(t *testing.T) {
 		Size:      "1Gi",
 		MountPath: "/data",
 	}
+	svc.Token = "test-token"
 
 	podSpec, err := svc.ToPodSpec(&testConfig)
 	if err != nil {
@@ -448,5 +505,31 @@ func TestToPodSpecWithVolume(t *testing.T) {
 	}
 	if !foundVolume || !foundMount {
 		t.Fatalf("expected volume and mount to be present")
+	}
+}
+
+func TestToPodSpecWithExposeMetadataEnvVars(t *testing.T) {
+	copy, err := deepcopy.Anything(testService)
+	if err != nil {
+		t.Fatalf("unable to deep copy test service: %v", err)
+	}
+	svc := copy.(Service)
+	svc.Token = "test-token"
+	svc.Expose.APIPort = 8080
+
+	podSpec, err := svc.ToPodSpec(&testConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	envVars := envVarsToMap(podSpec.Containers[0].Env)
+	if envVars[OscarServiceNameEnvVar] != svc.Name {
+		t.Fatalf("expected %s to be %q, got %q", OscarServiceNameEnvVar, svc.Name, envVars[OscarServiceNameEnvVar])
+	}
+	if envVars[OscarServiceTokenEnvVar] != svc.Token {
+		t.Fatalf("expected %s to be %q, got %q", OscarServiceTokenEnvVar, svc.Token, envVars[OscarServiceTokenEnvVar])
+	}
+	if envVars[OscarServiceBasePathEnvVar] != "/system/services/testname/exposed" {
+		t.Fatalf("expected %s to be %q, got %q", OscarServiceBasePathEnvVar, "/system/services/testname/exposed", envVars[OscarServiceBasePathEnvVar])
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds automatic injection of OSCAR-managed service metadata into service containers.

The following environment variables are now available at runtime:

+ OSCAR_SERVICE_NAME
+ OSCAR_SERVICE_TOKEN
+ OSCAR_SERVICE_BASE_PATH

This avoids parsing /oscar/config/function_config.yaml inside the container just to retrieve service metadata such as the service name, token, or exposed base path.

## Changes
+ Inject OSCAR-managed metadata env vars during PodSpec creation
+ Set OSCAR_SERVICE_BASE_PATH to /system/services/<service_name>/exposed for exposed services
+ Set OSCAR_SERVICE_BASE_PATH to an empty string for non-exposed services
+ Add unit tests covering exposed and non-exposed service behavior
+ Update the OpenClaw exposed-service example to use OSCAR_SERVICE_TOKEN
+ Document the new runtime variables in the FDL and service documentation

## Validation
+ go test ./pkg/types
+ go test ./pkg/backends/resources
+ go test ./pkg/backends
+ Deployed a Notebook and checked the variables.

## Notes
+ The canonical documentation for these variables is now in docs/fdl.md, with additional runtime context in docs/oscar-service.md. docs/exposed-services.md only keeps the exposed-service-specific note for OSCAR_SERVICE_BASE_PATH.

Fixes: https://github.com/grycap/issue-tracker/issues/335