### PR TITLE
Speed up local OSCAR image builds and add explicit no-cache rebuild support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,12 @@
 .git/
+.git
+**/.git
 .gitignore
 .dockerignore
 Dockerfile*
+.cache/
+.codex/
+.specify/
 
 # Common build/test outputs
 **/node_modules/
@@ -20,3 +25,13 @@ coverage/
 .idea/
 .DS_Store
 Thumbs.db
+
+# Project content not needed for the runtime image build
+deploy/
+docs/
+examples/
+log/
+site/
+specs/
+templates/
+tools/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,42 @@
+# syntax=docker/dockerfile:1.7
+
 FROM golang:1.25 AS build
 
 ARG VERSION
 ARG GIT_COMMIT
 ARG GOOS=linux
 
-RUN mkdir /oscar
 WORKDIR /oscar
 
-COPY go.mod .
-COPY go.sum .
-COPY main.go .
-COPY pkg pkg
+COPY go.mod go.sum ./
 
-RUN GOOS=${GOOS} CGO_ENABLED=0 go build --ldflags "-s -w \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY main.go ./
+COPY pkg ./pkg
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=${GOOS} CGO_ENABLED=0 go build --ldflags "-s -w \
 -X \"github.com/grycap/oscar/v3/pkg/version.Version=${VERSION}\" \
 -X \"github.com/grycap/oscar/v3/pkg/version.GitCommit=${GIT_COMMIT}\"" \
--a -installsuffix cgo -o oscar .
+    -o oscar .
 
 
 FROM node:20-alpine AS ui-build
 
 WORKDIR /dashboard
 
+COPY dashboard/package.json ./
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install
+
 COPY dashboard /dashboard
 
-
-RUN npm install && npm run deploy_container
+RUN --mount=type=cache,target=/root/.npm \
+    node scripts/deploy_container.cjs && npm run build
 
 
 FROM alpine:3.14

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,16 @@ NAMESPACE ?= oscar
 DEPLOYMENT ?= $(IMAGE_NAME)
 BUILD_CONTEXT ?= ../oscar
 KUBECTL ?= kubectl
+DOCKER ?= docker
+DOCKER_BUILDKIT ?= 1
+BUILDKIT_PROGRESS ?= auto
+NO_CACHE ?=
 
 IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 KUBE_CONTEXT_ARG := $(if $(KUBE_CONTEXT),--context $(KUBE_CONTEXT),)
+DOCKER_BUILD_ENV := DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) \
+	BUILDKIT_PROGRESS=$(BUILDKIT_PROGRESS)
+DOCKER_BUILD_FLAGS := $(if $(NO_CACHE),--no-cache,)
 
 help:
 	@echo "Available targets:"
@@ -20,12 +27,16 @@ help:
 	@echo ""
 	@echo "Optional variables:"
 	@echo "  KUBE_CONTEXT - Kubernetes context to use for rollout"
+	@echo "  DOCKER_BUILDKIT - Enable Docker BuildKit (default: 1)"
+	@echo "  BUILDKIT_PROGRESS - BuildKit progress output (default: auto)"
+	@echo "  NO_CACHE - Set to 1 to force docker build --no-cache"
 
 build:
-	docker build -t $(IMAGE) $(BUILD_CONTEXT)
+	$(DOCKER_BUILD_ENV) $(DOCKER) build $(DOCKER_BUILD_FLAGS) \
+		-t $(IMAGE) $(BUILD_CONTEXT)
 
 push: build
-	docker push $(IMAGE)
+	$(DOCKER) push $(IMAGE)
 
 rollout:
 	$(KUBECTL) $(KUBE_CONTEXT_ARG) rollout restart deployment/$(DEPLOYMENT) -n $(NAMESPACE)


### PR DESCRIPTION
## Summary

This PR speeds up the local OSCAR image build and deploy workflow without changing deployment semantics.

It improves Docker layer reuse for both the Go backend and the dashboard build, reduces the Docker build context to only the files needed for the runtime image, and adds explicit support for forcing a clean rebuild when needed.

## Changes

- enable Docker BuildKit by default from the `Makefile`
- cache Go module downloads and Go build artifacts in the Docker build
- remove forced full recompilation flags from the Go build step
- avoid duplicate `npm install` work in the dashboard image build
- reorder dashboard build layers to maximize cache hits
- shrink the Docker build context with `.dockerignore`
- add `NO_CACHE=1` support to map to `docker build --no-cache`

## Why

Local `make deploy` iterations were slower than necessary because the image build repeatedly redownloaded dependencies, rebuilt layers that could be cached, and sent a much larger build context than required.

## Validation

- `docker build -t localhost:5001/oscar:feat-speed-build-test .`
- repeated `docker build` reuses cached layers successfully
- `make build IMAGE_TAG=feat-speed-build-make-test BUILD_CONTEXT=.`
- `make -n build BUILD_CONTEXT=. IMAGE_TAG=dry-run-test`
- `make -n build BUILD_CONTEXT=. IMAGE_TAG=dry-run-test NO_CACHE=1`

## Impact

The default local workflow stays the same:

- `make deploy KUBE_CONTEXT=kind-oscar-test-mty`

But rebuilds are significantly faster after the first successful build, and clean rebuilds remain available via:

- `make deploy KUBE_CONTEXT=kind-oscar-test-mty NO_CACHE=1`
