### PR TITLE
Improve Resp. Time of /services?include=deployment

### DIFF
--- a/pkg/handlers/deployment.go
+++ b/pkg/handlers/deployment.go
@@ -651,3 +651,59 @@ func validateServiceName(c *gin.Context, serviceName string) (string, bool) {
 	}
 	return serviceName, true
 }
+
+func inspectDeploymentRuntimeStatusOnly(back types.ServerlessBackend, kubeClientset kubernetes.Interface, service *types.Service, cfg *types.Config) (types.ServiceDeploymentStatus, error) {
+	namespace := resolveServiceNamespace(service, cfg)
+	service.Namespace = namespace
+
+	if service.Expose.APIPort != 0 {
+		return inspectExposedDeploymentRuntimeStatusOnly(kubeClientset, service)
+	}
+
+	if getter, ok := back.(deploymentRuntimeServiceGetter); ok {
+		knService, err := getter.GetRuntimeService(namespace, service.Name)
+		if err == nil {
+			return inspectKnativeDeploymentRuntimeStatusOnly(kubeClientset, service, knService)
+		}
+		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+			return types.ServiceDeploymentStatus{}, err
+		}
+	}
+
+	return inspectPodBackedDeploymentRuntimeStatusOnly(kubeClientset, service)
+}
+
+func inspectPodBackedDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interface, service *types.Service) (types.ServiceDeploymentStatus, error) {
+	_, err := backends.ListServicePods(kubeClientset, service.Namespace, service.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
+			return unavailableDeploymentStatus(service, "Current runtime resources are unavailable."), nil
+		}
+		return types.ServiceDeploymentStatus{}, err
+	}
+
+	return unavailableDeploymentStatus(service, "Current deployment visibility is unavailable for this service runtime."), nil
+}
+
+func inspectKnativeDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interface, service *types.Service, knService *knv1.Service) (types.ServiceDeploymentStatus, error) {
+	pods, err := backends.ListKnativeServicePods(kubeClientset, service.Namespace, service.Name)
+	if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+		return types.ServiceDeploymentStatus{}, err
+	}
+	items := podItems(pods)
+	current := filterCurrentRuntimePods(items)
+
+	return deploymentStatusFromKnativeService(service, knService, current), nil
+}
+
+func inspectExposedDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interface, service *types.Service) (types.ServiceDeploymentStatus, error) {
+	deployment, err := backends.GetExposedServiceDeployment(kubeClientset, service.Namespace, service.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
+			return unavailableDeploymentStatus(service, "Current deployment resources are unavailable."), nil
+		}
+		return types.ServiceDeploymentStatus{}, err
+	}
+
+	return deploymentStatusFromDeployment(service, deployment), nil
+}

--- a/pkg/handlers/list.go
+++ b/pkg/handlers/list.go
@@ -111,10 +111,10 @@ func includeQueryContains(raw string, target string) bool {
 }
 
 func setDeploymentSummary(back types.ServerlessBackend, kubeClientset kubernetes.Interface, cfg *types.Config, service *types.Service) error {
-	runtimeCtx, err := inspectDeploymentRuntime(back, kubeClientset, service, cfg)
+	runtimeStatus, err := inspectDeploymentRuntimeStatusOnly(back, kubeClientset, service, cfg)
 	if err != nil {
 		return err
 	}
-	service.Deployment = deploymentSummaryFromStatus(runtimeCtx.status)
+	service.Deployment = deploymentSummaryFromStatus(runtimeStatus)
 	return nil
 }


### PR DESCRIPTION
**Deployment status inspection refactor:**

* Added a new function, `inspectDeploymentRuntimeStatusOnly` based on `inspectDeploymentRuntime`.
* Added variant for specialized helper functions: `inspectPodBackedDeploymentRuntimeStatusOnly` based on  `inspectPodBackedDeploymentRuntime`, `inspectKnativeDeploymentRuntimeStatusOnly` based on  `inspectKnativeDeploymentRuntime`, and `inspectExposedDeploymentRuntimeStatusOnly` bsed on `inspectExposedDeploymentRuntime`.

**Integration with deployment summary:**

* Updated `setDeploymentSummary` to use the new `inspectDeploymentRuntimeStatusOnly` function, replacing the previous `inspectDeploymentRuntime` call, and ensuring the deployment summary is built from the new runtime status.

**Performance impact**

* Local testing (12 services, 50 API calls via Postman) shows  Avg. Resp. Time reduced from ~2200 ms to ~1300 ms (~40% improvement) when calling `/services?include=deployment`.
