### PR TITLE
[codex] Fix update handler admin state isolation

### DIFF
--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -70,6 +70,7 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 			return
 		}
 		authHeader := c.GetHeader("Authorization")
+		isAdminUser := false
 		if len(strings.Split(authHeader, "Bearer")) == 1 {
 			isAdminUser = true
 			createLogger.Printf("[*] Updating service as admin user")

--- a/pkg/handlers/update_test.go
+++ b/pkg/handlers/update_test.go
@@ -165,7 +165,7 @@ func TestMakeUpdateHandlerForbiddenOwner(t *testing.T) {
 	})
 	r.PUT("/system/services", MakeUpdateHandler(cfg, back))
 
-	body := `{"name":"svc","token":"t","visibility":"private"}`
+	body := `{"name":"svc","image":"img","script":"echo","token":"t","visibility":"private"}`
 	req := httptest.NewRequest(http.MethodPut, "/system/services", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer token")
@@ -174,6 +174,36 @@ func TestMakeUpdateHandlerForbiddenOwner(t *testing.T) {
 
 	if resp.Code == http.StatusOK {
 		t.Fatalf("expected error status for different owner, got %d", resp.Code)
+	}
+}
+
+func TestMakeUpdateHandlerIgnoresStaleGlobalAdminState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{Name: "svc", Owner: "owner"}
+	cfg := &types.Config{MinIOProvider: &types.MinIOProvider{}}
+	isAdminUser = true
+	defer func() { isAdminUser = false }()
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("uidOrigin", "other")
+		c.Next()
+	})
+	r.PUT("/system/services", MakeUpdateHandler(cfg, back))
+
+	body := `{"name":"svc","image":"img","script":"echo","token":"t","visibility":"private"}`
+	req := httptest.NewRequest(http.MethodPut, "/system/services", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer token")
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for different owner despite stale admin state, got %d", resp.Code)
+	}
+	if back.UpdatedService != nil {
+		t.Fatalf("expected backend not to update service, got %+v", back.UpdatedService)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a security issue in the service update handler where admin detection depended on the package-level `isAdminUser` variable shared with the create handler.

The update handler now uses a request-local `isAdminUser` variable, so a previous Basic Auth/admin request cannot leave stale global state that affects a later OIDC `PUT /system/services` request.

## Root Cause

`pkg/handlers/create.go` defines `isAdminUser` as package-level mutable state. `MakeUpdateHandler` previously wrote to that same variable only when the request was not Bearer/OIDC. If the variable had already been set to `true`, an OIDC update request could skip the owner authorization block and be treated as admin for that request.

## Security Impact

Without this fix, stale global state could allow an authenticated OIDC user to update a service they do not own after an admin request had set `isAdminUser = true` in the same process.

## Changes

- Make admin detection in `MakeUpdateHandler` request-local.
- Add a regression test that seeds the stale global admin state and verifies a Bearer request from a different owner still receives `403 Forbidden` and does not update the backend.
- Tighten the existing forbidden-owner test payload so it reaches the ownership authorization path instead of failing earlier JSON validation.

## Validation

- `GOCACHE=/tmp/go-build go test ./pkg/handlers`
