### PR TITLE
fix: scope system metrics to authorized OIDC services

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,12 @@ the list of users per service, set `include_users=true` (JSON only).
 The `start`/`end` query parameters are optional. If omitted, the API defaults to
 the last 24 hours (end = now, start = end - 24h).
 
+When using OIDC Bearer tokens, metrics are limited to the services visible to
+the authenticated user under the usual service visibility rules (`public`,
+owned services, and `restricted` services where the user is listed in
+`allowed_users`). When using Basic Auth as the OSCAR admin user, metrics remain
+cluster-wide and include all services.
+
 ### Prometheus usage metrics
 
 CPU/GPU hours are fetched from Prometheus. If `PROMETHEUS_URL` is not set, the

--- a/main.go
+++ b/main.go
@@ -154,9 +154,9 @@ func main() {
 	metricsSources := metrics.DefaultSources(cfg, back, kubeClientset)
 	metricsAgg := &metrics.Aggregator{Sources: metricsSources}
 	metricsGroup := r.Group("/system/metrics", auth.GetAuthMiddleware(cfg, kubeClientset))
-	metricsGroup.GET("", handlers.MakeMetricsSummaryHandler(metricsAgg))
-	metricsGroup.GET("/breakdown", handlers.MakeMetricsBreakdownHandler(metricsAgg))
-	metricsGroup.GET("/:serviceName", handlers.MakeMetricValueHandler(metricsAgg))
+	metricsGroup.GET("", handlers.MakeMetricsSummaryHandler(back, metricsAgg))
+	metricsGroup.GET("/breakdown", handlers.MakeMetricsBreakdownHandler(back, metricsAgg))
+	metricsGroup.GET("/:serviceName", handlers.MakeMetricValueHandler(back, metricsAgg))
 	// Quotas
 	if cfg.KueueEnable {
 		system.GET("/quotas/user", handlers.MakeGetOwnQuotaHandler(*qb, cfg))

--- a/pkg/handlers/metrics.go
+++ b/pkg/handlers/metrics.go
@@ -62,11 +62,14 @@ type serviceBreakdownResponse struct {
 // @Security BasicAuth
 // @Security BearerAuth
 // @Router /system/metrics/{serviceName} [get]
-func MakeMetricValueHandler(agg *metrics.Aggregator) gin.HandlerFunc {
+func MakeMetricValueHandler(back types.ServerlessBackend, agg *metrics.Aggregator) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		serviceName := strings.TrimSpace(c.Param("serviceName"))
 		if serviceName == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "serviceName is required"})
+			return
+		}
+		if _, ok := getAuthorizedServiceForMetrics(c, back, serviceName); !ok {
 			return
 		}
 
@@ -75,9 +78,14 @@ func MakeMetricValueHandler(agg *metrics.Aggregator) gin.HandlerFunc {
 			return
 		}
 
+		scopedAgg, ok := scopedMetricsAggregator(c, back, agg)
+		if !ok {
+			return
+		}
+
 		metricRaw := strings.TrimSpace(c.Query("metric"))
 		if metricRaw == "" {
-			metricsList, err := loadAllServiceMetrics(c, agg, tr, serviceName)
+			metricsList, err := loadAllServiceMetrics(c, scopedAgg, tr, serviceName)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
@@ -97,7 +105,7 @@ func MakeMetricValueHandler(agg *metrics.Aggregator) gin.HandlerFunc {
 			return
 		}
 
-		resp, err := agg.MetricValue(c.Request.Context(), tr, serviceName, metricKey)
+		resp, err := scopedAgg.MetricValue(c.Request.Context(), tr, serviceName, metricKey)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -143,14 +151,19 @@ func loadAllServiceMetrics(c *gin.Context, agg *metrics.Aggregator, tr metrics.T
 // @Security BasicAuth
 // @Security BearerAuth
 // @Router /system/metrics [get]
-func MakeMetricsSummaryHandler(agg *metrics.Aggregator) gin.HandlerFunc {
+func MakeMetricsSummaryHandler(back types.ServerlessBackend, agg *metrics.Aggregator) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tr, ok := parseTimeRange(c)
 		if !ok {
 			return
 		}
 
-		resp, err := agg.Summary(c.Request.Context(), tr)
+		scopedAgg, ok := scopedMetricsAggregator(c, back, agg)
+		if !ok {
+			return
+		}
+
+		resp, err := scopedAgg.Summary(c.Request.Context(), tr)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -175,7 +188,7 @@ func MakeMetricsSummaryHandler(agg *metrics.Aggregator) gin.HandlerFunc {
 // @Security BasicAuth
 // @Security BearerAuth
 // @Router /system/metrics/breakdown [get]
-func MakeMetricsBreakdownHandler(agg *metrics.Aggregator) gin.HandlerFunc {
+func MakeMetricsBreakdownHandler(back types.ServerlessBackend, agg *metrics.Aggregator) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tr, ok := parseTimeRange(c)
 		if !ok {
@@ -195,7 +208,12 @@ func MakeMetricsBreakdownHandler(agg *metrics.Aggregator) gin.HandlerFunc {
 		}
 
 		includeUsers := strings.ToLower(strings.TrimSpace(c.DefaultQuery("include_users", "false"))) == "true"
-		resp, err := agg.Breakdown(c.Request.Context(), tr, groupBy, includeUsers)
+		scopedAgg, ok := scopedMetricsAggregator(c, back, agg)
+		if !ok {
+			return
+		}
+
+		resp, err := scopedAgg.Breakdown(c.Request.Context(), tr, groupBy, includeUsers)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -259,6 +277,39 @@ func MakeMetricsBreakdownHandler(agg *metrics.Aggregator) gin.HandlerFunc {
 
 		c.JSON(http.StatusOK, resp)
 	}
+}
+
+func scopedMetricsAggregator(c *gin.Context, back types.ServerlessBackend, agg *metrics.Aggregator) (*metrics.Aggregator, bool) {
+	allowedServices, scoped, ok := allowedMetricsServiceIDs(c, back)
+	if !ok {
+		return nil, false
+	}
+	if !scoped {
+		return agg, true
+	}
+	return &metrics.Aggregator{
+		Sources: metrics.ScopeSources(agg.Sources, allowedServices),
+	}, true
+}
+
+func allowedMetricsServiceIDs(c *gin.Context, back types.ServerlessBackend) (map[string]struct{}, bool, bool) {
+	if !isBearerRequest(c) {
+		return nil, false, true
+	}
+
+	services, ok := listAuthorizedServicesForMetrics(c, back)
+	if !ok {
+		return nil, false, false
+	}
+
+	allowed := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		if service == nil {
+			continue
+		}
+		allowed[service.Name] = struct{}{}
+	}
+	return allowed, true, true
 }
 
 func parseTimeRange(c *gin.Context) (metrics.TimeRange, bool) {

--- a/pkg/handlers/metrics_test.go
+++ b/pkg/handlers/metrics_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/backends"
 	"github.com/grycap/oscar/v3/pkg/metrics"
 	"github.com/grycap/oscar/v3/pkg/types"
+	"github.com/grycap/oscar/v3/pkg/utils"
 )
 
 type fakeServiceInventory struct {
@@ -27,8 +29,10 @@ func (f *fakeServiceInventory) ListServices(ctx context.Context, tr metrics.Time
 }
 
 type fakeUsageMetrics struct {
-	cpu float64
-	gpu float64
+	cpu          float64
+	gpu          float64
+	cpuByService map[string]float64
+	gpuByService map[string]float64
 }
 
 func (f *fakeUsageMetrics) Name() string {
@@ -36,6 +40,9 @@ func (f *fakeUsageMetrics) Name() string {
 }
 
 func (f *fakeUsageMetrics) UsageHours(ctx context.Context, tr metrics.TimeRange, serviceID string) (float64, float64, *types.SourceStatus, error) {
+	if f.cpuByService != nil || f.gpuByService != nil {
+		return f.cpuByService[serviceID], f.gpuByService[serviceID], &types.SourceStatus{Name: f.Name(), Status: "ok"}, nil
+	}
 	return f.cpu, f.gpu, &types.SourceStatus{Name: f.Name(), Status: "ok"}, nil
 }
 
@@ -48,7 +55,16 @@ func (f *fakeRequestLogs) Name() string {
 }
 
 func (f *fakeRequestLogs) ListRequests(ctx context.Context, tr metrics.TimeRange, serviceID string) ([]metrics.RequestRecord, *types.SourceStatus, error) {
-	return f.records, &types.SourceStatus{Name: f.Name(), Status: "ok"}, nil
+	if serviceID == "" {
+		return f.records, &types.SourceStatus{Name: f.Name(), Status: "ok"}, nil
+	}
+	filtered := make([]metrics.RequestRecord, 0, len(f.records))
+	for _, record := range f.records {
+		if record.ServiceID == serviceID {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered, &types.SourceStatus{Name: f.Name(), Status: "ok"}, nil
 }
 
 type fakeCountrySource struct{}
@@ -64,23 +80,28 @@ func (f *fakeCountrySource) CountryForRecord(ctx context.Context, record metrics
 	return record.Country, &types.SourceStatus{Name: f.Name(), Status: "ok"}, nil
 }
 
-func setupMetricsRouter(agg *metrics.Aggregator) *gin.Engine {
+func setupMetricsRouter(back types.ServerlessBackend, agg *metrics.Aggregator, middlewares ...gin.HandlerFunc) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.GET("/system/metrics", MakeMetricsSummaryHandler(agg))
-	router.GET("/system/metrics/", MakeMetricsSummaryHandler(agg))
-	router.GET("/system/metrics/breakdown", MakeMetricsBreakdownHandler(agg))
-	router.GET("/system/metrics/:serviceName", MakeMetricValueHandler(agg))
+	for _, middleware := range middlewares {
+		router.Use(middleware)
+	}
+	router.GET("/system/metrics", MakeMetricsSummaryHandler(back, agg))
+	router.GET("/system/metrics/", MakeMetricsSummaryHandler(back, agg))
+	router.GET("/system/metrics/breakdown", MakeMetricsBreakdownHandler(back, agg))
+	router.GET("/system/metrics/:serviceName", MakeMetricValueHandler(back, agg))
 	return router
 }
 
 func TestMetricValueHandler(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{Name: "svc-a", Owner: "owner@example.org", Visibility: utils.PUBLIC}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			UsageMetrics: &fakeUsageMetrics{cpu: 2.5, gpu: 1.0},
 		},
 	}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics/svc-a?metric=cpu-hours&start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
 	rec := httptest.NewRecorder()
@@ -99,6 +120,8 @@ func TestMetricValueHandler(t *testing.T) {
 }
 
 func TestMetricValueHandlerAllMetrics(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{Name: "svc-a", Owner: "owner@example.org", Visibility: utils.PUBLIC}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			UsageMetrics: &fakeUsageMetrics{cpu: 2.5, gpu: 1.0},
@@ -108,7 +131,7 @@ func TestMetricValueHandlerAllMetrics(t *testing.T) {
 			}},
 		},
 	}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics/svc-a?start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
 	rec := httptest.NewRecorder()
@@ -140,6 +163,8 @@ func TestMetricValueHandlerAllMetrics(t *testing.T) {
 }
 
 func TestMetricsSummaryHandler(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{{Name: "svc-a", Owner: "owner@example.org", Visibility: utils.PUBLIC}}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			ServiceInventory: &fakeServiceInventory{services: []metrics.ServiceDescriptor{{ID: "svc-a"}}},
@@ -150,7 +175,7 @@ func TestMetricsSummaryHandler(t *testing.T) {
 			CountrySource: &fakeCountrySource{},
 		},
 	}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics?start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
 	rec := httptest.NewRecorder()
@@ -170,6 +195,8 @@ func TestMetricsSummaryHandler(t *testing.T) {
 }
 
 func TestMetricsSummaryDefaultsToLastDay(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{{Name: "svc-a", Owner: "owner@example.org", Visibility: utils.PUBLIC}}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			ServiceInventory: &fakeServiceInventory{services: []metrics.ServiceDescriptor{{ID: "svc-a"}}},
@@ -178,7 +205,7 @@ func TestMetricsSummaryDefaultsToLastDay(t *testing.T) {
 			CountrySource:    &fakeCountrySource{},
 		},
 	}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 
 	before := time.Now().UTC()
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics", nil)
@@ -204,6 +231,8 @@ func TestMetricsSummaryDefaultsToLastDay(t *testing.T) {
 }
 
 func TestMetricsBreakdownCSVExport(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{{Name: "svc-a", Owner: "owner@example.org", Visibility: utils.PUBLIC}}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
@@ -212,7 +241,7 @@ func TestMetricsBreakdownCSVExport(t *testing.T) {
 			CountrySource: &fakeCountrySource{},
 		},
 	}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics/breakdown?start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z&group_by=service&format=csv", nil)
 	rec := httptest.NewRecorder()
@@ -230,8 +259,9 @@ func TestMetricsBreakdownCSVExport(t *testing.T) {
 }
 
 func TestMetricsBreakdownInvalidTimeRange(t *testing.T) {
+	back := backends.MakeFakeBackend()
 	agg := &metrics.Aggregator{}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics/breakdown?start=bad&end=2026-01-02T00:00:00Z&group_by=service", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -241,8 +271,9 @@ func TestMetricsBreakdownInvalidTimeRange(t *testing.T) {
 }
 
 func TestMetricsValueMissingServiceID(t *testing.T) {
+	back := backends.MakeFakeBackend()
 	agg := &metrics.Aggregator{}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics/%20?metric=cpu-hours&start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -252,13 +283,197 @@ func TestMetricsValueMissingServiceID(t *testing.T) {
 }
 
 func TestMetricsSummaryTimeRangeOrder(t *testing.T) {
+	back := backends.MakeFakeBackend()
 	agg := &metrics.Aggregator{}
-	router := setupMetricsRouter(agg)
+	router := setupMetricsRouter(back, agg)
 	req := httptest.NewRequest(http.MethodGet, "/system/metrics?start=2026-01-02T00:00:00Z&end=2026-01-01T00:00:00Z", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMetricsSummaryHandlerScopesOIDCToVisibleServices(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{
+		{Name: "svc-public", Owner: "owner@example.org", Visibility: utils.PUBLIC},
+		{Name: "svc-owned", Owner: "user@example.org", Visibility: utils.PRIVATE},
+		{Name: "svc-restricted", Owner: "owner@example.org", Visibility: utils.RESTRICTED, AllowedUsers: []string{"user@example.org"}},
+		{Name: "svc-private", Owner: "owner@example.org", Visibility: utils.PRIVATE},
+	}
+	agg := &metrics.Aggregator{
+		Sources: metrics.Sources{
+			ServiceInventory: &fakeServiceInventory{services: []metrics.ServiceDescriptor{
+				{ID: "svc-public"},
+				{ID: "svc-owned"},
+				{ID: "svc-restricted"},
+				{ID: "svc-private"},
+			}},
+			UsageMetrics: &fakeUsageMetrics{
+				cpuByService: map[string]float64{
+					"svc-public":     1,
+					"svc-owned":      2,
+					"svc-restricted": 3,
+					"svc-private":    4,
+				},
+				gpuByService: map[string]float64{
+					"svc-public":     1,
+					"svc-owned":      0,
+					"svc-restricted": 1,
+					"svc-private":    2,
+				},
+			},
+			RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
+				{ServiceID: "svc-public", UserID: "u1", Type: metrics.RequestSync, Country: "ES"},
+				{ServiceID: "svc-owned", UserID: "u2", Type: metrics.RequestAsync, Country: "FR"},
+				{ServiceID: "svc-restricted", UserID: "u3", Type: metrics.RequestSync, Country: "DE"},
+				{ServiceID: "svc-private", UserID: "u4", Type: metrics.RequestSync, Country: "IT"},
+			}},
+			CountrySource: &fakeCountrySource{},
+		},
+	}
+	router := setupMetricsRouter(back, agg, func(c *gin.Context) {
+		c.Set("uidOrigin", "user@example.org")
+		c.Next()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics?start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp types.MetricsSummaryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unexpected json error: %v", err)
+	}
+	if resp.Totals.ServicesCountActive != 3 {
+		t.Fatalf("expected 3 visible services, got %d", resp.Totals.ServicesCountActive)
+	}
+	if resp.Totals.ServicesCountTotal != 3 {
+		t.Fatalf("expected 3 visible services in totals, got %d", resp.Totals.ServicesCountTotal)
+	}
+	if resp.Totals.CPUHoursTotal != 6 {
+		t.Fatalf("expected scoped CPU total 6, got %v", resp.Totals.CPUHoursTotal)
+	}
+	if resp.Totals.RequestsCountTotal != 3 {
+		t.Fatalf("expected scoped request total 3, got %d", resp.Totals.RequestsCountTotal)
+	}
+	if resp.Totals.UsersCount != 3 {
+		t.Fatalf("expected scoped users count 3, got %d", resp.Totals.UsersCount)
+	}
+}
+
+func TestMetricsSummaryHandlerBasicAuthSeesAllServices(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{
+		{Name: "svc-public", Owner: "owner@example.org", Visibility: utils.PUBLIC},
+		{Name: "svc-private", Owner: "owner@example.org", Visibility: utils.PRIVATE},
+	}
+	agg := &metrics.Aggregator{
+		Sources: metrics.Sources{
+			ServiceInventory: &fakeServiceInventory{services: []metrics.ServiceDescriptor{{ID: "svc-public"}, {ID: "svc-private"}}},
+			UsageMetrics: &fakeUsageMetrics{
+				cpuByService: map[string]float64{"svc-public": 1, "svc-private": 4},
+				gpuByService: map[string]float64{"svc-public": 0, "svc-private": 2},
+			},
+			RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
+				{ServiceID: "svc-public", UserID: "u1", Type: metrics.RequestSync, Country: "ES"},
+				{ServiceID: "svc-private", UserID: "u2", Type: metrics.RequestSync, Country: "FR"},
+			}},
+			CountrySource: &fakeCountrySource{},
+		},
+	}
+	router := setupMetricsRouter(back, agg)
+
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics?start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
+	req.Header.Set("Authorization", "Basic b3NjYXI6cGFzcw==")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp types.MetricsSummaryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unexpected json error: %v", err)
+	}
+	if resp.Totals.ServicesCountActive != 2 {
+		t.Fatalf("expected 2 services for basic auth, got %d", resp.Totals.ServicesCountActive)
+	}
+	if resp.Totals.CPUHoursTotal != 5 {
+		t.Fatalf("expected unscoped CPU total 5, got %v", resp.Totals.CPUHoursTotal)
+	}
+	if resp.Totals.RequestsCountTotal != 2 {
+		t.Fatalf("expected unscoped request total 2, got %d", resp.Totals.RequestsCountTotal)
+	}
+}
+
+func TestMetricsBreakdownHandlerScopesOIDCToVisibleServices(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{
+		{Name: "svc-public", Owner: "owner@example.org", Visibility: utils.PUBLIC},
+		{Name: "svc-private", Owner: "owner@example.org", Visibility: utils.PRIVATE},
+	}
+	agg := &metrics.Aggregator{
+		Sources: metrics.Sources{
+			RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
+				{ServiceID: "svc-public", UserID: "u1", Type: metrics.RequestSync, Country: "ES"},
+				{ServiceID: "svc-private", UserID: "u2", Type: metrics.RequestAsync, Country: "FR"},
+			}},
+		},
+	}
+	router := setupMetricsRouter(back, agg, func(c *gin.Context) {
+		c.Set("uidOrigin", "user@example.org")
+		c.Next()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics/breakdown?start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z&group_by=service", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp serviceBreakdownResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unexpected json error: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 visible service in breakdown, got %d", len(resp.Items))
+	}
+	if resp.Items[0].Key != "svc-public" {
+		t.Fatalf("expected only svc-public in breakdown, got %s", resp.Items[0].Key)
+	}
+}
+
+func TestMetricValueHandlerRejectsUnauthorizedOIDCService(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{Name: "svc-private", Owner: "owner@example.org", Visibility: utils.PRIVATE}
+	agg := &metrics.Aggregator{
+		Sources: metrics.Sources{
+			UsageMetrics: &fakeUsageMetrics{cpu: 2.5, gpu: 1.0},
+		},
+	}
+	router := setupMetricsRouter(back, agg, func(c *gin.Context) {
+		c.Set("uidOrigin", "user@example.org")
+		c.Next()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics/svc-private?metric=cpu-hours&start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
 	}
 }
 

--- a/pkg/handlers/service_access.go
+++ b/pkg/handlers/service_access.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/types"
+	"github.com/grycap/oscar/v3/pkg/utils"
+	"github.com/grycap/oscar/v3/pkg/utils/auth"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+func isBearerRequest(c *gin.Context) bool {
+	return strings.HasPrefix(c.GetHeader("Authorization"), "Bearer ")
+}
+
+func isServiceAccessibleByUser(service *types.Service, uid string) bool {
+	if service == nil {
+		return false
+	}
+	if service.Visibility == utils.PUBLIC {
+		return true
+	}
+	if uid == service.Owner {
+		return true
+	}
+	return service.Visibility == utils.RESTRICTED && slices.Contains(service.AllowedUsers, uid)
+}
+
+func listAuthorizedServicesForMetrics(c *gin.Context, back types.ServerlessBackend) ([]*types.Service, bool) {
+	services, err := back.ListServices()
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return nil, false
+	}
+	if !isBearerRequest(c) {
+		return services, true
+	}
+
+	uid, err := auth.GetUIDFromContext(c)
+	if err != nil {
+		c.String(http.StatusUnauthorized, err.Error())
+		return nil, false
+	}
+
+	filtered := make([]*types.Service, 0, len(services))
+	for _, service := range services {
+		if isServiceAccessibleByUser(service, uid) {
+			filtered = append(filtered, service)
+		}
+	}
+	return filtered, true
+}
+
+func getAuthorizedServiceForMetrics(c *gin.Context, back types.ServerlessBackend, serviceName string) (*types.Service, bool) {
+	service, err := back.ReadService("", serviceName)
+	if err != nil {
+		if errors.IsNotFound(err) || errors.IsGone(err) {
+			c.Status(http.StatusNotFound)
+		} else {
+			c.String(http.StatusInternalServerError, err.Error())
+		}
+		return nil, false
+	}
+	if !isBearerRequest(c) {
+		return service, true
+	}
+
+	uid, err := auth.GetUIDFromContext(c)
+	if err != nil {
+		c.String(http.StatusUnauthorized, err.Error())
+		return nil, false
+	}
+	if !isServiceAccessibleByUser(service, uid) {
+		c.Status(http.StatusForbidden)
+		return nil, false
+	}
+	return service, true
+}

--- a/pkg/metrics/scoped.go
+++ b/pkg/metrics/scoped.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+type scopedServiceInventorySource struct {
+	inner   ServiceInventorySource
+	allowed map[string]struct{}
+}
+
+func (s *scopedServiceInventorySource) Name() string {
+	return s.inner.Name()
+}
+
+func (s *scopedServiceInventorySource) ListServices(ctx context.Context, tr TimeRange) ([]ServiceDescriptor, *types.SourceStatus, error) {
+	services, status, err := s.inner.ListServices(ctx, tr)
+	return filterServiceDescriptors(services, s.allowed), status, err
+}
+
+type scopedUsageMetricsSource struct {
+	inner UsageMetricsSource
+}
+
+func (s *scopedUsageMetricsSource) Name() string {
+	return s.inner.Name()
+}
+
+func (s *scopedUsageMetricsSource) UsageHours(ctx context.Context, tr TimeRange, serviceID string) (float64, float64, *types.SourceStatus, error) {
+	return s.inner.UsageHours(ctx, tr, serviceID)
+}
+
+type scopedRequestLogSource struct {
+	inner   RequestLogSource
+	allowed map[string]struct{}
+}
+
+func (s *scopedRequestLogSource) Name() string {
+	return s.inner.Name()
+}
+
+func (s *scopedRequestLogSource) ListRequests(ctx context.Context, tr TimeRange, serviceID string) ([]RequestRecord, *types.SourceStatus, error) {
+	records, status, err := s.inner.ListRequests(ctx, tr, serviceID)
+	if err != nil {
+		return records, status, err
+	}
+	return filterRequestRecords(records, s.allowed), status, nil
+}
+
+func ScopeSources(src Sources, allowedServiceIDs map[string]struct{}) Sources {
+	if allowedServiceIDs == nil {
+		return src
+	}
+
+	scoped := src
+	if src.ServiceInventory != nil {
+		scoped.ServiceInventory = &scopedServiceInventorySource{
+			inner:   src.ServiceInventory,
+			allowed: cloneAllowedServices(allowedServiceIDs),
+		}
+	}
+	if src.UsageMetrics != nil {
+		// Wrap usage metrics so sumUsage falls back to per-service iteration
+		// instead of issuing a cluster-wide wildcard query.
+		scoped.UsageMetrics = &scopedUsageMetricsSource{inner: src.UsageMetrics}
+	}
+	if src.RequestLogs != nil {
+		scoped.RequestLogs = &scopedRequestLogSource{
+			inner:   src.RequestLogs,
+			allowed: cloneAllowedServices(allowedServiceIDs),
+		}
+	}
+	if src.ExposedRequestLogs != nil {
+		scoped.ExposedRequestLogs = &scopedRequestLogSource{
+			inner:   src.ExposedRequestLogs,
+			allowed: cloneAllowedServices(allowedServiceIDs),
+		}
+	}
+	return scoped
+}
+
+func cloneAllowedServices(allowed map[string]struct{}) map[string]struct{} {
+	if allowed == nil {
+		return nil
+	}
+	cloned := make(map[string]struct{}, len(allowed))
+	for serviceID := range allowed {
+		cloned[serviceID] = struct{}{}
+	}
+	return cloned
+}
+
+func filterServiceDescriptors(services []ServiceDescriptor, allowed map[string]struct{}) []ServiceDescriptor {
+	if allowed == nil {
+		return services
+	}
+	filtered := make([]ServiceDescriptor, 0, len(services))
+	for _, service := range services {
+		if _, ok := allowed[service.ID]; ok {
+			filtered = append(filtered, service)
+		}
+	}
+	return filtered
+}
+
+func filterRequestRecords(records []RequestRecord, allowed map[string]struct{}) []RequestRecord {
+	if allowed == nil {
+		return records
+	}
+	filtered := make([]RequestRecord, 0, len(records))
+	for _, record := range records {
+		if _, ok := allowed[record.ServiceID]; ok {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
+}

--- a/specs/001-metrics-collection/contracts/metrics.yaml
+++ b/specs/001-metrics-collection/contracts/metrics.yaml
@@ -1,11 +1,12 @@
 openapi: 3.0.3
 info:
   title: OSCAR Metrics Reporting
-  version: 1.2.0
+  version: 1.2.1
 paths:
   /system/metrics/{serviceName}:
     get:
       summary: Get a single metric value for a service and time range
+      description: For OIDC Bearer requests, access is limited to services visible to the authenticated user. Basic Auth as the OSCAR admin user remains cluster-wide.
       parameters:
         - name: serviceName
           in: path
@@ -43,11 +44,14 @@ paths:
                   - $ref: "#/components/schemas/ServiceMetrics"
         "400":
           description: Invalid parameters
+        "403":
+          description: The authenticated OIDC user cannot access the requested service
         "500":
           description: Metrics computation failed
   /system/metrics:
     get:
       summary: Get metrics summary for a time range
+      description: For OIDC Bearer requests, totals are scoped to services visible to the authenticated user. Basic Auth as the OSCAR admin user returns cluster-wide totals.
       parameters:
         - name: start
           in: query
@@ -77,6 +81,7 @@ paths:
   /system/metrics/breakdown:
     get:
       summary: Get metrics breakdown by dimension
+      description: For OIDC Bearer requests, breakdown items are scoped to services visible to the authenticated user. Basic Auth as the OSCAR admin user remains cluster-wide.
       parameters:
         - name: start
           in: query

--- a/specs/001-metrics-collection/quickstart.md
+++ b/specs/001-metrics-collection/quickstart.md
@@ -10,6 +10,10 @@ range to support reporting.
 - Access to the OSCAR manager API with appropriate credentials.
 - A time range expressed as ISO 8601 timestamps.
 
+When using `Authorization: Bearer ...`, responses are limited to services the
+OIDC user can access. When using Basic Auth as the OSCAR admin user, the same
+endpoints return cluster-wide metrics for all services.
+
 ## Example: Single service metric value
 
 ```bash
@@ -48,8 +52,9 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 ## Expected Output
 
 - Metric value: per-service value plus completeness status for the requested
-  metric.
+  metric. OIDC requests fail for services the caller cannot access.
 - Summary: totals for services, CPU/GPU hours, request counts, countries, users,
-  plus source completeness status.
+  plus source completeness status, scoped to visible services for OIDC users.
 - Breakdown: per-service, per-user, or per-country executions, unique users,
-  membership classification, and per-country request totals.
+  membership classification, and per-country request totals, scoped to visible
+  services for OIDC users.

--- a/specs/001-metrics-collection/spec.md
+++ b/specs/001-metrics-collection/spec.md
@@ -91,6 +91,8 @@ report marks the source as missing and flags affected metrics.
   historical metric data for at least 6 months).
 - A report spans a period with partial data source coverage (surface completeness
   flags and partial counts).
+- An OIDC user requests metrics for a service that is not visible to that user
+  (deny access and do not expose service metrics).
 
 ## Requirements *(mandatory)*
 
@@ -133,6 +135,14 @@ report marks the source as missing and flags affected metrics.
 - **FR-017**: Breakdown requests with `group_by=service` MUST support an optional
   `include_users=true` flag that returns the list of users per service in JSON
   responses (CSV export excludes the user list).
+- **FR-018**: Metrics endpoints MUST apply the same service visibility rules as
+  `/system/services` for OIDC Bearer requests. OIDC users MUST only receive
+  metrics for services they can access (`public`, owned services, and
+  `restricted` services where the user appears in `allowed_users`).
+- **FR-019**: Metrics endpoints accessed with Basic Auth as the OSCAR admin user
+  MUST continue to return cluster-wide data for all services.
+- **FR-020**: Per-service metrics requests for an inaccessible service MUST be
+  rejected without returning service metrics.
 
 ### Non-Functional Requirements
 
@@ -184,6 +194,9 @@ per-service when used with `/system/metrics/{serviceName}`.
 - **Time range**: Both start and end timestamps are inclusive. If omitted,
   the system defaults to the last 24 hours (end = now, start = end - 24h).
 - **Metrics base path**: All metrics endpoints are served under `/system/metrics`.
+- **Metrics authorization scope**: OIDC Bearer requests are limited to the
+  caller's visible services; Basic Auth as the OSCAR admin user remains
+  cluster-wide.
 - **Breakdown membership**: Include membership only when `group_by=user`.
 - **Breakdown user list**: Include per-service user lists only when
   `group_by=service` and `include_users=true`.
@@ -203,6 +216,8 @@ per-service when used with `/system/metrics/{serviceName}`.
 - Existing service inventory, execution logs, resource usage metrics, and OIDC
   group membership data are available and can be queried for the requested time
   range.
+- Service visibility for metrics follows the same access model already enforced
+  by the service listing and read endpoints.
 - Metric data is retained for at least 6 months to support 3/6 month reporting
   windows.
 - Country attribution can be derived from request metadata when available.


### PR DESCRIPTION
Limit /system/metrics endpoints for OIDC users to the services they can access, while preserving cluster-wide visibility for Basic Auth as oscar.

- scope summary and breakdown metrics to authorized services for Bearer requests
- reject per-service metrics requests for inaccessible services
- keep Basic Auth behavior unchanged for cluster-wide reporting
- add handler tests for OIDC scoping and Basic Auth visibility
- update metrics docs and specs to document the authorization behavior

Fixes https://github.com/grycap/issue-tracker/issues/349

