### PR TITLE
fix: add admin exception for mounting private buckets 

### DIFF
--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -604,6 +604,20 @@ func createBuckets(service *types.Service, cfg *types.Config, minIOAdminClient *
 					Owner:      service.Owner,
 				}
 				visibility := minIOAdminClient.GetCurrentResourceVisibility(minio)
+
+				// Add admin exception for mount buckets
+				// Only allowed private buckets
+				// Admin buckets have no MinIO policy so visibility returns "".
+				// Guard against mounting another user's bucket by verifying the owner tag is empty or matches the admin user
+				// (oscar in our case, as admin users don't have a UID and are identified by the "owner" tag in MinIO buckets).
+				// (user buckets always carry their UID in the "owner" tag).
+				if isAdminUser && visibility == "" {
+					bucketTags, _ := minIOAdminClient.GetTaggedMetadata(splitPath[0])
+					if bucketTags["owner"] == "oscar" || bucketTags["owner"] == "" {
+						visibility = utils.PRIVATE
+					}
+				}
+
 				if visibility != utils.PRIVATE {
 					return nil, fmt.Errorf("the bucket \"%s\" must be private to be used as mount", minio.BucketName)
 				} else {


### PR DESCRIPTION
Bucket mounting logic improvements:

* Added a special case for admin users: if the bucket's visibility is empty (which means it's an admin bucket with no MinIO policy), the code now checks the bucket's "owner" tag. If the tag is either empty or matches the admin user ("oscar"), it treats the bucket as private, allowing the mount operation. This prevents admin from mounting buckets owned by other users, while still allowing them to mount their own or unowned buckets.
