### PR TITLE
Add managed volume quotas to system quotas

### DIFF
--- a/deploy/yaml/oscar-rbac.yaml
+++ b/deploy/yaml/oscar-rbac.yaml
@@ -21,6 +21,8 @@ rules:
   - secrets
   - services
   - persistentvolumeclaims
+  - resourcequotas
+  - limitranges
   verbs:
   - get
   - list
@@ -136,6 +138,8 @@ rules:
   - pods/log
   - podtemplates
   - persistentvolumeclaims
+  - resourcequotas
+  - limitranges
   - secrets
   - services
   verbs:

--- a/main.go
+++ b/main.go
@@ -100,6 +100,11 @@ func main() {
 	var qb *types.QuotaBackend
 	if cfg.KueueEnable {
 		qb = types.CreateQuotaBackend(kubeConfig, kubeClientset)
+	} else if cfg.VolumeEnable {
+		qb = &types.QuotaBackend{KubeClientset: kubeClientset}
+	}
+	if qb == nil && (cfg.KueueEnable || cfg.VolumeEnable) {
+		qb = &types.QuotaBackend{KubeClientset: kubeClientset}
 	}
 
 	// Create the router
@@ -128,7 +133,6 @@ func main() {
 	if cfg.VolumeEnable {
 		system.GET("/volumes", handlers.MakeListVolumesHandler(cfg, back))
 		system.POST("/volumes", handlers.MakeCreateVolumeHandler(cfg, back))
-		system.PUT("/volumes/:userId", handlers.MakeUpdateVolumeHandler(cfg, back))
 		system.GET("/volumes/:volumeName", handlers.MakeReadVolumeHandler(cfg, back))
 		system.DELETE("/volumes/:volumeName", handlers.MakeDeleteVolumeHandler(cfg, back))
 	}
@@ -158,7 +162,7 @@ func main() {
 	metricsGroup.GET("/breakdown", handlers.MakeMetricsBreakdownHandler(back, metricsAgg))
 	metricsGroup.GET("/:serviceName", handlers.MakeMetricValueHandler(back, metricsAgg))
 	// Quotas
-	if cfg.KueueEnable {
+	if cfg.KueueEnable || cfg.VolumeEnable {
 		system.GET("/quotas/user", handlers.MakeGetOwnQuotaHandler(*qb, cfg))
 		system.GET("/quotas/user/:userId", handlers.MakeGetUserQuotaHandler(*qb, cfg))
 		system.PUT("/quotas/user/:userId", handlers.MakeUpdateUserQuotaHandler(*qb, cfg))

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -51,6 +51,17 @@ const (
 	servicePortNumber  = 80
 	routeKindIngress   = "ingress"
 	routeKindHTTPRoute = "httproute"
+
+	livenessInitialDelaySeconds  = 60
+	livenessFailureThreshold     = 12
+	livenessPeriodSeconds        = 10
+	livenessTimeoutSeconds       = 10
+	readinessInitialDelaySeconds = 10
+	readinessPeriodSeconds       = 5
+	readinessTimeoutSeconds      = 10
+	startupFailureThreshold      = 18
+	startupPeriodSeconds         = 10
+	startupTimeoutSeconds        = 10
 )
 
 var httpRouteGVR = schema.GroupVersionResource{
@@ -478,16 +489,23 @@ func getPodTemplateSpec(service types.Service, namespace string, cfg *types.Conf
 		}
 
 		podSpec.Containers[i].LivenessProbe = &v1.Probe{
-			InitialDelaySeconds: 30,
-			PeriodSeconds:       10,
+			FailureThreshold:    livenessFailureThreshold,
+			InitialDelaySeconds: livenessInitialDelaySeconds,
+			PeriodSeconds:       livenessPeriodSeconds,
 			ProbeHandler:        probeHandler,
-			TimeoutSeconds:      2,
+			TimeoutSeconds:      livenessTimeoutSeconds,
 		}
 		podSpec.Containers[i].ReadinessProbe = &v1.Probe{
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       5,
+			InitialDelaySeconds: readinessInitialDelaySeconds,
+			PeriodSeconds:       readinessPeriodSeconds,
 			ProbeHandler:        probeHandler,
-			TimeoutSeconds:      2,
+			TimeoutSeconds:      readinessTimeoutSeconds,
+		}
+		podSpec.Containers[i].StartupProbe = &v1.Probe{
+			FailureThreshold: startupFailureThreshold,
+			PeriodSeconds:    startupPeriodSeconds,
+			ProbeHandler:     probeHandler,
+			TimeoutSeconds:   startupTimeoutSeconds,
 		}
 	}
 	var num int32 = 0777

--- a/pkg/backends/resources/expose_test.go
+++ b/pkg/backends/resources/expose_test.go
@@ -66,6 +66,71 @@ func newExposeService(name string, nodePort int32, setAuth bool) types.Service {
 	return svc
 }
 
+func TestGetPodTemplateSpecProbeDefaults(t *testing.T) {
+	svc := newExposeService("svc", 0, false)
+	svc.Expose.HealthPath = "/healthz"
+	svc.Expose.ProbeMode = "direct"
+
+	template := getPodTemplateSpec(svc, "oscar-svc", newTestConfig())
+	container := template.Spec.Containers[0]
+
+	if container.LivenessProbe == nil {
+		t.Fatalf("expected liveness probe")
+	}
+	if container.ReadinessProbe == nil {
+		t.Fatalf("expected readiness probe")
+	}
+	if container.StartupProbe == nil {
+		t.Fatalf("expected startup probe")
+	}
+
+	liveness := container.LivenessProbe
+	if liveness.FailureThreshold != livenessFailureThreshold {
+		t.Fatalf("expected liveness failure threshold %d, got %d",
+			livenessFailureThreshold, liveness.FailureThreshold)
+	}
+	if liveness.InitialDelaySeconds != livenessInitialDelaySeconds {
+		t.Fatalf("expected liveness initial delay %d, got %d",
+			livenessInitialDelaySeconds, liveness.InitialDelaySeconds)
+	}
+	if liveness.PeriodSeconds != livenessPeriodSeconds {
+		t.Fatalf("expected liveness period %d, got %d",
+			livenessPeriodSeconds, liveness.PeriodSeconds)
+	}
+	if liveness.TimeoutSeconds != livenessTimeoutSeconds {
+		t.Fatalf("expected liveness timeout %d, got %d",
+			livenessTimeoutSeconds, liveness.TimeoutSeconds)
+	}
+
+	readiness := container.ReadinessProbe
+	if readiness.InitialDelaySeconds != readinessInitialDelaySeconds {
+		t.Fatalf("expected readiness initial delay %d, got %d",
+			readinessInitialDelaySeconds, readiness.InitialDelaySeconds)
+	}
+	if readiness.PeriodSeconds != readinessPeriodSeconds {
+		t.Fatalf("expected readiness period %d, got %d",
+			readinessPeriodSeconds, readiness.PeriodSeconds)
+	}
+	if readiness.TimeoutSeconds != readinessTimeoutSeconds {
+		t.Fatalf("expected readiness timeout %d, got %d",
+			readinessTimeoutSeconds, readiness.TimeoutSeconds)
+	}
+
+	startup := container.StartupProbe
+	if startup.FailureThreshold != startupFailureThreshold {
+		t.Fatalf("expected startup failure threshold %d, got %d",
+			startupFailureThreshold, startup.FailureThreshold)
+	}
+	if startup.PeriodSeconds != startupPeriodSeconds {
+		t.Fatalf("expected startup period %d, got %d",
+			startupPeriodSeconds, startup.PeriodSeconds)
+	}
+	if startup.TimeoutSeconds != startupTimeoutSeconds {
+		t.Fatalf("expected startup timeout %d, got %d",
+			startupTimeoutSeconds, startup.TimeoutSeconds)
+	}
+}
+
 func useFakeGatewayClient(t *testing.T) {
 	t.Helper()
 

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -42,7 +42,7 @@ var (
 // @Description Retrieve cluster configuration and MinIO credentials for the authenticated user.
 // @Tags config
 // @Produce json
-// @Success 200 {object} handlers.ConfigForUser
+// @Success 200 {object} types.ConfigForUser
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
 // @Security BasicAuth
@@ -118,7 +118,7 @@ func MakeConfigHandler(cfg *types.Config, back kubernetes.Interface) gin.Handler
 // @Description Change the cluster configuration
 // @Tags config
 // @Produce json
-// @Success 200 {object} handlers.ConfigForUser
+// @Success 200 {object} types.ConfigForUser
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
 // @Security BasicAuth

--- a/pkg/handlers/quotas.go
+++ b/pkg/handlers/quotas.go
@@ -38,7 +38,7 @@ var (
 
 // MakeGetOwnQuotaHandler handles GET /system/quotas/user for the bearer user.
 // @Summary Get own quotas
-// @Description Return CPU and memory quotas and current usage for the authenticated user. CPU values are in millicores, memory values in bytes.
+// @Description Return CPU, memory, and volume quotas and current usage for the authenticated user. CPU values are in millicores, memory values in bytes, volume values use Kubernetes quantities.
 // @Tags quotas
 // @Produce json
 // @Success 200 {object} types.QuotaResponse
@@ -54,7 +54,7 @@ func MakeGetOwnQuotaHandler(qb types.QuotaBackend, cfg *types.Config) gin.Handle
 			c.String(http.StatusUnauthorized, fmt.Sprintf("missing user identificator: %v", err))
 			return
 		}
-		if err := ensureKueueQuotasEnabled(cfg); err != nil {
+		if err := ensureQuotasEnabled(cfg); err != nil {
 			writeQuotaError(c, err)
 			return
 		}
@@ -69,11 +69,11 @@ func MakeGetOwnQuotaHandler(qb types.QuotaBackend, cfg *types.Config) gin.Handle
 
 // MakeGetUserQuotaHandler handles GET /system/quotas/user/{userId} for admin (basic auth).
 // @Summary Get user quotas
-// @Description GET returns CPU/memory quotas and usage for the specified user (admin only). CPU values are in millicores, memory values in bytes.
+// @Description GET returns CPU, memory, and volume quotas and usage for the specified user (admin only). CPU values are in millicores, memory values in bytes, volume values use Kubernetes quantities.
 // @Tags quotas
 // @Produce json
 // @Param userId path string true "User ID"
-// @Success 200 {object} quotaResponse
+// @Success 200 {object} types.QuotaResponse
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 403 {string} string "Forbidden"
 // @Failure 503 {string} string "Service Unavailable"
@@ -88,7 +88,7 @@ func MakeGetUserQuotaHandler(qb types.QuotaBackend, cfg *types.Config) gin.Handl
 			c.String(http.StatusForbidden, "forbidden")
 			return
 		}
-		if err := ensureKueueQuotasEnabled(cfg); err != nil {
+		if err := ensureQuotasEnabled(cfg); err != nil {
 			writeQuotaError(c, err)
 			return
 		}
@@ -104,13 +104,13 @@ func MakeGetUserQuotaHandler(qb types.QuotaBackend, cfg *types.Config) gin.Handl
 
 // MakeUpdateUserQuotaHandler handles PUT /system/quotas/user/{userId} for admin (basic auth).
 // @Summary Update user quotas
-// @Description PUT updates CPU/memory nominal quotas for the specified user (admin only). At least one of cpu or memory must be provided. CPU values are in millicores, memory values in bytes.
+// @Description PUT updates CPU, memory, and volume quotas for the specified user (admin only). At least one of cpu, memory, or volumes must be provided. CPU values are in millicores, memory values in bytes, volume values use Kubernetes quantities.
 // @Tags quotas
 // @Accept json
 // @Produce json
 // @Param userId path string true "User ID"
-// @Param quotas body quotaUpdateRequest false "Quota update payload (at least one of cpu or memory)"
-// @Success 200 {object} quotaResponse
+// @Param quotas body types.QuotaUpdateRequest false "Quota update payload (at least one of cpu, memory, or volumes)"
+// @Success 200 {object} types.QuotaResponse
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 403 {string} string "Forbidden"
@@ -132,11 +132,11 @@ func MakeUpdateUserQuotaHandler(qb types.QuotaBackend, cfg *types.Config) gin.Ha
 			c.String(http.StatusBadRequest, fmt.Sprintf("invalid payload: %v", err))
 			return
 		}
-		if req.CPU == "" && req.Memory == "" {
-			c.String(http.StatusBadRequest, "cpu or memory must be provided")
+		if req.CPU == "" && req.Memory == "" && !hasVolumeQuotaUpdate(req.Volumes) {
+			c.String(http.StatusBadRequest, "cpu, memory or volumes must be provided")
 			return
 		}
-		if err := ensureKueueQuotasEnabled(cfg); err != nil {
+		if err := ensureQuotasEnabled(cfg); err != nil {
 			writeQuotaError(c, err)
 			return
 		}
@@ -160,6 +160,13 @@ func ensureKueueQuotasEnabled(cfg *types.Config) error {
 	return nil
 }
 
+func ensureQuotasEnabled(cfg *types.Config) error {
+	if cfg == nil || (!cfg.KueueEnable && !cfg.VolumeEnable) {
+		return fmt.Errorf("%w: /system/quotas requires KUEUE_ENABLE=true or VOLUME_ENABLE=true", errKueueDisabled)
+	}
+	return nil
+}
+
 func writeQuotaError(c *gin.Context, err error) {
 	if errors.Is(err, errKueueDisabled) || errors.Is(err, errKueueUnavailable) {
 		c.String(http.StatusServiceUnavailable, err.Error())
@@ -169,55 +176,101 @@ func writeQuotaError(c *gin.Context, err error) {
 }
 
 func fetchQuota(ctx context.Context, cfg *types.Config, qb types.QuotaBackend, user string) (*types.QuotaResponse, error) {
-
-	cqName := utils.BuildClusterQueueName(user)
-	cq, err := qb.Kueueclient.KueueV1beta2().ClusterQueues().Get(ctx, cqName, metav1.GetOptions{})
-	if err != nil {
-		if isMissingKueueAPI(err) {
-			return nil, fmt.Errorf("%w: install Kueue CRDs before using /system/quotas: %v", errKueueUnavailable, err)
-		}
-		return nil, fmt.Errorf("getting ClusterQueue %s: %w", cqName, err)
-	}
-
 	resp := &types.QuotaResponse{
-		UserID:       user,
-		ClusterQueue: cqName,
-		Resources:    map[string]types.QuotaValues{},
+		UserID: user,
 	}
 
-	var maxCPU int64
-	var maxMem int64
-	if len(cq.Spec.ResourceGroups) > 0 && len(cq.Spec.ResourceGroups[0].Flavors) > 0 {
-		for _, res := range cq.Spec.ResourceGroups[0].Flavors[0].Resources {
-			switch res.Name {
-			case corev1.ResourceCPU:
-				maxCPU = res.NominalQuota.MilliValue()
-			case corev1.ResourceMemory:
-				maxMem = res.NominalQuota.Value()
+	if cfg.KueueEnable {
+		if qb.Kueueclient == nil {
+			return nil, fmt.Errorf("%w: Kueue client is not initialized", errKueueUnavailable)
+		}
+
+		cqName := utils.BuildClusterQueueName(user)
+		cq, err := qb.Kueueclient.KueueV1beta2().ClusterQueues().Get(ctx, cqName, metav1.GetOptions{})
+		if err != nil {
+			if isMissingKueueAPI(err) {
+				return nil, fmt.Errorf("%w: install Kueue CRDs before using /system/quotas: %v", errKueueUnavailable, err)
+			}
+			return nil, fmt.Errorf("getting ClusterQueue %s: %w", cqName, err)
+		}
+
+		resp.ClusterQueue = cqName
+		resp.Resources = map[string]types.QuotaValues{}
+
+		var maxCPU int64
+		var maxMem int64
+		if len(cq.Spec.ResourceGroups) > 0 && len(cq.Spec.ResourceGroups[0].Flavors) > 0 {
+			for _, res := range cq.Spec.ResourceGroups[0].Flavors[0].Resources {
+				switch res.Name {
+				case corev1.ResourceCPU:
+					maxCPU = res.NominalQuota.MilliValue()
+				case corev1.ResourceMemory:
+					maxMem = res.NominalQuota.Value()
+				}
 			}
 		}
-	}
 
-	var usedCPU int64
-	var usedMem int64
-	if len(cq.Status.FlavorsUsage) > 0 {
-		for _, res := range cq.Status.FlavorsUsage[0].Resources {
-			switch res.Name {
-			case corev1.ResourceCPU:
-				usedCPU = res.Total.MilliValue()
-			case corev1.ResourceMemory:
-				usedMem = res.Total.Value()
+		var usedCPU int64
+		var usedMem int64
+		if len(cq.Status.FlavorsUsage) > 0 {
+			for _, res := range cq.Status.FlavorsUsage[0].Resources {
+				switch res.Name {
+				case corev1.ResourceCPU:
+					usedCPU = res.Total.MilliValue()
+				case corev1.ResourceMemory:
+					usedMem = res.Total.Value()
+				}
 			}
 		}
+
+		resp.Resources["cpu"] = types.QuotaValues{Max: maxCPU, Used: usedCPU}
+		resp.Resources["memory"] = types.QuotaValues{Max: maxMem, Used: usedMem}
 	}
 
-	resp.Resources["cpu"] = types.QuotaValues{Max: maxCPU, Used: usedCPU}
-	resp.Resources["memory"] = types.QuotaValues{Max: maxMem, Used: usedMem}
+	if cfg.VolumeEnable {
+		if qb.KubeClientset == nil {
+			return nil, fmt.Errorf("Kubernetes client is not initialized")
+		}
+		volumes, err := utils.GetVolumeQuotaInfo(auth.FormatUID(user), utils.BuildUserNamespace(cfg, user), cfg, qb.KubeClientset)
+		if err != nil {
+			return nil, fmt.Errorf("getting volume quotas for user %s: %w", user, err)
+		}
+		resp.Volumes = volumes
+	}
 
 	return resp, nil
 }
 
 func updateQuota(ctx context.Context, cfg *types.Config, qb types.QuotaBackend, user string, req types.QuotaUpdateRequest) error {
+	if req.CPU != "" || req.Memory != "" {
+		if err := ensureKueueQuotasEnabled(cfg); err != nil {
+			return err
+		}
+		if err := updateKueueQuota(ctx, qb, user, req); err != nil {
+			return err
+		}
+	}
+
+	if hasVolumeQuotaUpdate(req.Volumes) {
+		if !cfg.VolumeEnable {
+			return fmt.Errorf("volume quotas require VOLUME_ENABLE=true")
+		}
+		if qb.KubeClientset == nil {
+			return fmt.Errorf("Kubernetes client is not initialized")
+		}
+		if err := updateVolumeQuota(user, req.Volumes, cfg, qb); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateKueueQuota(ctx context.Context, qb types.QuotaBackend, user string, req types.QuotaUpdateRequest) error {
+	if qb.Kueueclient == nil {
+		return fmt.Errorf("%w: Kueue client is not initialized", errKueueUnavailable)
+	}
+
 	cqName := utils.BuildClusterQueueName(user)
 	cq, err := qb.Kueueclient.KueueV1beta2().ClusterQueues().Get(ctx, cqName, metav1.GetOptions{})
 	if err != nil {
@@ -259,6 +312,73 @@ func updateQuota(ctx context.Context, cfg *types.Config, qb types.QuotaBackend, 
 		return fmt.Errorf("%w: install Kueue CRDs before using /system/quotas: %v", errKueueUnavailable, err)
 	}
 	return err
+}
+
+func updateVolumeQuota(user string, update *types.VolumeQuotaUpdate, cfg *types.Config, qb types.QuotaBackend) error {
+	quotaName := auth.FormatUID(user)
+	namespace := utils.BuildUserNamespace(cfg, user)
+	current, err := utils.GetVolumeLimitInfo(quotaName, namespace, cfg, qb.KubeClientset)
+	if err != nil {
+		utils.EnsureVolumeLimits(quotaName, namespace, qb.KubeClientset, cfg)
+		current, err = utils.GetVolumeLimitInfo(quotaName, namespace, cfg, qb.KubeClientset)
+		if err != nil {
+			return fmt.Errorf("getting current volume quota: %w", err)
+		}
+	}
+
+	var nonManagedVolumes int
+	var nonManagedStorage resource.Quantity
+	if update.Disk != "" || update.Volumes != "" {
+		nonManagedVolumes, nonManagedStorage, err = utils.GetNonManagedVolumeUsage(namespace, qb.KubeClientset)
+		if err != nil {
+			return fmt.Errorf("getting non-managed volume usage: %w", err)
+		}
+	}
+
+	merged := *current
+	if update.Disk != "" {
+		visibleDisk, err := resource.ParseQuantity(update.Disk)
+		if err != nil {
+			return fmt.Errorf("invalid volumes.disk quantity: %w", err)
+		}
+		visibleDisk.Add(nonManagedStorage)
+		merged.DiskAvailable = visibleDisk.String()
+	}
+	if update.Volumes != "" {
+		visibleVolumes, err := resource.ParseQuantity(update.Volumes)
+		if err != nil {
+			return fmt.Errorf("invalid volumes.volumes quantity: %w", err)
+		}
+		merged.MaxVolumes = fmt.Sprintf("%d", visibleVolumes.Value()+int64(nonManagedVolumes))
+	}
+	if update.MaxDiskperVolume != "" {
+		merged.MaxDiskperVolume = update.MaxDiskperVolume
+	}
+	if update.MinDiskperVolume != "" {
+		merged.MinDiskperVolume = update.MinDiskperVolume
+	}
+
+	if _, err := resource.ParseQuantity(merged.DiskAvailable); err != nil {
+		return fmt.Errorf("invalid volumes.disk quantity: %w", err)
+	}
+	if _, err := resource.ParseQuantity(merged.MaxVolumes); err != nil {
+		return fmt.Errorf("invalid volumes.volumes quantity: %w", err)
+	}
+	if _, err := resource.ParseQuantity(merged.MaxDiskperVolume); err != nil {
+		return fmt.Errorf("invalid volumes.max_disk_per_volume quantity: %w", err)
+	}
+	if _, err := resource.ParseQuantity(merged.MinDiskperVolume); err != nil {
+		return fmt.Errorf("invalid volumes.min_disk_per_volume quantity: %w", err)
+	}
+
+	return utils.UpdateVolumeLimits(merged, quotaName, namespace, qb.KubeClientset, cfg)
+}
+
+func hasVolumeQuotaUpdate(update *types.VolumeQuotaUpdate) bool {
+	return update != nil && (update.Disk != "" ||
+		update.Volumes != "" ||
+		update.MaxDiskperVolume != "" ||
+		update.MinDiskperVolume != "")
 }
 
 func isMissingKueueAPI(err error) bool {

--- a/pkg/handlers/quotas_test.go
+++ b/pkg/handlers/quotas_test.go
@@ -23,7 +23,11 @@ import (
 
 	"github.com/grycap/oscar/v3/pkg/types"
 	"github.com/grycap/oscar/v3/pkg/utils"
+	"github.com/grycap/oscar/v3/pkg/utils/auth"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func newTestConfig() *types.Config {
@@ -150,6 +154,13 @@ func TestQuotaResponseStructures(t *testing.T) {
 				},
 				isValid: false,
 			},
+			{
+				name: "only volumes",
+				req: types.QuotaUpdateRequest{
+					Volumes: &types.VolumeQuotaUpdate{MaxDiskperVolume: "5Gi"},
+				},
+				isValid: true,
+			},
 		}
 
 		for _, tt := range tests {
@@ -165,8 +176,8 @@ func TestQuotaResponseStructures(t *testing.T) {
 					t.Fatalf("Failed to unmarshal types.QuotaUpdateRequest: %v", err)
 				}
 
-				// Test validation logic (CPU or memory must be provided)
-				hasValidField := unmarshaled.CPU != "" || unmarshaled.Memory != ""
+				// Test validation logic (CPU, memory or volume quotas must be provided)
+				hasValidField := unmarshaled.CPU != "" || unmarshaled.Memory != "" || hasVolumeQuotaUpdate(unmarshaled.Volumes)
 				if hasValidField != tt.isValid {
 					t.Errorf("Expected valid=%t, got valid=%t", tt.isValid, hasValidField)
 				}
@@ -177,6 +188,242 @@ func TestQuotaResponseStructures(t *testing.T) {
 
 func TestFetchQuotaSkipped(t *testing.T) {
 	t.Skip("fetchQuota requires a valid Kueue client to be initialized")
+}
+
+func TestFetchQuotaIncludesVolumeQuotas(t *testing.T) {
+	user := "user@example.org"
+	cfg := &types.Config{
+		ServicesNamespace: "oscar-svc",
+		VolumeEnable:      true,
+		VolumeAvailable:   "7Gi",
+		VolumeMax:         "5",
+		VolumeMaxDisk:     "5Gi",
+		VolumeMinDisk:     "200Mi",
+	}
+	namespace := utils.BuildUserNamespace(cfg, user)
+	quotaName := auth.FormatUID(user)
+	client := fake.NewSimpleClientset(
+		&corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: namespace},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceRequestsStorage:        resource.MustParse("7Gi"),
+					corev1.ResourcePersistentVolumeClaims: resource.MustParse("5"),
+				},
+			},
+			Status: corev1.ResourceQuotaStatus{
+				Used: corev1.ResourceList{
+					corev1.ResourceRequestsStorage:        resource.MustParse("2Gi"),
+					corev1.ResourcePersistentVolumeClaims: resource.MustParse("1"),
+				},
+			},
+		},
+		&corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: namespace},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{
+					{
+						Type: corev1.LimitTypePersistentVolumeClaim,
+						Max:  corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+						Min:  corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("200Mi")},
+					},
+				},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oscar-pvc",
+				Namespace: namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+				},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "legacy-workspace",
+				Namespace: namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managed-volume",
+				Namespace: namespace,
+				Labels: map[string]string{
+					types.ManagedVolumeLabel: "true",
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		},
+	)
+
+	resp, err := fetchQuota(t.Context(), cfg, types.QuotaBackend{KubeClientset: client}, user)
+	if err != nil {
+		t.Fatalf("unexpected fetchQuota error: %v", err)
+	}
+	if resp.Volumes == nil {
+		t.Fatalf("expected volume quotas in response")
+	}
+	if resp.Volumes.Disk.Max != "4Gi" || resp.Volumes.Disk.Used != "1Gi" {
+		t.Fatalf("unexpected disk quota values: %+v", resp.Volumes.Disk)
+	}
+	if resp.Volumes.Volumes.Max != "3" || resp.Volumes.Volumes.Used != "1" {
+		t.Fatalf("unexpected pvc quota values: %+v", resp.Volumes.Volumes)
+	}
+	if resp.Volumes.MaxDiskperVolume != "5Gi" || resp.Volumes.MinDiskperVolume != "200Mi" {
+		t.Fatalf("unexpected per-volume quota values: %+v", resp.Volumes)
+	}
+}
+
+func TestUpdateVolumeQuotaMergesPartialUpdate(t *testing.T) {
+	user := "user@example.org"
+	cfg := &types.Config{
+		ServicesNamespace: "oscar-svc",
+		VolumeEnable:      true,
+		VolumeAvailable:   "7Gi",
+		VolumeMax:         "5",
+		VolumeMaxDisk:     "5Gi",
+		VolumeMinDisk:     "200Mi",
+	}
+	namespace := utils.BuildUserNamespace(cfg, user)
+	quotaName := auth.FormatUID(user)
+	client := fake.NewSimpleClientset(
+		&corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: namespace},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceRequestsStorage:        resource.MustParse("7Gi"),
+					corev1.ResourcePersistentVolumeClaims: resource.MustParse("5"),
+				},
+			},
+		},
+		&corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: namespace},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{
+					{
+						Type: corev1.LimitTypePersistentVolumeClaim,
+						Max:  corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+						Min:  corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("200Mi")},
+					},
+				},
+			},
+		},
+	)
+
+	err := updateVolumeQuota(user, &types.VolumeQuotaUpdate{MaxDiskperVolume: "10Gi"}, cfg, types.QuotaBackend{KubeClientset: client})
+	if err != nil {
+		t.Fatalf("unexpected updateVolumeQuota error: %v", err)
+	}
+
+	quota, err := client.CoreV1().ResourceQuotas(namespace).Get(t.Context(), quotaName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected resource quota get error: %v", err)
+	}
+	totalStorage := quota.Spec.Hard[corev1.ResourceRequestsStorage]
+	if totalStorage != resource.MustParse("7Gi") {
+		t.Fatalf("expected total storage quota to be preserved, got %s", totalStorage.String())
+	}
+	limit, err := client.CoreV1().LimitRanges(namespace).Get(t.Context(), quotaName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected limit range get error: %v", err)
+	}
+	maxStorage := limit.Spec.Limits[0].Max[corev1.ResourceStorage]
+	if maxStorage != resource.MustParse("10Gi") {
+		t.Fatalf("expected per-volume max to be updated, got %s", maxStorage.String())
+	}
+	minStorage := limit.Spec.Limits[0].Min[corev1.ResourceStorage]
+	if minStorage != resource.MustParse("200Mi") {
+		t.Fatalf("expected per-volume min to be preserved, got %s", minStorage.String())
+	}
+}
+
+func TestUpdateVolumeQuotaStoresUserVisibleDiskQuota(t *testing.T) {
+	user := "user@example.org"
+	cfg := &types.Config{
+		ServicesNamespace: "oscar-svc",
+		VolumeEnable:      true,
+		VolumeAvailable:   "7Gi",
+		VolumeMax:         "5",
+		VolumeMaxDisk:     "5Gi",
+		VolumeMinDisk:     "200Mi",
+	}
+	namespace := utils.BuildUserNamespace(cfg, user)
+	quotaName := auth.FormatUID(user)
+	client := fake.NewSimpleClientset(
+		&corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: namespace},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceRequestsStorage:        resource.MustParse("7Gi"),
+					corev1.ResourcePersistentVolumeClaims: resource.MustParse("5"),
+				},
+			},
+		},
+		&corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Name: quotaName, Namespace: namespace},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{
+					{
+						Type: corev1.LimitTypePersistentVolumeClaim,
+						Max:  corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+						Min:  corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("200Mi")},
+					},
+				},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oscar-pvc",
+				Namespace: namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+				},
+			},
+		},
+	)
+
+	err := updateVolumeQuota(user, &types.VolumeQuotaUpdate{Disk: "10Gi", Volumes: "3"}, cfg, types.QuotaBackend{KubeClientset: client})
+	if err != nil {
+		t.Fatalf("unexpected updateVolumeQuota error: %v", err)
+	}
+
+	quota, err := client.CoreV1().ResourceQuotas(namespace).Get(t.Context(), quotaName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected resource quota get error: %v", err)
+	}
+	rawStorage := quota.Spec.Hard[corev1.ResourceRequestsStorage]
+	if rawStorage != resource.MustParse("12Gi") {
+		t.Fatalf("expected raw storage quota to include non-managed PVC usage, got %s", rawStorage.String())
+	}
+	rawVolumes := quota.Spec.Hard[corev1.ResourcePersistentVolumeClaims]
+	if rawVolumes.Value() != 4 {
+		t.Fatalf("expected raw volume quota to include non-managed PVC count, got %s", rawVolumes.String())
+	}
+
+	resp, err := fetchQuota(t.Context(), cfg, types.QuotaBackend{KubeClientset: client}, user)
+	if err != nil {
+		t.Fatalf("unexpected fetchQuota error: %v", err)
+	}
+	if resp.Volumes.Disk.Max != "10Gi" {
+		t.Fatalf("expected visible disk quota 10Gi, got %s", resp.Volumes.Disk.Max)
+	}
+	if resp.Volumes.Volumes.Max != "3" {
+		t.Fatalf("expected visible volume quota 3, got %s", resp.Volumes.Volumes.Max)
+	}
 }
 
 func TestEnsureKueueQuotasEnabled(t *testing.T) {
@@ -320,6 +567,12 @@ func TestQuotaJSONTags(t *testing.T) {
 		req := types.QuotaUpdateRequest{
 			CPU:    "1000m",
 			Memory: "2Gi",
+			Volumes: &types.VolumeQuotaUpdate{
+				Disk:             "7Gi",
+				Volumes:          "5",
+				MaxDiskperVolume: "5Gi",
+				MinDiskperVolume: "200Mi",
+			},
 		}
 
 		data, err := json.Marshal(req)
@@ -340,6 +593,15 @@ func TestQuotaJSONTags(t *testing.T) {
 
 		if _, exists := raw["memory"]; !exists {
 			t.Error("Expected 'memory' field in JSON")
+		}
+		volumes, ok := raw["volumes"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected 'volumes' field in JSON")
+		}
+		for _, field := range []string{"disk", "volumes", "max_disk_per_volume", "min_disk_per_volume"} {
+			if _, exists := volumes[field]; !exists {
+				t.Errorf("Expected volumes.%s field in JSON", field)
+			}
 		}
 	})
 }

--- a/pkg/handlers/volumes.go
+++ b/pkg/handlers/volumes.go
@@ -36,7 +36,7 @@ import (
 // @Description List managed volumes in the caller namespace.
 // @Tags volumes
 // @Produce json
-// @Success 200 {object} types.VolumeInfo
+// @Success 200 {array} types.ManagedVolume
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
 // @Security BasicAuth
@@ -44,7 +44,7 @@ import (
 // @Router /system/volumes [get]
 func MakeListVolumesHandler(cfg *types.Config, back types.ServerlessBackend) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		namespace, uid, err := resolveVolumeCaller(c, cfg, back)
+		namespace, _, err := resolveVolumeCaller(c, cfg, back)
 		if err != nil {
 			c.String(http.StatusInternalServerError, err.Error())
 			return
@@ -56,18 +56,7 @@ func MakeListVolumesHandler(cfg *types.Config, back types.ServerlessBackend) gin
 			return
 		}
 
-		VolumeLimits, err := utils.GetVolumeLimitInfo(auth.FormatUID(uid), utils.BuildUserNamespace(cfg, uid), cfg, back.GetKubeClientset())
-		if err != nil {
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		volumeInfo := types.VolumeInfo{
-			VolumeLimits:  *VolumeLimits,
-			ManagedVolume: volumes,
-		}
-
-		c.JSON(http.StatusOK, volumeInfo)
+		c.JSON(http.StatusOK, volumes)
 	}
 }
 
@@ -103,6 +92,12 @@ func MakeCreateVolumeHandler(cfg *types.Config, back types.ServerlessBackend) gi
 			c.String(http.StatusInternalServerError, err.Error())
 			return
 		}
+		if owner != types.DefaultOwner {
+			if err := utils.ValidateManagedVolumeQuota(auth.FormatUID(owner), namespace, req.Size, cfg, back.GetKubeClientset()); err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
+		}
 
 		err = resources.CreateManagedVolume(
 			c.Request.Context(),
@@ -132,43 +127,6 @@ func MakeCreateVolumeHandler(cfg *types.Config, back types.ServerlessBackend) gi
 			return
 		}
 		c.JSON(http.StatusCreated, volume)
-	}
-}
-
-// MakeUpdateVolumeHandler godoc
-// @Summary Update volume
-// @Description Update a managed volume in the caller namespace.
-// @Tags volumes
-// @Accept json
-// @Produce json
-// @Param volume body types.ManagedVolumeCreateRequest true "Volume definition"
-// @Success 204 {string} string "No Content"
-// @Failure 400 {string} string "Bad Request"
-// @Failure 401 {string} string "Unauthorized"
-// @Failure 409 {string} string "Conflict"
-// @Failure 500 {string} string "Internal Server Error"
-// @Security BasicAuth
-// @Router /system/volumes/{userId} [post]
-func MakeUpdateVolumeHandler(cfg *types.Config, back types.ServerlessBackend) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		user := c.Param("userId")
-		authUser := c.GetString(gin.AuthUserKey)
-		if authUser != cfg.Username {
-			c.String(http.StatusForbidden, "forbidden")
-			return
-		}
-
-		var vl types.VolumeLimits
-		if err := c.ShouldBindJSON(&vl); err != nil {
-			c.String(http.StatusBadRequest, fmt.Sprintf("The volume specification is not valid: %v", err))
-			return
-		}
-
-		err := utils.UpdateVolumeLimits(vl, auth.FormatUID(user), utils.BuildUserNamespace(cfg, user), back.GetKubeClientset(), cfg)
-		if err != nil {
-			c.String(http.StatusInternalServerError, fmt.Sprintf("Error at updating volume: %v", err))
-		}
-		c.Status(http.StatusNoContent)
 	}
 }
 

--- a/pkg/handlers/volumes_test.go
+++ b/pkg/handlers/volumes_test.go
@@ -70,6 +70,32 @@ func TestVolumeHandlersCRUD(t *testing.T) {
 	}
 }
 
+func TestCreateVolumeHandlerRejectsQuotaExceeded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	back := backends.MakeFakeBackend()
+	cfg := &types.Config{ServicesNamespace: "oscar-svc"}
+	createBaseRuntimePVC(t, back, cfg)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("uidOrigin", "user@example.org")
+		c.Next()
+	})
+	r.POST("/system/volumes", MakeCreateVolumeHandler(cfg, back))
+
+	req := httptest.NewRequest(http.MethodPost, "/system/volumes", strings.NewReader(`{"name":"too-large","size":"2Gi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer token")
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected create volume status 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "not enough volume disk quota") {
+		t.Fatalf("expected volume quota error, got %s", resp.Body.String())
+	}
+}
+
 func TestDeleteVolumeHandlerRejectsAttachedVolume(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	back := backends.MakeFakeBackend()

--- a/pkg/types/quotas.go
+++ b/pkg/types/quotas.go
@@ -30,8 +30,9 @@ type QuotaBackend struct {
 
 type QuotaResponse struct {
 	UserID       string                 `json:"user_id"`
-	ClusterQueue string                 `json:"cluster_queue"`
-	Resources    map[string]QuotaValues `json:"resources"`
+	ClusterQueue string                 `json:"cluster_queue,omitempty"`
+	Resources    map[string]QuotaValues `json:"resources,omitempty"`
+	Volumes      *VolumeQuotaResponse   `json:"volumes,omitempty"`
 }
 
 type QuotaValues struct {
@@ -39,9 +40,33 @@ type QuotaValues struct {
 	Used int64 `json:"used"`
 }
 
+type VolumeQuotaResponse struct {
+	// Disk contains the user-visible storage quota for OSCAR-managed volumes.
+	Disk VolumeQuotaValues `json:"disk"`
+	// Volumes contains the user-visible count quota for OSCAR-managed volumes.
+	Volumes          VolumeQuotaValues `json:"volumes"`
+	MaxDiskperVolume string            `json:"max_disk_per_volume"`
+	MinDiskperVolume string            `json:"min_disk_per_volume"`
+}
+
+type VolumeQuotaValues struct {
+	Max  string `json:"max"`
+	Used string `json:"used"`
+}
+
 type QuotaUpdateRequest struct {
-	CPU    string `json:"cpu"`
-	Memory string `json:"memory"`
+	CPU     string             `json:"cpu"`
+	Memory  string             `json:"memory"`
+	Volumes *VolumeQuotaUpdate `json:"volumes,omitempty"`
+}
+
+type VolumeQuotaUpdate struct {
+	// Disk sets the user-visible storage quota for OSCAR-managed volumes.
+	Disk string `json:"disk,omitempty"`
+	// Volumes sets the user-visible count quota for OSCAR-managed volumes.
+	Volumes          string `json:"volumes,omitempty"`
+	MaxDiskperVolume string `json:"max_disk_per_volume,omitempty"`
+	MinDiskperVolume string `json:"min_disk_per_volume,omitempty"`
 }
 
 func CreateQuotaBackend(kubeConfig *rest.Config, kubeClientset *kubernetes.Clientset) *QuotaBackend {

--- a/pkg/types/volume.go
+++ b/pkg/types/volume.go
@@ -31,11 +31,6 @@ const (
 	VolumePhaseDeleted  = "deleted"
 )
 
-type VolumeInfo struct {
-	VolumeLimits  VolumeLimits    `json:"volume_limits"`
-	ManagedVolume []ManagedVolume `json:"managed_volume"`
-}
-
 type VolumeLimits struct {
 	DiskAvailable    string `json:"disk_available"`
 	MaxVolumes       string `json:"max_volumes"`

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -207,7 +207,7 @@ func ensureControllerRole(ctx context.Context, kubeClientset kubernetes.Interfac
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods", "pods/log", "podtemplates", "configmaps", "secrets", "services", "persistentvolumeclaims"},
+				Resources: []string{"pods", "pods/log", "podtemplates", "configmaps", "secrets", "services", "persistentvolumeclaims", "resourcequotas", "limitranges"},
 				Verbs:     []string{"get", "list", "watch", "create", "delete", "deletecollection", "update"},
 			},
 			{

--- a/pkg/utils/namespaces_test.go
+++ b/pkg/utils/namespaces_test.go
@@ -522,7 +522,7 @@ func TestNamespaceConstants(t *testing.T) {
 	}
 }
 
-func TestEnsureControllerRoleIncludesPodDeleteCollectionOnCreate(t *testing.T) {
+func TestEnsureControllerRoleIncludesVolumeQuotaPermissionsOnCreate(t *testing.T) {
 	ctx := context.Background()
 	namespace := "test-ns"
 
@@ -539,18 +539,38 @@ func TestEnsureControllerRoleIncludesPodDeleteCollectionOnCreate(t *testing.T) {
 		t.Fatalf("Unable to retrieve controller role: %v", err)
 	}
 
-	found := false
+	foundPodsRule := false
+	foundResourceQuotas := false
+	foundLimitRanges := false
 	for _, rule := range role.Rules {
 		if containsString(rule.APIGroups, "") && containsString(rule.Resources, "pods") {
-			found = true
+			foundPodsRule = true
 			if !containsString(rule.Verbs, "deletecollection") {
 				t.Fatalf("Expected pods rule to include deletecollection verb. Verbs: %v", rule.Verbs)
 			}
 		}
+		if containsString(rule.APIGroups, "") && containsString(rule.Resources, "resourcequotas") {
+			foundResourceQuotas = true
+			if !containsString(rule.Verbs, "get") || !containsString(rule.Verbs, "create") || !containsString(rule.Verbs, "update") {
+				t.Fatalf("Expected resourcequotas rule to include get/create/update verbs. Verbs: %v", rule.Verbs)
+			}
+		}
+		if containsString(rule.APIGroups, "") && containsString(rule.Resources, "limitranges") {
+			foundLimitRanges = true
+			if !containsString(rule.Verbs, "get") || !containsString(rule.Verbs, "create") || !containsString(rule.Verbs, "update") {
+				t.Fatalf("Expected limitranges rule to include get/create/update verbs. Verbs: %v", rule.Verbs)
+			}
+		}
 	}
 
-	if !found {
+	if !foundPodsRule {
 		t.Fatal("Expected a core API rule with pods resource")
+	}
+	if !foundResourceQuotas {
+		t.Fatal("Expected a core API rule with resourcequotas resource")
+	}
+	if !foundLimitRanges {
+		t.Fatal("Expected a core API rule with limitranges resource")
 	}
 }
 

--- a/pkg/utils/volume_limit.go
+++ b/pkg/utils/volume_limit.go
@@ -96,6 +96,143 @@ func GetVolumeLimitInfo(uid string, namespace string, cfg *types.Config, kubeCli
 	return &VolumeLimits, nil
 }
 
+func GetVolumeQuotaInfo(uid string, namespace string, cfg *types.Config, kubeClientset kubernetes.Interface) (*types.VolumeQuotaResponse, error) {
+	EnsureVolumeLimits(uid, namespace, kubeClientset, cfg)
+
+	resources, err := getResouceQuotas(uid, namespace, kubeClientset)
+	if err != nil {
+		return nil, err
+	}
+	limits, err := getLimits(uid, namespace, kubeClientset)
+	if err != nil {
+		return nil, err
+	}
+	if len(limits.Spec.Limits) == 0 {
+		return nil, fmt.Errorf("LimitRange %s/%s has no limits", namespace, uid)
+	}
+	managedUsage, nonManagedUsage, err := getVolumeUsage(namespace, kubeClientset)
+	if err != nil {
+		return nil, err
+	}
+	effectiveDiskMax := getEffectiveStorageQuota(resources.Spec.Hard, nonManagedUsage.Storage)
+	effectiveVolumeMax := getEffectivePVCQuota(resources.Spec.Hard, nonManagedUsage.Count)
+
+	volumeQuota := types.VolumeQuotaResponse{
+		Disk: types.VolumeQuotaValues{
+			Max:  effectiveDiskMax.String(),
+			Used: managedUsage.Storage.String(),
+		},
+		Volumes: types.VolumeQuotaValues{
+			Max:  fmt.Sprintf("%d", effectiveVolumeMax),
+			Used: fmt.Sprintf("%d", managedUsage.Count),
+		},
+		MaxDiskperVolume: getResourceQuantity(limits.Spec.Limits[0].Max, v1.ResourceStorage),
+		MinDiskperVolume: getResourceQuantity(limits.Spec.Limits[0].Min, v1.ResourceStorage),
+	}
+	return &volumeQuota, nil
+}
+
+func ValidateManagedVolumeQuota(uid string, namespace string, size string, cfg *types.Config, kubeClientset kubernetes.Interface) error {
+	quota, err := GetVolumeQuotaInfo(uid, namespace, cfg, kubeClientset)
+	if err != nil {
+		return err
+	}
+	requested, err := resource.ParseQuantity(size)
+	if err != nil {
+		return fmt.Errorf("invalid volume size: %w", err)
+	}
+	maxDisk, err := resource.ParseQuantity(quota.Disk.Max)
+	if err != nil {
+		return fmt.Errorf("invalid volume disk quota: %w", err)
+	}
+	usedDisk, err := resource.ParseQuantity(quota.Disk.Used)
+	if err != nil {
+		return fmt.Errorf("invalid used volume disk quota: %w", err)
+	}
+	availableDisk := maxDisk.DeepCopy()
+	availableDisk.Sub(usedDisk)
+	if availableDisk.Sign() < 0 {
+		availableDisk = resource.Quantity{}
+	}
+	if requested.Cmp(availableDisk) > 0 {
+		return fmt.Errorf("not enough volume disk quota: requested %s, available %s", requested.String(), availableDisk.String())
+	}
+	maxVolumes, err := resource.ParseQuantity(quota.Volumes.Max)
+	if err != nil {
+		return fmt.Errorf("invalid volume count quota: %w", err)
+	}
+	usedVolumes, err := resource.ParseQuantity(quota.Volumes.Used)
+	if err != nil {
+		return fmt.Errorf("invalid used volume count quota: %w", err)
+	}
+	availableVolumes := maxVolumes.Value() - usedVolumes.Value()
+	if availableVolumes < 0 {
+		availableVolumes = 0
+	}
+	if availableVolumes < 1 {
+		return fmt.Errorf("not enough volume count quota: requested 1, available %d", availableVolumes)
+	}
+	return nil
+}
+
+func GetNonManagedVolumeUsage(namespace string, kubeClientset kubernetes.Interface) (int, resource.Quantity, error) {
+	_, nonManagedUsage, err := getVolumeUsage(namespace, kubeClientset)
+	if err != nil {
+		return 0, resource.Quantity{}, err
+	}
+	return nonManagedUsage.Count, nonManagedUsage.Storage, nil
+}
+
+type volumeUsage struct {
+	Count   int
+	Storage resource.Quantity
+}
+
+func getVolumeUsage(namespace string, kubeClientset kubernetes.Interface) (volumeUsage, volumeUsage, error) {
+	list, err := kubeClientset.CoreV1().PersistentVolumeClaims(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return volumeUsage{}, volumeUsage{}, err
+	}
+
+	managed := volumeUsage{}
+	nonManaged := volumeUsage{}
+	for i := range list.Items {
+		usage := &nonManaged
+		if list.Items[i].Labels[types.ManagedVolumeLabel] == "true" {
+			usage = &managed
+		}
+		usage.Count++
+		if qty, ok := list.Items[i].Spec.Resources.Requests[v1.ResourceStorage]; ok {
+			usage.Storage.Add(qty)
+		}
+	}
+	return managed, nonManaged, nil
+}
+
+func getEffectiveStorageQuota(list v1.ResourceList, overhead resource.Quantity) resource.Quantity {
+	max := resource.Quantity{}
+	if qty, ok := list[v1.ResourceRequestsStorage]; ok {
+		max = qty.DeepCopy()
+	}
+	max.Sub(overhead)
+	if max.Sign() < 0 {
+		return resource.Quantity{}
+	}
+	return max
+}
+
+func getEffectivePVCQuota(list v1.ResourceList, overhead int) int64 {
+	var max int64
+	if qty, ok := list[v1.ResourcePersistentVolumeClaims]; ok {
+		max = qty.Value()
+	}
+	effective := max - int64(overhead)
+	if effective < 0 {
+		return 0
+	}
+	return effective
+}
+
 // Create resources
 func createResources(name string, namespace string, kubeClientset kubernetes.Interface, vl *types.VolumeLimits) error {
 	resource := getResourceDef(name, namespace, *vl)


### PR DESCRIPTION
## Summary

Adds managed persistent volume quota support to `/system/quotas` and centralizes quota updates there instead of `/system/volumes`.

## Changes

- Exposes volume quota data in `/system/quotas` responses.
- Allows `PUT /system/quotas/user/{userId}` to update CPU, memory, and volume quotas.
- Makes volume quota values user-visible: non-managed PVC usage such as `oscar-pvc` is accounted for internally so a configured `volumes.disk` value is read back consistently.
- Lists only OSCAR-managed volumes from `/system/volumes` and removes the old volume quota update handler from that endpoint.
- Adds RBAC permissions for `resourcequotas` and `limitranges` in user namespaces.
- Validates managed volume creation against effective quota before Kubernetes returns a raw `ResourceQuota` error.
- Fixes Swagger annotations so the OpenAPI docs regenerate with the new quota types.

## Validation

- `swag init -g main.go -o pkg/apidocs`
- `go test ./pkg/handlers ./pkg/utils ./pkg/types`
- `go test ./pkg/backends ./pkg/backends/resources ./pkg/handlers ./pkg/handlers/buckets ./pkg/imagepuller ./pkg/metrics ./pkg/resourcemanager ./pkg/testsupport ./pkg/types ./pkg/utils ./pkg/utils/auth ./pkg/version`
