### PR TITLE
Use RFC3339 UTC timestamps for execution metrics logs

### DIFF
--- a/pkg/handlers/logs.go
+++ b/pkg/handlers/logs.go
@@ -462,8 +462,8 @@ func parseExecutionLogs(raw string) []executionLogEntry {
 		}
 
 		rawTimestamp := strings.TrimSpace(parts[0])
-		if parsedTime, err := time.ParseInLocation("2006/01/02 - 15:04:05", rawTimestamp, time.Local); err == nil {
-			entry.Timestamp = parsedTime.UTC().Format(time.RFC3339)
+		if parsedTime, err := time.Parse(time.RFC3339Nano, rawTimestamp); err == nil {
+			entry.Timestamp = parsedTime.UTC().Format(time.RFC3339Nano)
 		} else {
 			entry.Timestamp = rawTimestamp
 		}

--- a/pkg/handlers/logs_test.go
+++ b/pkg/handlers/logs_test.go
@@ -357,9 +357,9 @@ func TestMakeGetSystemLogsHandlerRejectsOIDC(t *testing.T) {
 
 func TestParseExecutionLogs(t *testing.T) {
 	raw := `
-[GIN-EXECUTIONS-LOGGER] 2025/10/28 - 16:53:34 | 200 |  347.805334ms | 172.25.0.1 | POST    /run/simple-test | oscar
-[GIN-EXECUTIONS-LOGGER] 2025/10/28 - 16:55:12 | 201 |   14.219292ms | 127.0.0.1 | POST    /job/simple-test | minio
-[GIN-EXECUTIONS-LOGGER] 2025/10/28 - 16:55:20 | 200 |   10.000000ms | 127.0.0.1 | GET     /health | oscar
+[GIN-EXECUTIONS-LOGGER] 2025-10-28T16:53:34Z | 200 |  347.805334ms | 172.25.0.1 | POST    /run/simple-test | oscar
+[GIN-EXECUTIONS-LOGGER] 2025-10-28T16:55:12Z | 201 |   14.219292ms | 127.0.0.1 | POST    /job/simple-test | minio
+[GIN-EXECUTIONS-LOGGER] 2025-10-28T16:55:20Z | 200 |   10.000000ms | 127.0.0.1 | GET     /health | oscar
 `
 
 	entries := parseExecutionLogs(raw)
@@ -367,24 +367,23 @@ func TestParseExecutionLogs(t *testing.T) {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
 
-	layout := "2006/01/02 - 15:04:05"
 	first := entries[0]
-	firstExpected, err := time.ParseInLocation(layout, "2025/10/28 - 16:53:34", time.Local)
+	firstExpected, err := time.Parse(time.RFC3339Nano, "2025-10-28T16:53:34Z")
 	if err != nil {
 		t.Fatalf("unable to parse expected timestamp: %v", err)
 	}
-	if first.Timestamp != firstExpected.UTC().Format(time.RFC3339) {
+	if first.Timestamp != firstExpected.UTC().Format(time.RFC3339Nano) {
 		t.Fatalf("unexpected first timestamp: %s", first.Timestamp)
 	}
 	if first.Method != "POST" || first.Path != "/run/simple-test" || first.User != "oscar" {
 		t.Fatalf("unexpected first entry: %+v", first)
 	}
 	second := entries[1]
-	secondExpected, err := time.ParseInLocation(layout, "2025/10/28 - 16:55:12", time.Local)
+	secondExpected, err := time.Parse(time.RFC3339Nano, "2025-10-28T16:55:12Z")
 	if err != nil {
 		t.Fatalf("unable to parse expected timestamp: %v", err)
 	}
-	if second.Timestamp != secondExpected.UTC().Format(time.RFC3339) {
+	if second.Timestamp != secondExpected.UTC().Format(time.RFC3339Nano) {
 		t.Fatalf("unexpected second timestamp: %s", second.Timestamp)
 	}
 	if second.Path != "/job/simple-test" || second.Status != 201 {

--- a/pkg/metrics/aggregators_test.go
+++ b/pkg/metrics/aggregators_test.go
@@ -286,7 +286,7 @@ func TestBuildLokiQuery(t *testing.T) {
 }
 
 func TestParseGinExecutionLogFromGinPrefix(t *testing.T) {
-	line := "[GIN] 2026/01/20 - 10:00:00 | 200 |  12.345ms | 10.0.0.1 | POST    /job/test-service | user@example.com"
+	line := "[GIN] 2026-01-20T10:00:00Z | 200 |  12.345ms | 10.0.0.1 | POST    /job/test-service | user@example.com"
 	record, ok := parseGinExecutionLog(line)
 	if !ok {
 		t.Fatal("expected log line to parse")
@@ -299,6 +299,10 @@ func TestParseGinExecutionLogFromGinPrefix(t *testing.T) {
 	}
 	if record.UserID != "user@example.com" {
 		t.Fatalf("expected user@example.com, got %s", record.UserID)
+	}
+	expectedTime := time.Date(2026, time.January, 20, 10, 0, 0, 0, time.UTC)
+	if !record.Timestamp.Equal(expectedTime) {
+		t.Fatalf("expected timestamp %s, got %s", expectedTime.Format(time.RFC3339Nano), record.Timestamp.Format(time.RFC3339Nano))
 	}
 }
 

--- a/pkg/metrics/sources.go
+++ b/pkg/metrics/sources.go
@@ -632,7 +632,7 @@ func parseGinExecutionLog(line string) (RequestRecord, bool) {
 	}
 
 	timestampRaw := strings.TrimSpace(parts[0])
-	timestamp, err := time.ParseInLocation("2006/01/02 - 15:04:05", timestampRaw, time.UTC)
+	timestamp, err := time.Parse(time.RFC3339Nano, timestampRaw)
 	if err != nil {
 		return RequestRecord{}, false
 	}
@@ -657,7 +657,7 @@ func parseGinExecutionLog(line string) (RequestRecord, bool) {
 		Country:    "",
 		AuthMethod: "",
 		Type:       reqType,
-		Timestamp:  timestamp,
+		Timestamp:  timestamp.UTC(),
 	}, ip != ""
 }
 

--- a/pkg/utils/auth/auth.go
+++ b/pkg/utils/auth/auth.go
@@ -79,7 +79,7 @@ func GetLoggerMiddleware() gin.HandlerFunc {
 		endTime := time.Now()
 
 		// Log custom information after the request is processed
-		logTime := endTime.Format("2006/01/02 - 15:04:05")
+		logTime := endTime.UTC().Format(time.RFC3339Nano)
 		latency := time.Since(startTime)
 		status := c.Writer.Status()
 		clientIP := c.ClientIP()


### PR DESCRIPTION
## Summary

This changes OSCAR execution log timestamps to an explicit UTC RFC3339 format and updates the metrics/log parsers accordingly.

The goal is to remove timezone ambiguity in `/system/metrics`, which could cause recent service activity to appear shifted and fall outside the selected dashboard time range.

## Changes

- emit `GIN-EXECUTIONS-LOGGER` timestamps in `UTC` using `RFC3339Nano`
- parse execution log timestamps in `pkg/metrics/sources.go` using `RFC3339Nano`
- parse execution log timestamps in `pkg/handlers/logs.go` using the same format
- update affected tests to the new timestamp format

## Why

Previously, execution logs were emitted without timezone information and metrics parsing interpreted them incorrectly as UTC. In clusters running in a local timezone, this could shift request timestamps by several hours and make fresh invocations disappear from metrics unless the queried end time was artificially moved forward.

With this change, timestamps are unambiguous end-to-end.

## Validation

- `go test ./pkg/metrics ./pkg/handlers`