### PR TITLE
fix: update REST API link in documentation to point to local api.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,6 @@ A summary of the components used:
 ![OSCAR components](images/oscar-components.png)
 
 An OSCAR cluster can be accessed via its
-[REST API](https://grycap.github.io/oscar/api/), the web-based 
+[REST API](api.md), the web-based 
 [OSCAR Dashboard](https://github.com/grycap/oscar-dashboard) and the command-line interface provided by
 [OSCAR CLI](https://github.com/grycap/oscar-cli).


### PR DESCRIPTION
Documentation updates:

* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L97-R97): Changed the REST API link from an external URL to a local `api.md` file to provide direct access to the bundled API documentation.
