### PR TITLE
fix quota reset

### DIFF
--- a/pkg/utils/kueue.go
+++ b/pkg/utils/kueue.go
@@ -185,7 +185,6 @@ func ensureClusterQueue(ctx context.Context, kueueClient *kueueclientset.Clients
 		len(current.Spec.ResourceGroups) == 0 ||
 		len(current.Spec.ResourceGroups[0].Flavors) == 0 ||
 		len(current.Spec.ResourceGroups[0].Flavors[0].Resources) == 0 ||
-		!reflect.DeepEqual(current.Spec.ResourceGroups, cq.Spec.ResourceGroups) ||
 		!reflect.DeepEqual(current.Spec.NamespaceSelector, cq.Spec.NamespaceSelector) {
 		current.Spec.ResourceGroups = cq.Spec.ResourceGroups
 		current.Spec.NamespaceSelector = cq.Spec.NamespaceSelector


### PR DESCRIPTION
Fixes #https://github.com/grycap/issue-tracker/issues/341

## Proposed Changes

Logic simplification:

* [`pkg/utils/kueue.go`](diffhunk://#diff-638ceb7948fcfe3dcffabc7f486dac7da1fe426dde0e74bc5af2765b7b6a7156L188): Removed the `reflect.DeepEqual` check between `current.Spec.ResourceGroups` and `cq.Spec.ResourceGroups` in the update condition of `ensureClusterQueue`, likely because the preceding checks already handle the necessary cases.