### PR TITLE
restrict container image documentation

### DIFF
--- a/docs/additional-config.md
+++ b/docs/additional-config.md
@@ -6,13 +6,18 @@ To give the administrator a more personalized cluster configuration, the OSCAR m
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: additional-oscar-config
-  namespace: oscar-svc
+  name: config.yaml
+  namespace: oscar
 data:
   config.yaml: |
     images:
-      allowed_prefixes:
-      - ghcr.io
+      allowed_image_repositories:  '["ghcr.io/grycap",...]'
+```
+
+Also, the administrator can use the PUT /system/config API call to modify the trusted image repositories. The next example only allows images from the `ghcr.io/grycap` repository/owner.
+
+```
+curl -vX PUT  -H "Authorization: Basic <echo 'user:password' -n | base64>"  https://<oscar_endpoint>/system/config -d '{"allowed_image_repositories":["ghcr.io/grycap"]}'
 ```
 
 Additionally, this property can be added when creating an OSCAR cluster through the IM, which will automatically create the ConfigMap.

--- a/docs/oscar-service.md
+++ b/docs/oscar-service.md
@@ -61,6 +61,14 @@ in order to test the OSCAR framework for specific applications. We recommend
 you to start with the
 [plant classification example](https://github.com/grycap/oscar/tree/master/examples/plant-classification-sync).
 
+#### Restrict Container images
+
+An admin user can allow a trusted image repository and discard images from other repositories. Use the PUT /system/config API call. The next example only allows images from the `ghcr.io/grycap` repository/owner.
+
+```
+curl -vX PUT  -H "Authorization: Basic <echo 'user:password' -n | base64>"  https://<oscar_endpoint>/system/config -d '{"allowed_image_repositories":["ghcr.io/grycap"]}'
+```
+
 
 ### External Storage Providers
 

--- a/docs/oscar-service.md
+++ b/docs/oscar-service.md
@@ -61,15 +61,6 @@ in order to test the OSCAR framework for specific applications. We recommend
 you to start with the
 [plant classification example](https://github.com/grycap/oscar/tree/master/examples/plant-classification-sync).
 
-#### Restrict Container images
-
-An admin user can allow a trusted image repository and discard images from other repositories. Use the PUT /system/config API call. The next example only allows images from the `ghcr.io/grycap` repository/owner.
-
-```
-curl -vX PUT  -H "Authorization: Basic <echo 'user:password' -n | base64>"  https://<oscar_endpoint>/system/config -d '{"allowed_image_repositories":["ghcr.io/grycap"]}'
-```
-
-
 ### External Storage Providers
 
 [FaaS Supervisor](https://github.com/grycap/faas-supervisor) downloads the input file and uploads the output file. Each [storage provider](fdl.md#storageproviders) has specific parameters, authentication, and capabilities. The current implementation supports:


### PR DESCRIPTION
Fixes # https://github.com/grycap/issue-tracker/issues/123

## Proposed Changes

**Documentation improvements for image repository configuration**

* Updated the example `ConfigMap` in `docs/additional-config.md` to use the new `allowed_image_repositories` field, replacing the previous `allowed_prefixes`, and clarified its format.
* Added instructions for modifying trusted image repositories using the `PUT /system/config` API call, including a sample `curl` command.

**Minor formatting and clarity**

* Removed an unnecessary blank line in `docs/oscar-service.md` to improve document formatting.
