### PR TITLE
shorten the namespace to 18

### DIFF
--- a/pkg/backends/k8s_test.go
+++ b/pkg/backends/k8s_test.go
@@ -847,7 +847,7 @@ func TestKubeGetKubeClientset(t *testing.T) {
 func TestGetExposedServiceDeployment(t *testing.T) {
 	client := fake.NewSimpleClientset(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "ns",
 		},
 	})
@@ -856,8 +856,8 @@ func TestGetExposedServiceDeployment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get exposed deployment: %v", err)
 	}
-	if deployment.Name != "svc-dlp" {
-		t.Fatalf("expected deployment name svc-dlp, got %s", deployment.Name)
+	if deployment.Name != "svc-dpl" {
+		t.Fatalf("expected deployment name svc-dpl, got %s", deployment.Name)
 	}
 }
 

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -1340,7 +1340,7 @@ func getProbePath(service types.Service) string {
 }
 
 func GetDeploymentName(nameContainer string) string {
-	return nameContainer + "-dlp"
+	return nameContainer + "-dpl"
 }
 
 func getHPAName(nameContainer string) string {

--- a/pkg/handlers/deployment_test.go
+++ b/pkg/handlers/deployment_test.go
@@ -46,7 +46,7 @@ func TestMakeGetDeploymentStatusHandlerReadyExposed(t *testing.T) {
 	now := metav1.NewTime(time.Now().UTC())
 	kubeClientset := testclient.NewSimpleClientset(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "ns",
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -195,7 +195,7 @@ func TestMakeGetDeploymentStatusHandlerDegraded(t *testing.T) {
 	now := metav1.NewTime(time.Now().UTC())
 	kubeClientset := testclient.NewSimpleClientset(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "ns",
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -251,7 +251,7 @@ func TestMakeGetDeploymentStatusHandlerPending(t *testing.T) {
 	now := metav1.NewTime(time.Now().UTC())
 	kubeClientset := testclient.NewSimpleClientset(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "ns",
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -304,7 +304,7 @@ func TestMakeGetDeploymentStatusHandlerFailed(t *testing.T) {
 	now := metav1.NewTime(time.Now().UTC())
 	kubeClientset := testclient.NewSimpleClientset(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "ns",
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/handlers/list_test.go
+++ b/pkg/handlers/list_test.go
@@ -128,7 +128,7 @@ func TestMakeListHandlerIncludeDeploymentSummary(t *testing.T) {
 	replicas := int32(2)
 	_, _ = back.GetKubeClientset().AppsV1().Deployments("default").Create(t.Context(), &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "default",
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/handlers/read_test.go
+++ b/pkg/handlers/read_test.go
@@ -187,7 +187,7 @@ func TestMakeReadHandlerIncludeDeploymentSummary(t *testing.T) {
 	replicas := int32(2)
 	_, _ = back.GetKubeClientset().AppsV1().Deployments("default").Create(t.Context(), &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-dlp",
+			Name:      "svc-dpl",
 			Namespace: "default",
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/handlers/volumes_test.go
+++ b/pkg/handlers/volumes_test.go
@@ -117,6 +117,10 @@ func TestDeleteVolumeHandlerRejectsAttachedVolume(t *testing.T) {
 
 func createBaseRuntimePVC(t *testing.T, back *backends.FakeBackend, cfg *types.Config) {
 	t.Helper()
+	namespace := utils.BuildUserNamespace(cfg, "user@example.org")
+	_, _ = back.GetKubeClientset().CoreV1().Namespaces().Create(t.Context(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}, metav1.CreateOptions{})
 	_, _ = back.GetKubeClientset().CoreV1().PersistentVolumes().Create(t.Context(), &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "base-oscar-pv",
@@ -134,10 +138,11 @@ func createBaseRuntimePVC(t *testing.T, back *backends.FakeBackend, cfg *types.C
 			Phase: v1.ClaimBound,
 		},
 	}, metav1.CreateOptions{})
-	_, _ = back.GetKubeClientset().CoreV1().ResourceQuotas("oscar-svc-user-example-org-547e41ffe2031bcdc35ffc6687f10d498c46").Create(t.Context(), &v1.ResourceQuota{
+	userNS := utils.BuildUserNamespace(cfg, "user@example.org")
+	_, _ = back.GetKubeClientset().CoreV1().ResourceQuotas(userNS).Create(t.Context(), &v1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "user",
-			Namespace: "oscar-svc-user-example-org-547e41ffe2031bcdc35ffc6687f10d498c46",
+			Namespace: userNS,
 		},
 		Spec: v1.ResourceQuotaSpec{
 			Hard: v1.ResourceList{
@@ -146,10 +151,10 @@ func createBaseRuntimePVC(t *testing.T, back *backends.FakeBackend, cfg *types.C
 			},
 		},
 	}, metav1.CreateOptions{})
-	_, _ = back.GetKubeClientset().CoreV1().LimitRanges("oscar-svc-user-example-org-547e41ffe2031bcdc35ffc6687f10d498c46").Create(t.Context(), &v1.LimitRange{
+	_, _ = back.GetKubeClientset().CoreV1().LimitRanges(userNS).Create(t.Context(), &v1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "user",
-			Namespace: "oscar-svc-user-example-org-547e41ffe2031bcdc35ffc6687f10d498c46",
+			Namespace: userNS,
 		},
 		Spec: v1.LimitRangeSpec{
 			Limits: []v1.LimitRangeItem{

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	maxNamespaceLength          = 63
+	maxNamespaceLength          = 18
 	controllerRoleName          = "oscar-controller"
 	controllerRoleBindingName   = "oscar-controller-binding"
 	namespaceManagedByLabel     = "app.kubernetes.io/managed-by"

--- a/pkg/utils/namespaces_test.go
+++ b/pkg/utils/namespaces_test.go
@@ -53,13 +53,13 @@ func TestBuildUserNamespace(t *testing.T) {
 			name:     "custom owner with default prefix",
 			cfg:      &types.Config{ServicesNamespace: "oscar-svc"},
 			owner:    "testuser",
-			expected: "oscar-svc-testuser-45c571a156ddcef41351a713bcddee5ba7e95460",
+			expected: "oscar-svc-testuser",
 		},
 		{
 			name:     "custom owner with custom prefix",
 			cfg:      &types.Config{ServicesNamespace: "custom-svc"},
 			owner:    "testuser",
-			expected: "custom-svc-testuser-45c571a156ddcef41351a713bcddee5ba7e95460",
+			expected: "custom-svc-testuse",
 		},
 		{
 			name:     "nil config",
@@ -71,7 +71,7 @@ func TestBuildUserNamespace(t *testing.T) {
 			name:     "empty services namespace",
 			cfg:      &types.Config{ServicesNamespace: ""},
 			owner:    "testuser",
-			expected: "oscar-svc-testuser-45c571a156ddcef41351a713bcddee5ba7e95460",
+			expected: "oscar-svc-testuser",
 		},
 	}
 
@@ -463,8 +463,8 @@ func TestEnsureUserNamespaceBasic(t *testing.T) {
 		// Just test namespace generation, don't try to create resources
 		expected := BuildUserNamespace(cfg, "testuser")
 
-		if expected != "oscar-svc-testuser-45c571a156ddcef41351a713bcddee5ba7e95460" {
-			t.Errorf("Expected namespace %s, got %s", "oscar-svc-testuser-45c571a156ddcef41351a713bcddee5ba7e95460", expected)
+		if expected != "oscar-svc-testuser" {
+			t.Errorf("Expected namespace %s, got %s", "oscar-svc-testuser", expected)
 		}
 	})
 
@@ -485,8 +485,8 @@ func TestEnsureUserNamespaceBasic(t *testing.T) {
 
 func TestNamespaceConstants(t *testing.T) {
 	// Test that constants have expected values
-	if maxNamespaceLength != 63 {
-		t.Errorf("Expected maxNamespaceLength 63, got %d", maxNamespaceLength)
+	if maxNamespaceLength != 18 {
+		t.Errorf("Expected maxNamespaceLength 18, got %d", maxNamespaceLength)
 	}
 
 	if controllerRoleName != "oscar-controller" {


### PR DESCRIPTION
Fixes # https://github.com/grycap/issue-tracker/issues/342

## Proposed Changes

**Namespace and Name Generation Updates:**

* Reduced the `maxNamespaceLength` constant from 63 to 18 in `pkg/utils/namespaces.go`, enforcing shorter namespace names throughout the codebase.
* Updated the `BuildUserNamespace` logic and related test cases in `pkg/utils/namespaces_test.go` to generate shorter user namespaces, removing appended hashes and truncating names to fit the new maximum length.

**Deployment Naming Consistency:**

* Changed the deployment name suffix from `-dlp` to `-dpl` in the `GetDeploymentName` function in `pkg/backends/resources/expose.go` and updated all related test cases to match the new naming convention. 