### PR TITLE
restrict images

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,8 @@ func main() {
 	system := r.Group("/system", auth.GetAuthMiddleware(cfg, kubeClientset))
 
 	// Config path
-	system.GET("/config", handlers.MakeConfigHandler(cfg))
+	system.GET("/config", handlers.MakeConfigHandler(cfg, kubeClientset))
+	system.PUT("/config", handlers.MakeConfigUpdateHandler(cfg, kubeClientset))
 
 	// CRUD Services
 	system.POST("/services", handlers.MakeCreateHandler(cfg, back))

--- a/pkg/backends/config.go
+++ b/pkg/backends/config.go
@@ -1,0 +1,43 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backends
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CreateOSCARCMConfiguration(back kubernetes.Interface, configMap *v1.ConfigMap, namespace string) error {
+	_, err := back.CoreV1().ConfigMaps(namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+	return err
+}
+
+func GetOSCARCMConfiguration(back kubernetes.Interface, nameConfigMap string, namespace string) (*v1.ConfigMap, error) {
+	cm, err := back.CoreV1().ConfigMaps(namespace).Get(context.TODO(), nameConfigMap, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func UpdateOSCARCMConfiguration(back kubernetes.Interface, configMap *v1.ConfigMap, namespace string) error {
+	_, err := back.CoreV1().ConfigMaps(namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/backends/k8s.go
+++ b/pkg/backends/k8s.go
@@ -18,6 +18,7 @@ package backends
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -371,19 +372,20 @@ func ListKnativeServicePods(kubeClientset kubernetes.Interface, namespace, servi
 
 func checkAdditionalConfig(configName string, configNamespace string, service types.Service, cfg *types.Config, kubeClientset kubernetes.Interface) error {
 	// Get the configMapwith the service additional settings
-	cm, err := kubeClientset.CoreV1().ConfigMaps(configNamespace).Get(context.TODO(), configName, metav1.GetOptions{})
+	cm, err := GetOSCARCMConfiguration(kubeClientset, cfg.AdditionalConfigPath, cfg.Namespace)
 	if err != nil {
 		return nil
 	}
 
-	additionalConfig := &types.AdditionalConfig{}
+	var air []string
 	// Unmarshal the FDL stored in the configMap
-	if err = yaml.Unmarshal([]byte(cm.Data[cfg.AdditionalConfigPath]), additionalConfig); err != nil {
+	err = json.Unmarshal([]byte(cm.Data[types.AIR]), &air)
+	if err != nil {
 		return nil
 	}
 
-	if len(additionalConfig.Images.AllowedPrefixes) > 0 {
-		for _, prefix := range additionalConfig.Images.AllowedPrefixes {
+	if len(air) > 0 {
+		for _, prefix := range air {
 			if strings.Contains(service.Image, prefix) {
 				return nil
 			}

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -17,24 +17,25 @@ limitations under the License.
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/backends"
 	"github.com/grycap/oscar/v3/pkg/types"
 	"github.com/grycap/oscar/v3/pkg/utils/auth"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
 	getUIDFromContextFn                = auth.GetUIDFromContext
 	getMultitenancyConfigFromContextFn = auth.GetMultitenancyConfigFromContext
 )
-
-type ConfigForUser struct {
-	Cfg           *types.Config        `json:"config"`
-	MinIOProvider *types.MinIOProvider `json:"minio_provider"`
-}
 
 // MakeConfigHandler godoc
 // @Summary Get configuration
@@ -47,14 +48,33 @@ type ConfigForUser struct {
 // @Security BasicAuth
 // @Security BearerAuth
 // @Router /system/config [get]
-func MakeConfigHandler(cfg *types.Config) gin.HandlerFunc {
+func MakeConfigHandler(cfg *types.Config, back kubernetes.Interface) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Return configForUser
-		var conf ConfigForUser
+		var conf types.ConfigForUser
 		minIOProvider := cfg.MinIOProvider
+		var air []string
+		cm, err := backends.GetOSCARCMConfiguration(back, cfg.AdditionalConfigPath, cfg.Namespace)
+		if err != nil && !apierrors.IsNotFound(err) {
+			c.String(http.StatusInternalServerError, fmt.Sprintln(err))
+
+		}
+		if apierrors.IsNotFound(err) {
+			air = []string{}
+		} else {
+			err := json.Unmarshal([]byte(cm.Data[types.AIR]), &air)
+			if err != nil {
+				c.String(http.StatusInternalServerError, fmt.Sprintln(err))
+
+			}
+		}
 		authHeader := c.GetHeader("Authorization")
 		if len(strings.Split(authHeader, "Bearer")) == 1 {
-			conf = ConfigForUser{cfg, minIOProvider}
+			conf = types.ConfigForUser{
+				Cfg:                      cfg,
+				MinIOProvider:            minIOProvider,
+				AllowedImageRepositories: air,
+			}
 		} else {
 
 			// Get MinIO credentials from k8s secret for user
@@ -82,9 +102,93 @@ func MakeConfigHandler(cfg *types.Config) gin.HandlerFunc {
 				Region:    minIOProvider.Region,
 			}
 
-			conf = ConfigForUser{cfg, userMinIOProvider}
+			conf = types.ConfigForUser{
+				Cfg:                      cfg,
+				MinIOProvider:            userMinIOProvider,
+				AllowedImageRepositories: air,
+			}
 		}
 
 		c.JSON(http.StatusOK, conf)
+	}
+}
+
+// MakeConfigHandler godoc
+// @Summary Put configuration
+// @Description Change the cluster configuration
+// @Tags config
+// @Produce json
+// @Success 200 {object} handlers.ConfigForUser
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 500 {string} string "Internal Server Error"
+// @Security BasicAuth
+// @Router /system/config [put]
+func MakeConfigUpdateHandler(cfg *types.Config, back kubernetes.Interface) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if len(strings.Split(authHeader, "Bearer")) > 1 {
+			c.JSON(http.StatusUnauthorized, "")
+
+		}
+		configInput := types.ConfigForUser{}
+		if err := c.ShouldBindJSON(&configInput); err != nil {
+			c.String(http.StatusBadRequest, fmt.Sprintf("The configuration specification is not valid: %v", err))
+			return
+		}
+		_, err := backends.GetOSCARCMConfiguration(back, cfg.AdditionalConfigPath, cfg.Namespace)
+
+		if err != nil && !apierrors.IsNotFound(err) {
+			c.JSON(http.StatusInternalServerError, err)
+			return
+
+		}
+		if apierrors.IsNotFound(err) {
+			if configInput.AllowedImageRepositories == nil || len(configInput.AllowedImageRepositories) == 0 {
+				cm := getOSCARCMConfigurationDefaultDefinition(cfg.AdditionalConfigPath)
+				backends.CreateOSCARCMConfiguration(back, cm, cfg.Namespace)
+				c.JSON(http.StatusOK, configInput.AllowedImageRepositories)
+				return
+
+			} else {
+				cm := getOSCARCMConfigurationCustomDefinition(cfg.AdditionalConfigPath, configInput.AllowedImageRepositories)
+				err := backends.CreateOSCARCMConfiguration(back, cm, cfg.Namespace)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, err)
+					return
+
+				}
+				c.JSON(http.StatusOK, configInput.AllowedImageRepositories)
+				return
+			}
+		}
+		newConfigMap := getOSCARCMConfigurationCustomDefinition(cfg.AdditionalConfigPath, configInput.AllowedImageRepositories)
+		backends.UpdateOSCARCMConfiguration(back, newConfigMap, cfg.Namespace)
+		c.JSON(http.StatusOK, configInput.AllowedImageRepositories)
+		return
+
+	}
+}
+
+func getOSCARCMConfigurationDefaultDefinition(name string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string]string{
+			types.AIR: "[]",
+		},
+	}
+}
+
+func getOSCARCMConfigurationCustomDefinition(name string, air []string) *v1.ConfigMap {
+	data, _ := json.Marshal(air)
+	dataString := string(data)
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string]string{
+			types.AIR: dataString,
+		},
 	}
 }

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -145,13 +145,22 @@ func MakeConfigUpdateHandler(cfg *types.Config, back kubernetes.Interface) gin.H
 		if apierrors.IsNotFound(err) {
 			if configInput.AllowedImageRepositories == nil || len(configInput.AllowedImageRepositories) == 0 {
 				cm := getOSCARCMConfigurationDefaultDefinition(cfg.AdditionalConfigPath)
-				backends.CreateOSCARCMConfiguration(back, cm, cfg.Namespace)
+				err = backends.CreateOSCARCMConfiguration(back, cm, cfg.Namespace)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, err)
+					return
+
+				}
 				c.JSON(http.StatusOK, configInput.AllowedImageRepositories)
 				return
 
 			} else {
-				cm := getOSCARCMConfigurationCustomDefinition(cfg.AdditionalConfigPath, configInput.AllowedImageRepositories)
-				err := backends.CreateOSCARCMConfiguration(back, cm, cfg.Namespace)
+				cm, err := getOSCARCMConfigurationCustomDefinition(cfg.AdditionalConfigPath, configInput.AllowedImageRepositories)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, err)
+					return
+				}
+				err = backends.CreateOSCARCMConfiguration(back, cm, cfg.Namespace)
 				if err != nil {
 					c.JSON(http.StatusInternalServerError, err)
 					return
@@ -161,8 +170,18 @@ func MakeConfigUpdateHandler(cfg *types.Config, back kubernetes.Interface) gin.H
 				return
 			}
 		}
-		newConfigMap := getOSCARCMConfigurationCustomDefinition(cfg.AdditionalConfigPath, configInput.AllowedImageRepositories)
-		backends.UpdateOSCARCMConfiguration(back, newConfigMap, cfg.Namespace)
+		newConfigMap, err := getOSCARCMConfigurationCustomDefinition(cfg.AdditionalConfigPath, configInput.AllowedImageRepositories)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, err)
+			return
+
+		}
+		err = backends.UpdateOSCARCMConfiguration(back, newConfigMap, cfg.Namespace)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, err)
+			return
+
+		}
 		c.JSON(http.StatusOK, configInput.AllowedImageRepositories)
 		return
 
@@ -180,8 +199,11 @@ func getOSCARCMConfigurationDefaultDefinition(name string) *v1.ConfigMap {
 	}
 }
 
-func getOSCARCMConfigurationCustomDefinition(name string, air []string) *v1.ConfigMap {
-	data, _ := json.Marshal(air)
+func getOSCARCMConfigurationCustomDefinition(name string, air []string) (*v1.ConfigMap, error) {
+	data, err := json.Marshal(air)
+	if err != nil {
+		return _, err
+	}
 	dataString := string(data)
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -190,5 +212,5 @@ func getOSCARCMConfigurationCustomDefinition(name string, air []string) *v1.Conf
 		Data: map[string]string{
 			types.AIR: dataString,
 		},
-	}
+	}, nil
 }

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -202,7 +202,7 @@ func getOSCARCMConfigurationDefaultDefinition(name string) *v1.ConfigMap {
 func getOSCARCMConfigurationCustomDefinition(name string, air []string) (*v1.ConfigMap, error) {
 	data, err := json.Marshal(air)
 	if err != nil {
-		return _, err
+		return nil, err
 	}
 	dataString := string(data)
 	return &v1.ConfigMap{

--- a/pkg/handlers/config_test.go
+++ b/pkg/handlers/config_test.go
@@ -54,6 +54,7 @@ func createExpectedBody(access_key string, secret_key string, cfg *types.Config)
 			"secret_key": secret_key,
 			"region":     cfg.MinIOProvider.Region,
 		},
+		"allowed_image_repositories": []interface{}{},
 	}
 }
 
@@ -71,9 +72,10 @@ func TestMakeConfigHandler(t *testing.T) {
 		},
 	}
 
+	kubeClientset := testclient.NewSimpleClientset()
 	t.Run("Without Authorization Header", func(t *testing.T) {
 		router := gin.New()
-		router.GET("/config", MakeConfigHandler(cfg))
+		router.GET("/config", MakeConfigHandler(cfg, kubeClientset))
 
 		req, _ := http.NewRequest("GET", "/config", nil)
 		w := httptest.NewRecorder()
@@ -101,10 +103,10 @@ func TestMakeConfigHandler(t *testing.T) {
 		},
 	}
 
-	kubeClientset := testclient.NewSimpleClientset(K8sObjects...)
+	kubeClientset = testclient.NewSimpleClientset(K8sObjects...)
 	t.Run("With Bearer Authorization Header", func(t *testing.T) {
 		router := gin.New()
-		router.GET("/config", MakeConfigHandler(cfg))
+		router.GET("/config", MakeConfigHandler(cfg, kubeClientset))
 
 		req, _ := http.NewRequest("GET", "/config", nil)
 		req.Header.Set("Authorization", "Bearer some-token")
@@ -145,7 +147,7 @@ func TestMakeConfigHandler(t *testing.T) {
 
 	t.Run("With Token Authorization Header", func(t *testing.T) {
 		router := gin.New()
-		router.GET("/config", MakeConfigHandler(cfg))
+		router.GET("/config", MakeConfigHandler(cfg, kubeClientset))
 
 		req, _ := http.NewRequest("GET", "/config", nil)
 		req.Header.Set("Authorization", "SomeToken")

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -46,6 +46,7 @@ const (
 	urlType               = "url"
 	serverlessBackendType = "serverlessBackend"
 	routeKindType         = "routeKind"
+	AIR                   = "allowed_image_repositories"
 )
 
 type configVar struct {
@@ -273,6 +274,12 @@ type Config struct {
 
 	// LokiExposedAppLabel app label for exposed-service logs
 	LokiExposedAppLabel string `json:"-"`
+}
+
+type ConfigForUser struct {
+	Cfg                      *Config        `json:"config"`
+	MinIOProvider            *MinIOProvider `json:"minio_provider"`
+	AllowedImageRepositories []string       `json:"allowed_image_repositories"`
 }
 
 var configVars = []configVar{


### PR DESCRIPTION
**API and Handler Enhancements:**

* Added a new `PUT /system/config` endpoint to allow updating the allowed image repositories, and updated the `GET /system/config` endpoint to return the AIR list as part of the configuration response. (`main.go`, `pkg/handlers/config.go`) [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L115-R116) [[2]](diffhunk://#diff-17e54cc2ca859515e6a073d75da8708e25a6ca9e43d9aa5c092559219a1bf8f3L50-R77) [[3]](diffhunk://#diff-17e54cc2ca859515e6a073d75da8708e25a6ca9e43d9aa5c092559219a1bf8f3L85-R194)

**Backend and Data Model Changes:**

* Implemented backend functions to create, retrieve, and update the AIR ConfigMap in Kubernetes. (`pkg/backends/config.go`)
* Introduced the `AllowedImageRepositories` field to the `ConfigForUser` struct, and defined the `AIR` constant in the types package. (`pkg/types/config.go`) [[1]](diffhunk://#diff-9d529726ce995cd997dcbdc23e3697f72a1ce88820157b2656aab9d106ab5efbR49) [[2]](diffhunk://#diff-9d529726ce995cd997dcbdc23e3697f72a1ce88820157b2656aab9d106ab5efbR279-R284)

**Logic and Behavior Updates:**

* Modified logic to fetch and unmarshal the AIR list from the ConfigMap, and to return it as part of the configuration for both regular and token-based authentication flows. (`pkg/handlers/config.go`) [[1]](diffhunk://#diff-17e54cc2ca859515e6a073d75da8708e25a6ca9e43d9aa5c092559219a1bf8f3L50-R77) [[2]](diffhunk://#diff-17e54cc2ca859515e6a073d75da8708e25a6ca9e43d9aa5c092559219a1bf8f3L85-R194)
* Updated image repository validation logic to use the AIR list from the ConfigMap, replacing the previous YAML-based approach. (`pkg/backends/k8s.go`) [[1]](diffhunk://#diff-5ce29d2fd045cb640dd3b0027b2daa136e20626714cda6cafdc56c9149bd7616L374-R388) [[2]](diffhunk://#diff-5ce29d2fd045cb640dd3b0027b2daa136e20626714cda6cafdc56c9149bd7616R21)

**Testing:**

* Updated tests to account for the new AIR field in the configuration response and to use the updated handler signatures. (`pkg/handlers/config_test.go`) [[1]](diffhunk://#diff-f24b056ed9f17882677c96c329bb7ef62edcb59370e4ee74edd1843cd6348409R57) [[2]](diffhunk://#diff-f24b056ed9f17882677c96c329bb7ef62edcb59370e4ee74edd1843cd6348409R75-R78) [[3]](diffhunk://#diff-f24b056ed9f17882677c96c329bb7ef62edcb59370e4ee74edd1843cd6348409L104-R109) [[4]](diffhunk://#diff-f24b056ed9f17882677c96c329bb7ef62edcb59370e4ee74edd1843cd6348409L148-R150)