### PR TITLE
update volume

### DIFF
--- a/pkg/utils/auth/oidc_test.go
+++ b/pkg/utils/auth/oidc_test.go
@@ -252,6 +252,10 @@ func TestGetOIDCMiddleware(t *testing.T) {
 		OIDCSubject:      "123433g",
 		OIDCValidIssuers: []string{server.URL},
 		OIDCGroups:       []string{"/group/group1", "/group/group2"},
+		VolumeAvailable:  "5Gi",
+		VolumeMax:        "7Gi",
+		VolumeMaxDisk:    "5Gi",
+		VolumeMinDisk:    "1Gi",
 	}
 	minIOAdminClient, _ := utils.MakeMinIOAdminClient(&cfg)
 	issuer := server.URL

--- a/pkg/utils/volume_limit.go
+++ b/pkg/utils/volume_limit.go
@@ -43,7 +43,7 @@ func EnsureVolumeLimits(name string, namespace string, kubeClientset kubernetes.
 	_, errQuotas := getResouceQuotas(name, namespace, kubeClientset)
 	quota := fromConftoVolumeLimits(cfg)
 
-	if errQuotas == nil {
+	if errQuotas != nil {
 		QuotasLogger.Printf("Creating ResourceQuota %s", name)
 		// #nosec
 		createResources(name, namespace, kubeClientset, &quota)
@@ -52,7 +52,7 @@ func EnsureVolumeLimits(name string, namespace string, kubeClientset kubernetes.
 	}
 
 	_, errLimits := getLimits(name, namespace, kubeClientset)
-	if errLimits == nil {
+	if errLimits != nil {
 		LimitsLogger.Printf("Creating Limit %s", name)
 		// #nosec
 		createLimits(name, namespace, kubeClientset, &quota)


### PR DESCRIPTION
Resource creation logic fixe:

* Updated the conditionals in `EnsureVolumeLimits` within `pkg/utils/volume_limit.go` to check for errors when retrieving `ResourceQuota` and `Limit` resources, so that creation only occurs if the resources are missing. [[1]](diffhunk://#diff-fd91ddc80c4fd039c37368eeecfb3485476edea2aca3862044fc97a5f18d9f27L46-R46) [[2]](diffhunk://#diff-fd91ddc80c4fd039c37368eeecfb3485476edea2aca3862044fc97a5f18d9f27L55-R55)