### PR TITLE
Fix kind deployment readiness wait

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -331,25 +331,24 @@ checkOSCARDeploy(){
     creation_timeout=120
     readiness_timeout=600
     start=$(date +%s)
-    echo -e "\n[*] Waiting for OSCAR pods to be scheduled ..."
+    echo -e "\n[*] Waiting for OSCAR deployment to be created ..."
     while true; do
-        pod_info=$(kubectl get pods -n oscar -l app=oscar --no-headers 2>/dev/null)
-        if [ -n "$pod_info" ]; then
-            pod_count=$(echo "$pod_info" | wc -l | tr -d ' ')
-            echo -e "\n[*] Detected $pod_count OSCAR pod(s). Waiting for them to become ready (timeout ${readiness_timeout}s) ..."
+        if kubectl get deployment -n oscar oscar >/dev/null 2>&1; then
+            echo -e "\n[*] OSCAR deployment detected. Waiting for rollout to complete (timeout ${readiness_timeout}s) ..."
             break
         fi
         actual=$(date +%s)
         if [ $((actual - start)) -gt $creation_timeout ]; then
-            echo -e "\n$RED[!]$END_COLOR Error: OSCAR pods were not created after ${creation_timeout}s."
-            kubectl get pods -n oscar
+            echo -e "\n$RED[!]$END_COLOR Error: OSCAR deployment was not created after ${creation_timeout}s."
+            kubectl get deployment -n oscar
             exit 1
         fi
         sleep 5
     done
 
-    if ! kubectl wait --namespace oscar --for=condition=Ready pod -l app=oscar --timeout="${readiness_timeout}s"; then
-        echo -e "\n$RED[!]$END_COLOR Error: OSCAR pods did not become ready after ${readiness_timeout}s."
+    if ! kubectl -n oscar rollout status deployment/oscar --timeout="${readiness_timeout}s"; then
+        echo -e "\n$RED[!]$END_COLOR Error: OSCAR deployment rollout did not complete after ${readiness_timeout}s."
+        kubectl get deployment -n oscar oscar
         kubectl get pods -n oscar
         failing_pods=$(kubectl get pods -n oscar -l app=oscar --no-headers | awk '{
             split($2, ready, "/");


### PR DESCRIPTION
## Summary

This fixes the local kind deployment flow so it waits for the OSCAR Deployment rollout instead of waiting directly on every pod matching `app=oscar`.

## Root Cause

`kind-deploy.sh` previously used `kubectl wait` against pods selected by `app=oscar`. During image switches or rollout transitions, that selector can include transient or old pods, which may leave the script waiting until the 600 second timeout even when the `Deployment/oscar` has already rolled out successfully.

## Changes

- Wait for the `oscar` Deployment object to be created before checking readiness.
- Use `kubectl -n oscar rollout status deployment/oscar` as the readiness gate.
- Keep the existing diagnostic output for pods and namespace events when the rollout fails.

## Validation

- `bash -n deploy/kind-deploy.sh`
- `git diff --check -- deploy/kind-deploy.sh`
- `kubectl -n oscar rollout status deployment/oscar --timeout=10s`
- Manual local kind deployment was tested successfully by Gonzalo.