### PR TITLE
Fix Alloy exposed service request matching

### DIFF
--- a/deploy/metrics/alloy-values.kind.yaml
+++ b/deploy/metrics/alloy-values.kind.yaml
@@ -91,7 +91,7 @@ alloy:
         forward_to = [loki.write.default.receiver]
 
         stage.match {
-          selector = "{namespace!=\"\"} |~ \"/system/services/.+/exposed/\""
+          selector = "{namespace!=\"\"} |~ \"/system/services/[^/[:space:]]+/exposed($|[/?[:space:]])\""
           action   = "keep"
 
           stage.label_drop {
@@ -100,7 +100,7 @@ alloy:
         }
 
         stage.match {
-          selector = "{namespace!=\"\"} !~ \"/system/services/.+/exposed/\""
+          selector = "{namespace!=\"\"} !~ \"/system/services/[^/[:space:]]+/exposed($|[/?[:space:]])\""
           action   = "drop"
         }
       }


### PR DESCRIPTION
## Summary
- Update the Alloy ingress log filters used by the local metrics stack so exposed service requests without a trailing slash are kept.
- Match `/system/services/<service>/exposed`, `/exposed/`, nested exposed paths, and query-string variants.

## Root cause
The Alloy pipeline kept only ingress log lines matching `/system/services/.+/exposed/`. Calls to the exposed service base path, such as `/system/services/<service>/exposed`, were dropped before reaching Loki. As a result, `/system/metrics/{service}?metric=requests-exposed-per-service` returned `0` even after successful exposed invocations.

## Validation
- Patched the live `monitoring/alloy` ConfigMap in the local cluster and restarted the Alloy DaemonSet.
- Ran `make test auth-keycloak-gmolto cluster-localhost ROBOT_SUITE=tests/api/system-metrics.robot` from `oscar-tests`.
- Result: `7 tests, 7 passed, 0 failed`.