### PR TITLE
[codex] Prevent OIDC config update mutations

### DIFF
--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -128,7 +128,7 @@ func MakeConfigUpdateHandler(cfg *types.Config, back kubernetes.Interface) gin.H
 		authHeader := c.GetHeader("Authorization")
 		if len(strings.Split(authHeader, "Bearer")) > 1 {
 			c.JSON(http.StatusUnauthorized, "")
-
+			return
 		}
 		configInput := types.ConfigForUser{}
 		if err := c.ShouldBindJSON(&configInput); err != nil {

--- a/pkg/handlers/config_test.go
+++ b/pkg/handlers/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grycap/oscar/v3/pkg/types"
 	"github.com/grycap/oscar/v3/pkg/utils/auth"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -169,4 +170,38 @@ func TestMakeConfigHandler(t *testing.T) {
 			t.Fatalf("Unexpected response body: %s", w.Body.String())
 		}
 	})
+}
+
+func TestMakeConfigUpdateHandlerRejectsBearerWithoutMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &types.Config{
+		Namespace:            "oscar",
+		AdditionalConfigPath: "oscar-config",
+		MinIOProvider:        &types.MinIOProvider{},
+	}
+	kubeClientset := testclient.NewSimpleClientset()
+
+	router := gin.New()
+	router.PUT("/config", MakeConfigUpdateHandler(cfg, kubeClientset))
+
+	body := `{"allowed_image_repositories":["registry.example.com/"]}`
+	req := httptest.NewRequest(http.MethodPut, "/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status code 401, got %d", w.Code)
+	}
+
+	_, err := kubeClientset.CoreV1().ConfigMaps(cfg.Namespace).Get(
+		req.Context(),
+		cfg.AdditionalConfigPath,
+		metav1.GetOptions{},
+	)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected config map not to be created, got err=%v", err)
+	}
 }


### PR DESCRIPTION
## Summary

This PR fixes an authorization bug in `PUT /system/config`: Bearer/OIDC requests were answered with `401 Unauthorized`, but the handler continued executing and could still create or update the OSCAR configuration ConfigMap.

The handler now returns immediately after rejecting Bearer requests, preserving the intended Basic Auth-only behavior for configuration updates.

## Root Cause

`MakeConfigUpdateHandler` wrote the unauthorized response for Bearer requests but did not stop the request flow. The remaining code still parsed the request body and performed ConfigMap create/update operations through the Kubernetes client.

## Security Impact

Without this fix, an authenticated OIDC user could mutate `allowed_image_repositories` even though the endpoint advertised and attempted to enforce Basic Auth-only access.

## Changes

- Add an explicit `return` after the Bearer/OIDC unauthorized response in `MakeConfigUpdateHandler`.
- Add a regression test that sends a Bearer `PUT /config` request and verifies both the `401 Unauthorized` response and that no ConfigMap is created.

## Validation

- `GOCACHE=/tmp/go-build go test ./pkg/handlers -run 'TestMakeConfig'`
- `GOCACHE=/tmp/go-build go test ./pkg/handlers`

Note: the full handlers package test suite requires local `httptest` listeners, so it was run with elevated local-network permissions in the Codex sandbox.