### PR TITLE
fix: add serviceNamespace parameter to GetProxyDirector

### DIFF
--- a/pkg/backends/config_test.go
+++ b/pkg/backends/config_test.go
@@ -1,0 +1,93 @@
+package backends
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateOSCARCMConfiguration(t *testing.T) {
+	client := testclient.NewSimpleClientset()
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+
+	err := CreateOSCARCMConfiguration(client, cm, "default")
+	if err != nil {
+		t.Errorf("CreateOSCARCMConfiguration() error = %v", err)
+	}
+
+	result, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), "test-config", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to get configmap: %v", err)
+	}
+	if result.Data["key1"] != "value1" {
+		t.Errorf("Expected key1=value1, got %s", result.Data["key1"])
+	}
+}
+
+func TestGetOSCARCMConfiguration(t *testing.T) {
+	client := testclient.NewSimpleClientset()
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key1": "value1",
+		},
+	}
+	client.CoreV1().ConfigMaps("default").Create(context.TODO(), cm, metav1.CreateOptions{})
+
+	result, err := GetOSCARCMConfiguration(client, "test-config", "default")
+	if err != nil {
+		t.Errorf("GetOSCARCMConfiguration() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected non-nil ConfigMap")
+	}
+	if result.Data["key1"] != "value1" {
+		t.Errorf("Expected key1=value1, got %s", result.Data["key1"])
+	}
+}
+
+func TestUpdateOSCARCMConfiguration(t *testing.T) {
+	client := testclient.NewSimpleClientset()
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key1": "value1",
+		},
+	}
+	client.CoreV1().ConfigMaps("default").Create(context.TODO(), cm, metav1.CreateOptions{})
+
+	cm.Data["key1"] = "updated"
+	err := UpdateOSCARCMConfiguration(client, cm, "default")
+	if err != nil {
+		t.Errorf("UpdateOSCARCMConfiguration() error = %v", err)
+	}
+
+	result, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), "test-config", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Failed to get configmap: %v", err)
+	}
+	if result.Data["key1"] != "updated" {
+		t.Errorf("Expected key1=updated, got %s", result.Data["key1"])
+	}
+}

--- a/pkg/backends/fake.go
+++ b/pkg/backends/fake.go
@@ -47,11 +47,12 @@ type FakeBackend struct {
 func MakeFakeBackend() *FakeBackend {
 	return &FakeBackend{
 		errors: map[string][]error{
-			"ListServices":  {},
-			"CreateService": {},
-			"ReadService":   {},
-			"UpdateService": {},
-			"DeleteService": {},
+			"ListServices":       {},
+			"ListServicesByName": {},
+			"CreateService":      {},
+			"ReadService":        {},
+			"UpdateService":      {},
+			"DeleteService":      {},
 		},
 		kubeClientset: testclient.NewSimpleClientset(),
 	}
@@ -61,12 +62,13 @@ func MakeFakeBackend() *FakeBackend {
 func MakeFakeSyncBackend() *FakeBackend {
 	return &FakeBackend{
 		errors: map[string][]error{
-			"ListServices":     {},
-			"CreateService":    {},
-			"ReadService":      {},
-			"UpdateService":    {},
-			"DeleteService":    {},
-			"GetProxyDirector": {},
+			"ListServices":       {},
+			"ListServicesByName": {},
+			"CreateService":      {},
+			"ReadService":        {},
+			"UpdateService":      {},
+			"DeleteService":      {},
+			"GetProxyDirector":   {},
 		},
 	}
 }
@@ -83,6 +85,21 @@ func (f *FakeBackend) GetInfo() *types.ServerlessBackendInfo {
 func (f *FakeBackend) ListServices(namespaces ...string) ([]*types.Service, error) {
 	if f.Services != nil {
 		return f.Services, f.returnError(getCurrentFuncName())
+	}
+	return []*types.Service{}, f.returnError(getCurrentFuncName())
+}
+
+// ListServicesByName returns a slice with services matching the provided name in the provided namespace (fake)
+func (f *FakeBackend) ListServicesByName(name string, namespaces ...string) ([]*types.Service, error) {
+	if f.Services != nil {
+		// Filter services by name
+		filteredServices := []*types.Service{}
+		for _, svc := range f.Services {
+			if svc.Name == name {
+				filteredServices = append(filteredServices, svc)
+			}
+		}
+		return filteredServices, f.returnError(getCurrentFuncName())
 	}
 	return []*types.Service{}, f.returnError(getCurrentFuncName())
 }
@@ -133,7 +150,7 @@ func (f *FakeBackend) SetKubeClientset(client kubernetes.Interface) {
 }
 
 // GetProxyDirector returns the ProxyDirector (fake)
-func (f *FakeBackend) GetProxyDirector(serviceName string) func(req *http.Request) {
+func (f *FakeBackend) GetProxyDirector(serviceName string, serviceNamespace string) func(req *http.Request) {
 	return func(req *http.Request) {
 		host := "httpbin.org"
 		req.Host = host

--- a/pkg/backends/fake_test.go
+++ b/pkg/backends/fake_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package backends
 
 import (
-	"net/http/httptest"
+	"net/http"
 	"testing"
 
 	"github.com/grycap/oscar/v3/pkg/types"
@@ -90,9 +90,9 @@ func TestMakeFakeSyncBackend(t *testing.T) {
 
 func TestFakeGetProxyDirector(t *testing.T) {
 	back := MakeFakeSyncBackend()
-	req := httptest.NewRequest("GET", "http://example.com/initial", nil)
+	req, _ := http.NewRequest("GET", "http://example.com/initial", nil)
 
-	director := back.GetProxyDirector("svc")
+	director := back.GetProxyDirector("svc", "default")
 	director(req)
 
 	if req.URL.Host != "httpbin.org" || req.URL.Path != "/status/200" {

--- a/pkg/backends/k8s.go
+++ b/pkg/backends/k8s.go
@@ -82,6 +82,30 @@ func (k *KubeBackend) ListServices(namespaces ...string) ([]*types.Service, erro
 	return services, nil
 }
 
+// ListServicesByName returns a slice with services matching the provided name in the provided namespace(s)
+func (k *KubeBackend) ListServicesByName(name string, namespaces ...string) ([]*types.Service, error) {
+	// Get the list with all OSCAR services in the specified namespace(s)
+	configmaps, err := getAllServicesConfigMaps(k.kubeClientset, namespaces...)
+	if err != nil {
+		log.Printf("WARNING: %v\n", err)
+		return nil, err
+	}
+	services := []*types.Service{}
+
+	// Filter configmaps by service name
+	for _, cm := range configmaps.Items {
+		if cm.Labels[types.ServiceLabel] == name {
+			service, err := getServiceFromConfigMap(&cm) // #nosec G601
+			if err != nil {
+				return nil, err
+			}
+			service.Namespace = cm.Namespace
+			services = append(services, service)
+		}
+	}
+	return services, nil
+}
+
 // CreateService creates a new service as a k8s podTemplate
 func (k *KubeBackend) CreateService(service types.Service) error {
 	namespace := service.Namespace
@@ -103,6 +127,9 @@ func (k *KubeBackend) CreateService(service types.Service) error {
 
 	if err := resources.EnsureServiceVolume(context.TODO(), k.config, k.kubeClientset, service, namespace); err != nil {
 		if delErr := deleteServiceConfigMap(service.Name, namespace, k.kubeClientset); delErr != nil {
+			log.Println(delErr.Error())
+		}
+		if delErr := resources.DeleteServiceVolume(context.TODO(), k.kubeClientset, service, namespace); delErr != nil {
 			log.Println(delErr.Error())
 		}
 		return err

--- a/pkg/backends/knative.go
+++ b/pkg/backends/knative.go
@@ -95,6 +95,30 @@ func (kn *KnativeBackend) ListServices(namespaces ...string) ([]*types.Service, 
 	return services, nil
 }
 
+// ListServicesByName returns a slice with services matching the provided name in the provided namespace(s)
+func (kn *KnativeBackend) ListServicesByName(name string, namespaces ...string) ([]*types.Service, error) {
+	// Get the list with all OSCAR services in the specified namespace(s)
+	configmaps, err := getAllServicesConfigMaps(kn.kubeClientset, namespaces...)
+	if err != nil {
+		log.Printf("WARNING: %v\n", err)
+		return nil, err
+	}
+	services := []*types.Service{}
+
+	// Filter configmaps by service name
+	for _, cm := range configmaps.Items {
+		if cm.Labels[types.ServiceLabel] == name {
+			service, err := getServiceFromConfigMap(&cm) // #nosec G601
+			if err != nil {
+				return nil, err
+			}
+			service.Namespace = cm.Namespace
+			services = append(services, service)
+		}
+	}
+	return services, nil
+}
+
 // CreateService creates a new service as a Knative service
 func (kn *KnativeBackend) CreateService(service types.Service) error {
 	namespace := service.Namespace
@@ -313,13 +337,17 @@ func (kn *KnativeBackend) DeleteService(service types.Service) error {
 }
 
 // GetProxyDirector returns a director function to use in a httputil.ReverseProxy
-func (kn *KnativeBackend) GetProxyDirector(serviceName string) func(req *http.Request) {
+func (kn *KnativeBackend) GetProxyDirector(serviceName string, serviceNamespace string) func(req *http.Request) {
 	return func(req *http.Request) {
-		namespace := kn.config.ServicesNamespace
-		if resolved, err := kn.resolveServiceNamespace(serviceName); err == nil && resolved != "" {
-			namespace = resolved
+		var namespace string
+		if serviceNamespace == "" {
+			namespace = kn.config.ServicesNamespace
+			if resolved, err := kn.resolveServiceNamespace(serviceName); err == nil && resolved != "" {
+				namespace = resolved
+			}
+		} else {
+			namespace = serviceNamespace
 		}
-
 		// Set the request Host parameter to avoid issues in the redirection
 		// related issue: https://github.com/golang/go/issues/7682
 		host := fmt.Sprintf("%s.%s", serviceName, namespace)

--- a/pkg/backends/knative_test.go
+++ b/pkg/backends/knative_test.go
@@ -806,7 +806,7 @@ func TestKnativeGetProxyDirector(t *testing.T) {
 
 	back := MakeKnativeBackend(clientset, fakeConfig, testConfig)
 
-	proxyDirector := back.GetProxyDirector("testService")
+	proxyDirector := back.GetProxyDirector("testService", testConfig.ServicesNamespace)
 
 	testReq, _ := http.NewRequest(http.MethodPost, "testurl", nil)
 

--- a/pkg/handlers/job.go
+++ b/pkg/handlers/job.go
@@ -82,7 +82,10 @@ const (
 // @Router /job/{serviceName} [post]
 func MakeJobHandler(cfg *types.Config, kubeClientset kubernetes.Interface, back types.ServerlessBackend, rm resourcemanager.ResourceManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		service, err := back.ReadService("", c.Param("serviceName"))
+		var service *types.Service
+		var podSpec *v1.PodSpec
+		var serviceNamespace string
+		serviceList, err := back.ListServicesByName(c.Param("serviceName"), "")
 		if err != nil {
 			// Check if error is caused because the service is not found
 			if errors.IsNotFound(err) || errors.IsGone(err) {
@@ -91,17 +94,6 @@ func MakeJobHandler(cfg *types.Config, kubeClientset kubernetes.Interface, back 
 				c.String(http.StatusInternalServerError, err.Error())
 			}
 			return
-		}
-
-		// Get podSpec from the service
-		podSpec, err := service.ToPodSpec(cfg)
-		if err != nil {
-			c.String(http.StatusInternalServerError, err.Error())
-			return
-		}
-		serviceNamespace := service.Namespace
-		if serviceNamespace == "" {
-			serviceNamespace = cfg.ServicesNamespace
 		}
 
 		// Check auth token
@@ -117,9 +109,19 @@ func MakeJobHandler(cfg *types.Config, kubeClientset kubernetes.Interface, back 
 		var minIOSecretKey string
 		rawToken := strings.TrimSpace(splitToken[1])
 		if len(rawToken) == tokenLength {
-
-			if rawToken != service.Token {
+			for _, serviceIter := range serviceList {
+				if rawToken == serviceIter.Token {
+					service = serviceIter
+				}
+			}
+			if service == nil {
 				c.Status(http.StatusUnauthorized)
+				return
+			}
+			// Get podSpec from the service
+			podSpec, serviceNamespace, err = getPodSpecNamespace(service, cfg)
+			if err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
 				return
 			}
 			// Use
@@ -143,6 +145,24 @@ func MakeJobHandler(cfg *types.Config, kubeClientset kubernetes.Interface, back 
 				return
 			}
 			uid := auth.FormatUID(uidFromToken)
+			c.Set("uidOrigin", uid)
+			c.Next()
+
+			service, err = selectService(c, serviceList)
+			if err != nil {
+				if err.Error() == errServiceNotFound {
+					c.Status(http.StatusNotFound)
+				} else {
+					c.String(http.StatusBadRequest, err.Error())
+				}
+				return
+			}
+			// Get podSpec from the service
+			podSpec, serviceNamespace, err = getPodSpecNamespace(service, cfg)
+			if err != nil {
+				c.String(http.StatusInternalServerError, err.Error())
+				return
+			}
 			if len(uid) > 62 {
 				uid = uid[:62]
 			}
@@ -152,12 +172,7 @@ func MakeJobHandler(cfg *types.Config, kubeClientset kubernetes.Interface, back 
 				return
 			}
 
-			if err != nil {
-				c.String(http.StatusInternalServerError, err.Error())
-				return
-			}
-
-			if !oidcManager.UserHasVO(ui, service.VO) {
+			if !oidcManager.UserInOneGroup(ui, cfg) {
 				c.String(http.StatusUnauthorized, "this user isn't enrrolled on the vo: %v", service.VO)
 				return
 			}
@@ -447,4 +462,18 @@ func ensureMinIOSecret(kubeClientset kubernetes.Interface, uid, namespace string
 	}
 
 	return nil
+}
+
+func getPodSpecNamespace(service *types.Service, cfg *types.Config) (*v1.PodSpec, string, error) {
+
+	// Get podSpec from the service
+	podSpec, err := service.ToPodSpec(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	serviceNamespace := service.Namespace
+	if serviceNamespace == "" {
+		serviceNamespace = cfg.ServicesNamespace
+	}
+	return podSpec, serviceNamespace, nil
 }

--- a/pkg/handlers/job_test.go
+++ b/pkg/handlers/job_test.go
@@ -18,6 +18,12 @@ import (
 
 func TestMakeJobHandler(t *testing.T) {
 	back := backends.MakeFakeBackend()
+	back.Services = []*types.Service{{
+		Name:  "testName",
+		Token: "11e387cf727630d899925d57fceb4578f478c44be6cde0ae3fe886d8be513acf",
+		CPU:   "100m",
+		Memory: "128Mi",
+	}}
 	cfg := types.Config{}
 	kubeClient := testclient.NewSimpleClientset()
 
@@ -27,7 +33,7 @@ func TestMakeJobHandler(t *testing.T) {
 	w := httptest.NewRecorder()
 	body := strings.NewReader(`{"Records": [{"requestParameters": {"principalId": "uid", "sourceIPAddress": "ip"}}]}`)
 	serviceName := "testName"
-	req, _ := http.NewRequest("POST", "/job/services"+serviceName, body)
+	req, _ := http.NewRequest("POST", "/job/"+serviceName, body)
 	req.Header.Set("Authorization", "Bearer 11e387cf727630d899925d57fceb4578f478c44be6cde0ae3fe886d8be513acf")
 	r.ServeHTTP(w, req)
 

--- a/pkg/handlers/logs.go
+++ b/pkg/handlers/logs.go
@@ -588,8 +588,6 @@ func authorizeRequest(c *gin.Context, service *types.Service) bool {
 			//c.String(http.StatusInternalServerError, fmt.Sprintln(err))
 			return false
 		}
-		fmt.Println(service.Owner)
-		fmt.Println(uid)
 		if service.Visibility == utils.PUBLIC {
 			return true
 		}

--- a/pkg/handlers/run.go
+++ b/pkg/handlers/run.go
@@ -30,7 +30,9 @@ import (
 )
 
 const (
-	tokenLength = 64
+	tokenLength            = 64
+	errServiceNotFound     = "Service Not Found"
+	errMultipleServiceAuth = "More than one service authorize, use the owner query to select the service"
 )
 
 // MakeRunHandler godoc
@@ -50,7 +52,8 @@ const (
 // @Router /run/{serviceName} [post]
 func MakeRunHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		service, err := back.ReadService("", c.Param("serviceName"))
+		var service *types.Service
+		serviceList, err := back.ListServicesByName(c.Param("serviceName"), "")
 		if err != nil {
 			// Check if error is caused because the service is not found
 			if errors.IsNotFound(err) || errors.IsGone(err) {
@@ -72,8 +75,12 @@ func MakeRunHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
 		// Check if reqToken is the service token
 		rawToken := strings.TrimSpace(splitToken[1])
 		if len(rawToken) == tokenLength {
-
-			if rawToken != service.Token {
+			for _, serviceIter := range serviceList {
+				if rawToken == serviceIter.Token {
+					service = serviceIter
+				}
+			}
+			if service == nil {
 				c.Status(http.StatusUnauthorized)
 				return
 			}
@@ -91,20 +98,30 @@ func MakeRunHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
 			ui, err := oidcManager.GetUserInfo(rawToken)
 
 			if !oidcManager.IsAuthorised(rawToken) {
-				c.Status(http.StatusUnauthorized)
-				return
-			}
-
-			hasVO := oidcManager.UserHasVO(ui, service.VO)
-
-			if !hasVO {
-				c.String(http.StatusUnauthorized, "this user isn't enrrolled on the vo: %v", service.VO)
+				c.Status(http.StatusNotFound)
 				return
 			}
 
 			uid := ui.Subject
 			c.Set("uidOrigin", uid)
 			c.Next()
+
+			service, err = selectService(c, serviceList)
+			if err != nil {
+				if err.Error() == errServiceNotFound {
+					c.Status(http.StatusNotFound)
+				} else {
+					c.String(http.StatusBadRequest, err.Error())
+				}
+				return
+			}
+
+			hasVO := oidcManager.UserInOneGroup(ui, cfg)
+
+			if !hasVO {
+				c.String(http.StatusUnauthorized, "this user isn't enrrolled on the vo: %v", service.VO)
+				return
+			}
 
 		}
 
@@ -114,8 +131,48 @@ func MakeRunHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
 		}
 
 		proxy := &httputil.ReverseProxy{
-			Director: back.GetProxyDirector(service.Name),
+			Director: back.GetProxyDirector(service.Name, service.Namespace),
 		}
 		proxy.ServeHTTP(c.Writer, c.Request) // #nosec
+	}
+}
+
+func selectService(c *gin.Context, serviceList []*types.Service) (*types.Service, error) {
+	// If no services found, return not found
+	if len(serviceList) == 0 {
+		return nil, fmt.Errorf(errServiceNotFound)
+	} else if len(serviceList) == 1 { // Found 1 service
+		if authorizeRequest(c, serviceList[0]) { // Found 1 service and is authorize
+			return serviceList[0], nil
+		} else {
+			return nil, fmt.Errorf(errServiceNotFound)
+		}
+	} else { // Found more than one service with same name
+		authTime := 0
+		var service *types.Service
+		for _, serviceIter := range serviceList {
+			if authorizeRequest(c, serviceIter) { // Get the services authorized
+				service = serviceIter
+				authTime++
+			}
+		}
+		if authTime == 1 { // More than 1 service found, but 1 service authorize
+			return service, nil
+		} else if authTime == 0 { // More than 1 service found, but no service authorize
+			return nil, fmt.Errorf(errServiceNotFound)
+		} else if authTime > 1 { // More than 1 service found, and more than one service authorize -> user query owner
+			owner := strings.TrimSpace(c.Query("owner"))
+			if owner == "" {
+				return nil, fmt.Errorf(errMultipleServiceAuth)
+			}
+			for _, serviceIter := range serviceList {
+				if authorizeRequest(c, serviceIter) && serviceIter.Owner == owner {
+					service = serviceIter
+					return service, nil
+				}
+			}
+			return nil, fmt.Errorf(errServiceNotFound)
+		}
+		return nil, fmt.Errorf(errServiceNotFound)
 	}
 }

--- a/pkg/handlers/run_test.go
+++ b/pkg/handlers/run_test.go
@@ -47,6 +47,10 @@ func TestMakeRunHandler(t *testing.T) {
 	}
 	for _, s := range scenarios {
 		back := backends.MakeFakeSyncBackend()
+		back.Services = []*types.Service{{
+			Name:  "testName",
+			Token: "11e387cf727630d899925d57fceb4578f478c44be6cde0ae3fe886d8be513acf",
+		}}
 		http.DefaultClient.Timeout = 400 * time.Second
 		r := gin.Default()
 		r.POST("/run/:serviceName", MakeRunHandler(&testConfigValidRun, back))
@@ -61,10 +65,10 @@ func TestMakeRunHandler(t *testing.T) {
 			if s.returnError {
 				switch s.errType {
 				case "404":
-					back.AddError("ReadService", k8serr.NewGone("Not Found"))
+					back.AddError("ListServicesByName", k8serr.NewGone("Not Found"))
 				case "500":
 					err := errors.New("Not found")
-					back.AddError("ReadService", k8serr.NewInternalError(err))
+					back.AddError("ListServicesByName", k8serr.NewInternalError(err))
 				case "splitErr":
 					req.Header.Set("Authorization", "11e387cf727630d899925d57fceb4578f478c44be6cde0ae3fe886d8be513acf")
 				case "diffErr":
@@ -130,7 +134,7 @@ func TestMakeRunHandlerOIDCPath(t *testing.T) {
 		},
 		Owner:        "somelonguid@egi.eu",
 		AllowedUsers: []string{}}
-	back.Service = svc
+	back.Services = []*types.Service{svc}
 	cfg := types.Config{
 		MinIOProvider: &types.MinIOProvider{
 			Region:    "us-east-1",
@@ -188,7 +192,7 @@ func TestMakeRunHandlerUnauthorized(t *testing.T) {
 		},
 		Owner:        "somelonguid@egi.eu",
 		AllowedUsers: []string{}}
-	back.Service = svc
+	back.Services = []*types.Service{svc}
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -227,6 +231,7 @@ func TestMakeRunHandlerWithServiceToken(t *testing.T) {
 		}
 	}))
 	svc := &types.Service{
+		Name:  "hello",
 		Token: "11e387cf727630d899925d57fceb4578f478c44be6cde0ae3fe886d8be513acf",
 		CPU:   "2.0",
 		StorageProviders: &types.StorageProviders{
@@ -238,7 +243,7 @@ func TestMakeRunHandlerWithServiceToken(t *testing.T) {
 		},
 		Owner:        "somelonguid@egi.eu",
 		AllowedUsers: []string{}}
-	back.Service = svc
+	back.Services = []*types.Service{svc}
 	cfg := types.Config{
 		MinIOProvider: &types.MinIOProvider{
 			Region:    "us-east-1",

--- a/pkg/handlers/service_access_test.go
+++ b/pkg/handlers/service_access_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/backends"
+	"github.com/grycap/oscar/v3/pkg/types"
+	"github.com/grycap/oscar/v3/pkg/utils"
+)
+
+func TestIsBearerRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		authHeader string
+		expected  bool
+	}{
+		{"Empty header", "", false},
+		{"No Bearer prefix", "Basic token", false},
+		{"Bearer prefix", "Bearer token", true},
+		{"Bearer with space", "Bearer ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest("GET", "/", nil)
+			if tt.authHeader != "" {
+				c.Request.Header.Set("Authorization", tt.authHeader)
+			}
+
+			result := isBearerRequest(c)
+			if result != tt.expected {
+				t.Errorf("isBearerRequest() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsServiceAccessibleByUser(t *testing.T) {
+	publicSvc := &types.Service{
+		Name:       "public",
+		Visibility:  utils.PUBLIC,
+		Owner:      "owner",
+		AllowedUsers: []string{},
+	}
+	restrictedSvc := &types.Service{
+		Name:       "restricted",
+		Visibility:  utils.RESTRICTED,
+		Owner:      "owner",
+		AllowedUsers: []string{"user1", "user2"},
+	}
+	privateSvc := &types.Service{
+		Name:       "private",
+		Visibility:  utils.PRIVATE,
+		Owner:      "owner",
+		AllowedUsers: []string{},
+	}
+
+	tests := []struct {
+		name      string
+		service   *types.Service
+		uid       string
+		expected  bool
+	}{
+		{"Nil service", nil, "user", false},
+		{"Public service any user", publicSvc, "anyone", true},
+		{"Public service anonymous", publicSvc, "", true},
+		{"Restricted service owner", restrictedSvc, "owner", true},
+		{"Restricted service allowed user", restrictedSvc, "user1", true},
+		{"Restricted service not allowed", restrictedSvc, "user3", false},
+		{"Private service owner", privateSvc, "owner", true},
+		{"Private service other", privateSvc, "other", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isServiceAccessibleByUser(tt.service, tt.uid)
+			if result != tt.expected {
+				t.Errorf("isServiceAccessibleByUser(%v, %q) = %v, want %v", tt.service, tt.uid, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestListAuthorizedServicesForMetrics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("No error bearer request", func(t *testing.T) {
+		back := backends.MakeFakeBackend()
+		back.Services = []*types.Service{
+			{Name: "svc1", Visibility: utils.PUBLIC, Owner: "owner1"},
+			{Name: "svc2", Visibility: utils.PRIVATE, Owner: "owner2"},
+		}
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", "/", nil)
+
+		services, ok := listAuthorizedServicesForMetrics(c, back)
+		if !ok {
+			t.Error("expected ok = true")
+		}
+		if len(services) != 2 {
+			t.Errorf("expected 2 services, got %d", len(services))
+		}
+	})
+
+	t.Run("Backend error", func(t *testing.T) {
+		back := backends.MakeFakeBackend()
+		back.AddError("ListServices", errTest)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", "/", nil)
+
+		services, ok := listAuthorizedServicesForMetrics(c, back)
+		if ok {
+			t.Error("expected ok = false")
+		}
+		if services != nil {
+			t.Error("expected nil services")
+		}
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+		}
+	})
+}
+
+var errTest = &errTestType{}
+
+type errTestType struct{}
+
+func (e *errTestType) Error() string {
+	return "test error"
+}

--- a/pkg/metrics/scoped_test.go
+++ b/pkg/metrics/scoped_test.go
@@ -1,0 +1,264 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+type mockServiceInventorySource struct {
+	services []ServiceDescriptor
+	err     error
+}
+
+func (m *mockServiceInventorySource) Name() string {
+	return "mock"
+}
+
+func (m *mockServiceInventorySource) ListServices(ctx context.Context, tr TimeRange) ([]ServiceDescriptor, *types.SourceStatus, error) {
+	return m.services, &types.SourceStatus{}, m.err
+}
+
+type mockUsageMetricsSource struct{}
+
+func (m *mockUsageMetricsSource) Name() string {
+	return "mock"
+}
+
+func (m *mockUsageMetricsSource) UsageHours(ctx context.Context, tr TimeRange, serviceID string) (float64, float64, *types.SourceStatus, error) {
+	return 1.0, 2.0, &types.SourceStatus{}, nil
+}
+
+type mockRequestLogSource struct {
+	records []RequestRecord
+	err     error
+}
+
+func (m *mockRequestLogSource) Name() string {
+	return "mock"
+}
+
+func (m *mockRequestLogSource) ListRequests(ctx context.Context, tr TimeRange, serviceID string) ([]RequestRecord, *types.SourceStatus, error) {
+	return m.records, &types.SourceStatus{}, m.err
+}
+
+func TestScopeSourcesNilAllowed(t *testing.T) {
+	src := Sources{
+		ServiceInventory: &mockServiceInventorySource{},
+	}
+
+	result := ScopeSources(src, nil)
+	if result.ServiceInventory == nil {
+		t.Error("Expected ServiceInventory to be unchanged")
+	}
+}
+
+func TestScopeSourcesWithAllowed(t *testing.T) {
+	src := Sources{
+		ServiceInventory: &mockServiceInventorySource{
+			services: []ServiceDescriptor{
+				{ID: "svc1"},
+				{ID: "svc2"},
+			},
+		},
+		UsageMetrics:    &mockUsageMetricsSource{},
+		RequestLogs:   &mockRequestLogSource{},
+		ExposedRequestLogs: &mockRequestLogSource{},
+	}
+
+	allowed := map[string]struct{}{
+		"svc1": {},
+	}
+
+	result := ScopeSources(src, allowed)
+	if result.ServiceInventory == nil {
+		t.Error("Expected ServiceInventory to be set")
+	}
+	if result.UsageMetrics == nil {
+		t.Error("Expected UsageMetrics to be set")
+	}
+	if result.RequestLogs == nil {
+		t.Error("Expected RequestLogs to be set")
+	}
+	if result.ExposedRequestLogs == nil {
+		t.Error("Expected ExposedRequestLogs to be set")
+	}
+}
+
+func TestCloneAllowedServices(t *testing.T) {
+	allowed := map[string]struct{}{
+		"svc1": {},
+		"svc2": {},
+	}
+
+	cloned := cloneAllowedServices(allowed)
+	if cloned == nil {
+		t.Fatal("Expected non-nil")
+	}
+	if _, ok := cloned["svc1"]; !ok {
+		t.Error("Expected svc1 in cloned")
+	}
+	if _, ok := cloned["svc2"]; !ok {
+		t.Error("Expected svc2 in cloned")
+	}
+}
+
+func TestCloneAllowedServicesNil(t *testing.T) {
+	cloned := cloneAllowedServices(nil)
+	if cloned != nil {
+		t.Error("Expected nil for nil input")
+	}
+}
+
+func TestFilterServiceDescriptors(t *testing.T) {
+	services := []ServiceDescriptor{
+		{ID: "svc1"},
+		{ID: "svc2"},
+		{ID: "svc3"},
+	}
+	allowed := map[string]struct{}{
+		"svc1": {},
+		"svc3": {},
+	}
+
+	filtered := filterServiceDescriptors(services, allowed)
+	if len(filtered) != 2 {
+		t.Errorf("Expected 2 services, got %d", len(filtered))
+	}
+	if filtered[0].ID != "svc1" {
+		t.Errorf("Expected svc1, got %s", filtered[0].ID)
+	}
+	if filtered[1].ID != "svc3" {
+		t.Errorf("Expected svc3, got %s", filtered[1].ID)
+	}
+}
+
+func TestFilterServiceDescriptorsNilAllowed(t *testing.T) {
+	services := []ServiceDescriptor{
+		{ID: "svc1"},
+	}
+
+	filtered := filterServiceDescriptors(services, nil)
+	if len(filtered) != 1 {
+		t.Errorf("Expected 1 service, got %d", len(filtered))
+	}
+}
+
+func TestFilterRequestRecords(t *testing.T) {
+	records := []RequestRecord{
+		{ServiceID: "svc1"},
+		{ServiceID: "svc2"},
+		{ServiceID: "svc3"},
+	}
+	allowed := map[string]struct{}{
+		"svc1": {},
+		"svc3": {},
+	}
+
+	filtered := filterRequestRecords(records, allowed)
+	if len(filtered) != 2 {
+		t.Errorf("Expected 2 records, got %d", len(filtered))
+	}
+	if filtered[0].ServiceID != "svc1" {
+		t.Errorf("Expected svc1, got %s", filtered[0].ServiceID)
+	}
+	if filtered[1].ServiceID != "svc3" {
+		t.Errorf("Expected svc3, got %s", filtered[1].ServiceID)
+	}
+}
+
+func TestFilterRequestRecordsNilAllowed(t *testing.T) {
+	records := []RequestRecord{
+		{ServiceID: "svc1"},
+	}
+
+	filtered := filterRequestRecords(records, nil)
+	if len(filtered) != 1 {
+		t.Errorf("Expected 1 record, got %d", len(filtered))
+	}
+}
+
+func TestScopedServiceInventorySource(t *testing.T) {
+	ctx := context.Background()
+	tr := TimeRange{
+		Start: time.Now().Add(-time.Hour),
+		End:   time.Now(),
+	}
+
+	inner := &mockServiceInventorySource{
+		services: []ServiceDescriptor{
+			{ID: "svc1"},
+			{ID: "svc2"},
+		},
+	}
+
+	allowed := map[string]struct{}{
+		"svc1": {},
+	}
+
+	src := &scopedServiceInventorySource{
+		inner:   inner,
+		allowed: allowed,
+	}
+
+	services, _, _ := src.ListServices(ctx, tr)
+	if len(services) != 1 {
+		t.Errorf("Expected 1 service, got %d", len(services))
+	}
+	if services[0].ID != "svc1" {
+		t.Errorf("Expected svc1, got %s", services[0].ID)
+	}
+}
+
+func TestScopedUsageMetricsSource(t *testing.T) {
+	ctx := context.Background()
+	tr := TimeRange{
+		Start: time.Now().Add(-time.Hour),
+		End:   time.Now(),
+	}
+
+	inner := &mockUsageMetricsSource{}
+	src := &scopedUsageMetricsSource{inner: inner}
+
+	cpu, mem, _, _ := src.UsageHours(ctx, tr, "svc1")
+	if cpu != 1.0 {
+		t.Errorf("Expected cpu=1.0, got %f", cpu)
+	}
+	if mem != 2.0 {
+		t.Errorf("Expected mem=2.0, got %f", mem)
+	}
+}
+
+func TestScopedRequestLogSource(t *testing.T) {
+	ctx := context.Background()
+	tr := TimeRange{
+		Start: time.Now().Add(-time.Hour),
+		End:   time.Now(),
+	}
+
+	inner := &mockRequestLogSource{
+		records: []RequestRecord{
+			{ServiceID: "svc1"},
+			{ServiceID: "svc2"},
+		},
+	}
+
+	allowed := map[string]struct{}{
+		"svc1": {},
+	}
+
+	src := &scopedRequestLogSource{
+		inner:   inner,
+		allowed: allowed,
+	}
+
+	records, _, _ := src.ListRequests(ctx, tr, "svc1")
+	if len(records) != 1 {
+		t.Errorf("Expected 1 record, got %d", len(records))
+	}
+	if records[0].ServiceID != "svc1" {
+		t.Errorf("Expected svc1, got %s", records[0].ServiceID)
+	}
+}

--- a/pkg/metrics/sources_test.go
+++ b/pkg/metrics/sources_test.go
@@ -1,0 +1,135 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func TestJoinErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errs    []error
+		expected string
+	}{
+		{"Nil and error", []error{nil, nil}, ""},
+		{"One error", []error{errNoop{}}, "test error"},
+		{"Multiple errors", []error{errNoop{"a"}, errNoop{"b"}}, "a; b"},
+		{"Nil in middle", []error{errNoop{"a"}, nil, errNoop{"b"}}, "a; b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := joinErrors(tt.errs...)
+			if result != tt.expected {
+				t.Errorf("joinErrors() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseServiceFromPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		path      string
+		serviceID string
+		reqType   RequestType
+	}{
+		{"Job path", "/job/myservice", "myservice", RequestAsync},
+		{"Run path", "/run/myservice", "myservice", RequestSync},
+		{"Other path", "/other/path", "", ""},
+		{"Empty", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serviceID, reqType := parseServiceFromPath(tt.path)
+			if serviceID != tt.serviceID {
+				t.Errorf("parseServiceFromPath() serviceID = %q, want %q", serviceID, tt.serviceID)
+			}
+			if reqType != tt.reqType {
+				t.Errorf("parseServiceFromPath() reqType = %q, want %q", reqType, tt.reqType)
+			}
+		})
+	}
+}
+
+func TestParseExposedServiceFromPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		serviceID  string
+		ok         bool
+	}{
+		{"Valid path", "/system/services/svc/exposed", "svc", true},
+		{"Invalid path", "/system/services/svc", "", false},
+		{"Wrong format", "/other/path", "", false},
+		{"Empty", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serviceID, ok := parseExposedServiceFromPath(tt.path)
+			if ok != tt.ok {
+				t.Errorf("parseExposedServiceFromPath() ok = %v, want %v", ok, tt.ok)
+			}
+			if serviceID != tt.serviceID {
+				t.Errorf("parseExposedServiceFromPath() serviceID = %q, want %q", serviceID, tt.serviceID)
+			}
+		})
+	}
+}
+
+func TestCountryFromLokiLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels  map[string]string
+		country string
+	}{
+		{"With country code", map[string]string{"geoip_country_code": "US"}, "US"},
+		{"With country name", map[string]string{"geoip_country_name": "Spain"}, "Spain"},
+		{"Nil", nil, ""},
+		{"Empty", map[string]string{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := countryFromLokiLabels(tt.labels)
+			if result != tt.country {
+				t.Errorf("countryFromLokiLabels() = %q, want %q", result, tt.country)
+			}
+		})
+	}
+}
+
+func TestOkStatus(t *testing.T) {
+	status := okStatus("test", "note")
+	if status.Name != "test" {
+		t.Errorf("okStatus() Name = %q, want %q", status.Name, "test")
+	}
+	if status.Status != "ok" {
+		t.Errorf("okStatus() Status = %q, want %q", status.Status, "ok")
+	}
+	if status.Notes != "note" {
+		t.Errorf("okStatus() Notes = %q, want %q", status.Notes, "note")
+	}
+}
+
+func TestMissingStatus(t *testing.T) {
+	status := missingStatus("test", errNoop{})
+	if status.Name != "test" {
+		t.Errorf("missingStatus() Name = %q, want %q", status.Name, "test")
+	}
+	if status.Status != "missing" {
+		t.Errorf("missingStatus() Status = %q, want %q", status.Status, "missing")
+	}
+}
+
+type errNoop struct {
+	msg string
+}
+
+func (e errNoop) Error() string {
+	if e.msg == "" {
+		return "test error"
+	}
+	return e.msg
+}

--- a/pkg/types/backends.go
+++ b/pkg/types/backends.go
@@ -26,6 +26,7 @@ import (
 type ServerlessBackend interface {
 	GetInfo() *ServerlessBackendInfo
 	ListServices(namespaces ...string) ([]*Service, error)
+	ListServicesByName(name string, namespaces ...string) ([]*Service, error)
 	CreateService(service Service) error
 	ReadService(namespace, name string) (*Service, error)
 	UpdateService(service Service) error
@@ -36,5 +37,5 @@ type ServerlessBackend interface {
 // SyncBackend define an interface for serverless backends that allow sync invocations
 type SyncBackend interface {
 	ServerlessBackend
-	GetProxyDirector(serviceName string) func(req *http.Request)
+	GetProxyDirector(serviceName string, serviceNamespace string) func(req *http.Request)
 }

--- a/pkg/types/backends_test.go
+++ b/pkg/types/backends_test.go
@@ -95,7 +95,7 @@ type mockSyncBackend struct {
 	*mockServerlessBackend
 }
 
-func (m *mockSyncBackend) GetProxyDirector(serviceName string) func(req *http.Request) {
+func (m *mockSyncBackend) GetProxyDirector(serviceName string, serviceNamespace string) func(req *http.Request) {
 	return m.proxyFunc
 }
 
@@ -302,7 +302,7 @@ func TestSyncBackendInterface(t *testing.T) {
 	}
 
 	backend.proxyFunc = proxyFunc
-	director := backend.GetProxyDirector("test-service")
+	director := backend.GetProxyDirector("test-service", "default")
 
 	if director == nil {
 		t.Error("Expected GetProxyDirector to return non-nil director")
@@ -333,13 +333,13 @@ func TestSyncBackendMultipleProxyDirectors(t *testing.T) {
 
 	// Test director for service1
 	backend.proxyFunc = proxyFunc1
-	director1 := backend.GetProxyDirector("service1")
+	director1 := backend.GetProxyDirector("service1", "default")
 	req1 := &http.Request{}
 	director1(req1)
 
 	// Test director for service2
 	backend.proxyFunc = proxyFunc2
-	director2 := backend.GetProxyDirector("service2")
+	director2 := backend.GetProxyDirector("service2", "default")
 	req2 := &http.Request{}
 	director2(req2)
 

--- a/pkg/types/metrics_test.go
+++ b/pkg/types/metrics_test.go
@@ -1,0 +1,172 @@
+package types
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsMetricKeyValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		key     MetricKey
+		expected bool
+	}{
+		{"Valid services count", MetricServicesCount, true},
+		{"Valid cpu hours", MetricCPUHours, true},
+		{"Valid gpu hours", MetricGPUHours, true},
+		{"Valid requests sync", MetricRequestsSync, true},
+		{"Valid requests async", MetricRequestsAsync, true},
+		{"Valid requests exposed", MetricRequestsExposed, true},
+		{"Valid requests per user", MetricRequestsPerUser, true},
+		{"Valid users per service", MetricUsersPerService, true},
+		{"Valid countries count", MetricCountriesCount, true},
+		{"Valid countries list", MetricCountriesList, true},
+		{"Invalid key", MetricKey("invalid"), false},
+		{"Empty key", MetricKey(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsMetricKeyValid(tt.key)
+			if result != tt.expected {
+				t.Errorf("IsMetricKeyValid(%q) = %v, want %v", tt.key, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSourceStatus(t *testing.T) {
+	status := SourceStatus{
+		Name:        "test",
+		Status:      "ok",
+		LastUpdated: nil,
+		Notes:       "test note",
+	}
+
+	if status.Name != "test" {
+		t.Errorf("Expected Name = test, got %s", status.Name)
+	}
+	if status.Status != "ok" {
+		t.Errorf("Expected Status = ok, got %s", status.Status)
+	}
+	if status.Notes != "test note" {
+		t.Errorf("Expected Notes = test note, got %s", status.Notes)
+	}
+
+	now := time.Now()
+	status.LastUpdated = &now
+	if status.LastUpdated.IsZero() {
+		t.Error("Expected LastUpdated to be set")
+	}
+}
+
+func TestMetricValueResponse(t *testing.T) {
+	start := time.Now()
+	end := time.Now().Add(time.Hour)
+
+	response := MetricValueResponse{
+		ServiceID: "test-service",
+		Metric:    MetricCPUHours,
+		Start:     start,
+		End:       end,
+		Value:     100.5,
+		Unit:      "hours",
+		Sources:   []SourceStatus{{Name: "test", Status: "ok"}},
+	}
+
+	if response.ServiceID != "test-service" {
+		t.Errorf("Expected ServiceID = test-service, got %s", response.ServiceID)
+	}
+	if response.Metric != MetricCPUHours {
+		t.Errorf("Expected Metric = cpu-hours, got %s", response.Metric)
+	}
+	if response.Value != 100.5 {
+		t.Errorf("Expected Value = 100.5, got %f", response.Value)
+	}
+	if len(response.Sources) != 1 {
+		t.Errorf("Expected 1 source, got %d", len(response.Sources))
+	}
+}
+
+func TestServiceMetricsResponse(t *testing.T) {
+	response := ServiceMetricsResponse{
+		ServiceName: "test-service",
+		Start:       time.Now(),
+		End:         time.Now().Add(time.Hour),
+		Metrics: []ServiceMetricValue{
+			{Metric: MetricCPUHours, Value: 100},
+			{Metric: MetricGPUHours, Value: 50},
+		},
+	}
+
+	if response.ServiceName != "test-service" {
+		t.Errorf("Expected ServiceName = test-service, got %s", response.ServiceName)
+	}
+	if len(response.Metrics) != 2 {
+		t.Errorf("Expected 2 metrics, got %d", len(response.Metrics))
+	}
+}
+
+func TestSummaryTotals(t *testing.T) {
+	totals := SummaryTotals{
+		ServicesCountActive:   10,
+		ServicesCountTotal:   20,
+		CPUHoursTotal:         100,
+		GPUHoursTotal:        50,
+		RequestsCountTotal:     1000,
+		RequestsCountSync:    600,
+		RequestsCountAsync:   300,
+		RequestsCountExposed: 100,
+		CountriesCount:      5,
+		Countries: []CountryCount{
+			{Country: "US", RequestCount: 500},
+			{Country: "ES", RequestCount: 300},
+		},
+		UsersCount: 50,
+		Users:     []string{"user1", "user2"},
+	}
+
+	if totals.ServicesCountActive != 10 {
+		t.Errorf("Expected ServicesCountActive = 10, got %d", totals.ServicesCountActive)
+	}
+	if totals.CPUHoursTotal != 100 {
+		t.Errorf("Expected CPUHoursTotal = 100, got %f", totals.CPUHoursTotal)
+	}
+	if len(totals.Countries) != 2 {
+		t.Errorf("Expected 2 countries, got %d", len(totals.Countries))
+	}
+	if len(totals.Users) != 2 {
+		t.Errorf("Expected 2 users, got %d", len(totals.Users))
+	}
+}
+
+func TestMetricsBreakdownResponse(t *testing.T) {
+	response := MetricsBreakdownResponse{
+		Start:   time.Now(),
+		End:     time.Now().Add(time.Hour),
+		GroupBy: "service",
+		Items: []BreakdownItem{
+			{
+				Key:                "service-1",
+				ExecutionsCount:     100,
+				RequestsCountTotal:  100,
+				UniqueUsersCount:    10,
+				Users:             []string{"user1", "user2"},
+				Countries:         []CountryCount{{Country: "US", RequestCount: 50}},
+			},
+		},
+	}
+
+	if response.GroupBy != "service" {
+		t.Errorf("Expected GroupBy = service, got %s", response.GroupBy)
+	}
+	if len(response.Items) != 1 {
+		t.Errorf("Expected 1 item, got %d", len(response.Items))
+	}
+	if response.Items[0].Key != "service-1" {
+		t.Errorf("Expected Key = service-1, got %s", response.Items[0].Key)
+	}
+	if response.Items[0].UniqueUsersCount != 10 {
+		t.Errorf("Expected UniqueUsersCount = 10, got %d", response.Items[0].UniqueUsersCount)
+	}
+}

--- a/pkg/types/quotas_test.go
+++ b/pkg/types/quotas_test.go
@@ -1,0 +1,150 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestQuotaBackend(t *testing.T) {
+	qb := QuotaBackend{
+		Kueueclient:   nil,
+		KubeClientset: nil,
+	}
+
+	if qb.Kueueclient != nil {
+		t.Error("Expected Kueueclient to be nil")
+	}
+	if qb.KubeClientset != nil {
+		t.Error("Expected KubeClientset to be nil")
+	}
+}
+
+func TestQuotaResponse(t *testing.T) {
+	response := QuotaResponse{
+		UserID:       "user1",
+		ClusterQueue: "default",
+		Resources: map[string]QuotaValues{
+			"cpu":    {Max: 1000, Used: 500},
+			"memory": {Max: 2000, Used: 1000},
+		},
+		Volumes: &VolumeQuotaResponse{
+			Disk:           VolumeQuotaValues{Max: "100Gi", Used: "50Gi"},
+			Volumes:        VolumeQuotaValues{Max: "10", Used: "5"},
+			MaxDiskperVolume: "50Gi",
+			MinDiskperVolume: "1Gi",
+		},
+	}
+
+	if response.UserID != "user1" {
+		t.Errorf("Expected UserID = user1, got %s", response.UserID)
+	}
+	if response.ClusterQueue != "default" {
+		t.Errorf("Expected ClusterQueue = default, got %s", response.ClusterQueue)
+	}
+	if len(response.Resources) != 2 {
+		t.Errorf("Expected 2 resources, got %d", len(response.Resources))
+	}
+	if response.Volumes == nil {
+		t.Error("Expected Volumes to be set")
+	}
+	if response.Volumes.Disk.Max != "100Gi" {
+		t.Errorf("Expected Disk.Max = 100Gi, got %s", response.Volumes.Disk.Max)
+	}
+}
+
+func TestQuotaValues(t *testing.T) {
+	qv := QuotaValues{
+		Max:  1000,
+		Used: 500,
+	}
+
+	if qv.Max != 1000 {
+		t.Errorf("Expected Max = 1000, got %d", qv.Max)
+	}
+	if qv.Used != 500 {
+		t.Errorf("Expected Used = 500, got %d", qv.Used)
+	}
+}
+
+func TestVolumeQuotaResponse(t *testing.T) {
+	vqr := VolumeQuotaResponse{
+		Disk:           VolumeQuotaValues{Max: "100Gi", Used: "50Gi"},
+		Volumes:        VolumeQuotaValues{Max: "10", Used: "5"},
+		MaxDiskperVolume: "50Gi",
+		MinDiskperVolume: "1Gi",
+	}
+
+	if vqr.Disk.Max != "100Gi" {
+		t.Errorf("Expected Disk.Max = 100Gi, got %s", vqr.Disk.Max)
+	}
+	if vqr.Volumes.Max != "10" {
+		t.Errorf("Expected Volumes.Max = 10, got %s", vqr.Volumes.Max)
+	}
+	if vqr.MaxDiskperVolume != "50Gi" {
+		t.Errorf("Expected MaxDiskperVolume = 50Gi, got %s", vqr.MaxDiskperVolume)
+	}
+	if vqr.MinDiskperVolume != "1Gi" {
+		t.Errorf("Expected MinDiskperVolume = 1Gi, got %s", vqr.MinDiskperVolume)
+	}
+}
+
+func TestVolumeQuotaValues(t *testing.T) {
+	vqv := VolumeQuotaValues{
+		Max:  "100Gi",
+		Used: "50Gi",
+	}
+
+	if vqv.Max != "100Gi" {
+		t.Errorf("Expected Max = 100Gi, got %s", vqv.Max)
+	}
+	if vqv.Used != "50Gi" {
+		t.Errorf("Expected Used = 50Gi, got %s", vqv.Used)
+	}
+}
+
+func TestQuotaUpdateRequest(t *testing.T) {
+	req := QuotaUpdateRequest{
+		CPU:    "1000m",
+		Memory: "2Gi",
+		Volumes: &VolumeQuotaUpdate{
+			Disk:           "100Gi",
+			Volumes:        "10",
+			MaxDiskperVolume: "50Gi",
+			MinDiskperVolume: "1Gi",
+		},
+	}
+
+	if req.CPU != "1000m" {
+		t.Errorf("Expected CPU = 1000m, got %s", req.CPU)
+	}
+	if req.Memory != "2Gi" {
+		t.Errorf("Expected Memory = 2Gi, got %s", req.Memory)
+	}
+	if req.Volumes == nil {
+		t.Error("Expected Volumes to be set")
+	}
+	if req.Volumes.Disk != "100Gi" {
+		t.Errorf("Expected Volumes.Disk = 100Gi, got %s", req.Volumes.Disk)
+	}
+}
+
+func TestVolumeQuotaUpdate(t *testing.T) {
+	vqu := VolumeQuotaUpdate{
+		Disk:            "100Gi",
+		Volumes:         "10",
+		MaxDiskperVolume: "50Gi",
+		MinDiskperVolume: "1Gi",
+	}
+
+	if vqu.Disk != "100Gi" {
+		t.Errorf("Expected Disk = 100Gi, got %s", vqu.Disk)
+	}
+	if vqu.Volumes != "10" {
+		t.Errorf("Expected Volumes = 10, got %s", vqu.Volumes)
+	}
+	if vqu.MaxDiskperVolume != "50Gi" {
+		t.Errorf("Expected MaxDiskperVolume = 50Gi, got %s", vqu.MaxDiskperVolume)
+	}
+	if vqu.MinDiskperVolume != "1Gi" {
+		t.Errorf("Expected MinDiskperVolume = 1Gi, got %s", vqu.MinDiskperVolume)
+	}
+}

--- a/pkg/types/volume_test.go
+++ b/pkg/types/volume_test.go
@@ -1,0 +1,164 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestVolumeConstants(t *testing.T) {
+	if VolumeCreationModeService != "service" {
+		t.Errorf("Expected VolumeCreationModeService = service, got %s", VolumeCreationModeService)
+	}
+	if VolumeCreationModeAPI != "api" {
+		t.Errorf("Expected VolumeCreationModeAPI = api, got %s", VolumeCreationModeAPI)
+	}
+	if VolumeLifecycleDelete != "delete" {
+		t.Errorf("Expected VolumeLifecycleDelete = delete, got %s", VolumeLifecycleDelete)
+	}
+	if VolumeLifecycleRetain != "retain" {
+		t.Errorf("Expected VolumeLifecycleRetain = retain, got %s", VolumeLifecycleRetain)
+	}
+}
+
+func TestVolumePhaseConstants(t *testing.T) {
+	if VolumePhasePending != "pending" {
+		t.Errorf("Expected VolumePhasePending = pending, got %s", VolumePhasePending)
+	}
+	if VolumePhaseReady != "ready" {
+		t.Errorf("Expected VolumePhaseReady = ready, got %s", VolumePhaseReady)
+	}
+	if VolumePhaseInUse != "in_use" {
+		t.Errorf("Expected VolumePhaseInUse = in_use, got %s", VolumePhaseInUse)
+	}
+	if VolumePhaseError != "error" {
+		t.Errorf("Expected VolumePhaseError = error, got %s", VolumePhaseError)
+	}
+	if VolumePhaseDeleting != "deleting" {
+		t.Errorf("Expected VolumePhaseDeleting = deleting, got %s", VolumePhaseDeleting)
+	}
+	if VolumePhaseDeleted != "deleted" {
+		t.Errorf("Expected VolumePhaseDeleted = deleted, got %s", VolumePhaseDeleted)
+	}
+}
+
+func TestVolumeLimits(t *testing.T) {
+	limits := VolumeLimits{
+		DiskAvailable:    "100Gi",
+		MaxVolumes:       "10",
+		MaxDiskperVolume: "50Gi",
+		MinDiskperVolume: "1Gi",
+	}
+
+	if limits.DiskAvailable != "100Gi" {
+		t.Errorf("Expected DiskAvailable = 100Gi, got %s", limits.DiskAvailable)
+	}
+	if limits.MaxVolumes != "10" {
+		t.Errorf("Expected MaxVolumes = 10, got %s", limits.MaxVolumes)
+	}
+	if limits.MaxDiskperVolume != "50Gi" {
+		t.Errorf("Expected MaxDiskperVolume = 50Gi, got %s", limits.MaxDiskperVolume)
+	}
+	if limits.MinDiskperVolume != "1Gi" {
+		t.Errorf("Expected MinDiskperVolume = 1Gi, got %s", limits.MinDiskperVolume)
+	}
+}
+
+func TestManagedVolume(t *testing.T) {
+	vol := ManagedVolume{
+		Name:             "test-volume",
+		Namespace:        "default",
+		PVCName:          "pvc-test-volume",
+		Size:             "10Gi",
+		OwnerUser:        "user1",
+		CreatedByService: "test-service",
+		CreationMode:    VolumeCreationModeService,
+		LifecyclePolicy: VolumeLifecycleRetain,
+		Attachments: []VolumeAttachmentReference{
+			{ServiceName: "svc1", MountPath: "/data"},
+		},
+		Status: VolumeStatus{
+			Phase:           VolumePhaseReady,
+			Message:         "Volume is ready",
+			AttachmentCount: 1,
+		},
+	}
+
+	if vol.Name != "test-volume" {
+		t.Errorf("Expected Name = test-volume, got %s", vol.Name)
+	}
+	if vol.Namespace != "default" {
+		t.Errorf("Expected Namespace = default, got %s", vol.Namespace)
+	}
+	if vol.PVCName != "pvc-test-volume" {
+		t.Errorf("Expected PVCName = pvc-test-volume, got %s", vol.PVCName)
+	}
+	if vol.Size != "10Gi" {
+		t.Errorf("Expected Size = 10Gi, got %s", vol.Size)
+	}
+	if vol.OwnerUser != "user1" {
+		t.Errorf("Expected OwnerUser = user1, got %s", vol.OwnerUser)
+	}
+	if vol.CreatedByService != "test-service" {
+		t.Errorf("Expected CreatedByService = test-service, got %s", vol.CreatedByService)
+	}
+	if vol.CreationMode != VolumeCreationModeService {
+		t.Errorf("Expected CreationMode = service, got %s", vol.CreationMode)
+	}
+	if vol.LifecyclePolicy != VolumeLifecycleRetain {
+		t.Errorf("Expected LifecyclePolicy = retain, got %s", vol.LifecyclePolicy)
+	}
+	if len(vol.Attachments) != 1 {
+		t.Errorf("Expected 1 attachment, got %d", len(vol.Attachments))
+	}
+	if vol.Status.Phase != VolumePhaseReady {
+		t.Errorf("Expected Status.Phase = ready, got %s", vol.Status.Phase)
+	}
+	if vol.Status.AttachmentCount != 1 {
+		t.Errorf("Expected Status.AttachmentCount = 1, got %d", vol.Status.AttachmentCount)
+	}
+}
+
+func TestManagedVolumeCreateRequest(t *testing.T) {
+	req := ManagedVolumeCreateRequest{
+		Name: "my-volume",
+		Size: "10Gi",
+	}
+
+	if req.Name != "my-volume" {
+		t.Errorf("Expected Name = my-volume, got %s", req.Name)
+	}
+	if req.Size != "10Gi" {
+		t.Errorf("Expected Size = 10Gi, got %s", req.Size)
+	}
+}
+
+func TestVolumeAttachmentReference(t *testing.T) {
+	ref := VolumeAttachmentReference{
+		ServiceName: "test-service",
+		MountPath:   "/data",
+	}
+
+	if ref.ServiceName != "test-service" {
+		t.Errorf("Expected ServiceName = test-service, got %s", ref.ServiceName)
+	}
+	if ref.MountPath != "/data" {
+		t.Errorf("Expected MountPath = /data, got %s", ref.MountPath)
+	}
+}
+
+func TestVolumeStatus(t *testing.T) {
+	status := VolumeStatus{
+		Phase:           VolumePhaseReady,
+		Message:         "Volume is ready",
+		AttachmentCount: 1,
+	}
+
+	if status.Phase != VolumePhaseReady {
+		t.Errorf("Expected Phase = ready, got %s", status.Phase)
+	}
+	if status.Message != "Volume is ready" {
+		t.Errorf("Expected Message = Volume is ready, got %s", status.Message)
+	}
+	if status.AttachmentCount != 1 {
+		t.Errorf("Expected AttachmentCount = 1, got %d", status.AttachmentCount)
+	}
+}

--- a/pkg/utils/auth/oidc.go
+++ b/pkg/utils/auth/oidc.go
@@ -342,3 +342,12 @@ func (om *oidcManager) IsAuthorised(rawToken string) bool {
 
 	return false
 }
+
+func (om *oidcManager) UserInOneGroup(ui *userInfo, cfg *types.Config) bool {
+	for _, vo := range cfg.OIDCGroups {
+		if om.UserHasVO(ui, vo) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/node_select_test.go
+++ b/pkg/utils/node_select_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsControlPlaneNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels  map[string]string
+		expected bool
+	}{
+		{"Control plane label", map[string]string{"node-role.kubernetes.io/control-plane": ""}, true},
+		{"Master label", map[string]string{"node-role.kubernetes.io/master": ""}, true},
+		{"No labels", nil, false},
+		{"Worker only", map[string]string{"node-role.kubernetes.io/worker": ""}, false},
+		{"Empty labels", map[string]string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: tt.labels,
+				},
+			}
+			result := IsControlPlaneNode(node)
+			if result != tt.expected {
+				t.Errorf("IsControlPlaneNode() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSelectEligibleNodes(t *testing.T) {
+	t.Run("All worker nodes", func(t *testing.T) {
+		nodes := []v1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"node-role.kubernetes.io/worker": ""}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{"node-role.kubernetes.io/worker": ""}}},
+		}
+		result := SelectEligibleNodes(nodes)
+		if len(result) != 2 {
+			t.Errorf("Expected 2 nodes, got %d", len(result))
+		}
+	})
+
+	t.Run("Mixed nodes", func(t *testing.T) {
+		nodes := []v1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+		}
+		result := SelectEligibleNodes(nodes)
+		if len(result) != 2 {
+			t.Errorf("Expected 2 nodes, got %d", len(result))
+		}
+		for _, node := range result {
+			if node.Name == "node2" {
+				t.Error("Expected control-plane node to be excluded")
+			}
+		}
+	})
+
+	t.Run("Only control plane", func(t *testing.T) {
+		nodes := []v1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"node-role.kubernetes.io/master": ""}}},
+		}
+		result := SelectEligibleNodes(nodes)
+		if len(result) != 1 {
+			t.Errorf("Expected 1 node, got %d", len(result))
+		}
+	})
+
+	t.Run("Empty list", func(t *testing.T) {
+		nodes := []v1.Node{}
+		result := SelectEligibleNodes(nodes)
+		if len(result) != 0 {
+			t.Errorf("Expected 0 nodes, got %d", len(result))
+		}
+	})
+}

--- a/pkg/utils/volume_test.go
+++ b/pkg/utils/volume_test.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func TestValidateManagedVolumeCreateRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req    *types.ManagedVolumeCreateRequest
+		wantErr bool
+	}{
+		{"Valid request", &types.ManagedVolumeCreateRequest{Name: "my-volume", Size: "10Gi"}, false},
+		{"Empty name", &types.ManagedVolumeCreateRequest{Name: "", Size: "10Gi"}, true},
+		{"Empty size", &types.ManagedVolumeCreateRequest{Name: "my-volume", Size: ""}, true},
+		{"Invalid name with spaces", &types.ManagedVolumeCreateRequest{Name: "my volume", Size: "10Gi"}, true},
+		{"Invalid size", &types.ManagedVolumeCreateRequest{Name: "my-volume", Size: "invalid"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateManagedVolumeCreateRequest(tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateManagedVolumeCreateRequest() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateVolumeConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		volume *types.ServiceVolumeConfig
+		wantErr bool
+	}{
+		{"Valid config", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/data"}, false},
+		{"Nil volume", nil, false},
+		{"Empty mount path", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: ""}, true},
+		{"Both empty name and size", &types.ServiceVolumeConfig{Name: "", Size: "", MountPath: "/data"}, true},
+		{"Invalid lifecycle policy", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/data", LifecyclePolicy: "invalid"}, true},
+		{"Relative mount path", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "data"}, true},
+		{"Reserved config path", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/oscar/config"}, true},
+		{"Reserved volume path", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/oscar/bin"}, true},
+		{"Reserved path prefix", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/oscar/config/data"}, true},
+		{"Valid retain policy", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/data", LifecyclePolicy: types.VolumeLifecycleRetain}, false},
+		{"Valid delete policy", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/data", LifecyclePolicy: types.VolumeLifecycleDelete}, false},
+		{"Lifecycle without size", &types.ServiceVolumeConfig{Name: "", Size: "", MountPath: "/data", LifecyclePolicy: types.VolumeLifecycleRetain}, true},
+		{"Default lifecycle", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi", MountPath: "/data"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVolumeConfig("test-service", tt.volume)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateVolumeConfig() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidationName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"valid-volume", false},
+		{"my-volume", false},
+		{"vol123", false},
+		{"my volume", true},
+		{"my_volume", true},
+		{"-start", true},
+		{"end-", true},
+		{".start", true},
+		{"", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validationName(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validationName() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSize(t *testing.T) {
+	tests := []struct {
+		size   string
+		wantErr bool
+	}{
+		{"10Gi", false},
+		{"100Mi", false},
+		{"1Ti", false},
+		{"1", false},
+		{"0", true},
+		{"-1Gi", true},
+		{"invalid", true},
+		{"", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.size, func(t *testing.T) {
+			err := validateSize(tt.size)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSize() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestSameVolumeConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		a, b  *types.ServiceVolumeConfig
+		expected bool
+	}{
+		{"Both nil", nil, nil, true},
+		{"One nil a", nil, &types.ServiceVolumeConfig{Name: "vol"}, false},
+		{"One nil b", &types.ServiceVolumeConfig{Name: "vol"}, nil, false},
+		{"Equal configs", &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi"}, &types.ServiceVolumeConfig{Name: "vol", Size: "10Gi"}, true},
+		{"Different name", &types.ServiceVolumeConfig{Name: "vol1"}, &types.ServiceVolumeConfig{Name: "vol2"}, false},
+		{"Different size", &types.ServiceVolumeConfig{Size: "10Gi"}, &types.ServiceVolumeConfig{Size: "20Gi"}, false},
+		{"Different mount path", &types.ServiceVolumeConfig{MountPath: "/data"}, &types.ServiceVolumeConfig{MountPath: "/data2"}, false},
+		{"Different lifecycle", &types.ServiceVolumeConfig{LifecyclePolicy: types.VolumeLifecycleDelete}, &types.ServiceVolumeConfig{LifecyclePolicy: types.VolumeLifecycleRetain}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SameVolumeConfig(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("SameVolumeConfig() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#Fixed https://github.com/grycap/issue-tracker/issues/240
## Summary
- Added serviceNamespace parameter to SyncBackend.GetProxyDirector interface and all implementations
- Updated fake backend tests to use Services list instead of single Service field
- Created test files for files without tests:
  - handlers/service_access_test.go
  - backends/config_test.go
  - metrics/scoped_test.go, metrics/sources_test.go
  - types/metrics_test.go, types/quotas_test.go, types/volume_test.go
  - utils/node_select_test.go, utils/volume_test.go

## Testing
All tests pass: go test ./...