### PR TITLE
Add lifecycle actions for exposed services

### DIFF
--- a/docs/deployment-visibility.md
+++ b/docs/deployment-visibility.md
@@ -21,3 +21,5 @@ service-access rules, return `unavailable` when OSCAR cannot inspect a current
 runtime representation, and keep deployment evidence separate from job
 execution logs under `/system/logs/...`.
 
+For exposed services, a Deployment scaled to zero replicas is reported as
+`stopped`.

--- a/docs/exposed-services.md
+++ b/docs/exposed-services.md
@@ -142,3 +142,22 @@ Two active pods of the deployment will be shown with the command `kubectl get po
 oscar-svc            nginx-dlp-6b9ddddbd7-cm6c9                         1/1     Running     0             2m1s
 oscar-svc            nginx-dlp-6b9ddddbd7-f4ml6                         1/1     Running     0             2m1s
 ```
+
+## Lifecycle operations
+
+Exposed services can be stopped, started, and restarted without deleting the
+OSCAR service definition:
+
+- `POST /system/services/{serviceName}/stop`
+- `POST /system/services/{serviceName}/start`
+- `POST /system/services/{serviceName}/restart`
+
+`stop` scales the exposed service Deployment to zero replicas and suspends its
+autoscaler so it does not immediately create pods again. `start` restores the
+previous replica count, or the exposed service `min_scale` when there is no
+stored previous value, and recreates the autoscaler if needed. `restart`
+performs a rolling pod restart by updating the Deployment pod template.
+
+These operations only apply to services with an `expose` section. They preserve
+the service definition, route, Kubernetes Service, and mounted persistent
+volumes, but they do not preserve in-memory process state inside the old pods.

--- a/main.go
+++ b/main.go
@@ -126,6 +126,9 @@ func main() {
 	system.GET("/services/:serviceName", handlers.MakeReadHandler(back, kubeClientset, cfg))
 	system.GET("/services/:serviceName/deployment", handlers.MakeGetDeploymentStatusHandler(back, kubeClientset, cfg))
 	system.GET("/services/:serviceName/deployment/logs", handlers.MakeGetDeploymentLogsHandler(back, kubeClientset, cfg))
+	system.POST("/services/:serviceName/stop", handlers.MakeStopExposedServiceHandler(back, kubeClientset, cfg))
+	system.POST("/services/:serviceName/start", handlers.MakeStartExposedServiceHandler(back, kubeClientset, cfg))
+	system.POST("/services/:serviceName/restart", handlers.MakeRestartExposedServiceHandler(back, kubeClientset, cfg))
 	system.PUT("/services", handlers.MakeUpdateHandler(cfg, back))
 	system.DELETE("/services/:serviceName", handlers.MakeDeleteHandler(cfg, back))
 

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -258,6 +258,23 @@ func upsertRoute(service types.Service, namespace string, kubeClientset kubernet
 	return createIngress(service, namespace, kubeClientset, cfg)
 }
 
+// EnsureExposeAuthResources recreates or refreshes authentication resources for an exposed service.
+func EnsureExposeAuthResources(service types.Service, namespace string, kubeClientset kubernetes.Interface, cfg *types.Config) error {
+	if !service.Expose.SetAuth {
+		return nil
+	}
+	if getRouteKind(cfg) == routeKindHTTPRoute {
+		if err := upsertTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
+			return err
+		}
+		return upsertTraefikAuthMiddleware(service, namespace)
+	}
+	if existsSecret(service.Name, namespace, kubeClientset, cfg) {
+		return updateSecret(service, namespace, kubeClientset, cfg)
+	}
+	return createSecret(service, namespace, kubeClientset, cfg)
+}
+
 func deleteRouteResources(serviceName string, namespace string, kubeClientset kubernetes.Interface, cfg *types.Config) error {
 	if existsIngress(serviceName, namespace, kubeClientset) {
 		if err := deleteIngress(getIngressName(serviceName), namespace, kubeClientset, cfg); err != nil {

--- a/pkg/handlers/deployment.go
+++ b/pkg/handlers/deployment.go
@@ -280,7 +280,7 @@ func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.D
 	state := types.DeploymentStatePending
 	switch {
 	case desired == 0:
-		state = types.DeploymentStatePending
+		state = types.DeploymentStateStopped
 	case available >= desired:
 		state = types.DeploymentStateReady
 	case available > 0:
@@ -292,6 +292,9 @@ func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.D
 	}
 
 	reason, transitioned := latestDeploymentCondition(deployment.Status.Conditions)
+	if state == types.DeploymentStateStopped {
+		reason = "Deployment is stopped."
+	}
 	if reason == "" && state == types.DeploymentStateDegraded {
 		reason = fmt.Sprintf("%d of %d instances are affected.", affected, desired)
 	}

--- a/pkg/handlers/lifecycle.go
+++ b/pkg/handlers/lifecycle.go
@@ -1,0 +1,309 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/backends"
+	"github.com/grycap/oscar/v3/pkg/backends/resources"
+	"github.com/grycap/oscar/v3/pkg/types"
+	"github.com/grycap/oscar/v3/pkg/utils/auth"
+	appsv1 "k8s.io/api/apps/v1"
+	autosv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	lifecyclePreviousReplicasAnnotation = "oscar.grycap.io/previous-replicas"
+	lifecycleStoppedAnnotation          = "oscar.grycap.io/stopped"
+	lifecycleRestartedAtAnnotation      = "oscar.grycap.io/restarted-at"
+)
+
+// MakeStopExposedServiceHandler godoc
+// @Summary Stop exposed service
+// @Description Stop an exposed service by scaling its Deployment to zero replicas.
+// @Tags services
+// @Produce json
+// @Param serviceName path string true "Service name"
+// @Success 200 {object} types.ServiceDeploymentStatus
+// @Failure 400 {string} string "Bad Request"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
+// @Failure 404 {string} string "Not Found"
+// @Failure 500 {string} string "Internal Server Error"
+// @Security BasicAuth
+// @Security BearerAuth
+// @Router /system/services/{serviceName}/stop [post]
+func MakeStopExposedServiceHandler(back types.ServerlessBackend, kubeClientset kubernetes.Interface, cfg *types.Config) gin.HandlerFunc {
+	return makeExposedServiceLifecycleHandler(back, kubeClientset, cfg, stopExposedService)
+}
+
+// MakeStartExposedServiceHandler godoc
+// @Summary Start exposed service
+// @Description Start a stopped exposed service by restoring its desired replicas.
+// @Tags services
+// @Produce json
+// @Param serviceName path string true "Service name"
+// @Success 200 {object} types.ServiceDeploymentStatus
+// @Failure 400 {string} string "Bad Request"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
+// @Failure 404 {string} string "Not Found"
+// @Failure 500 {string} string "Internal Server Error"
+// @Security BasicAuth
+// @Security BearerAuth
+// @Router /system/services/{serviceName}/start [post]
+func MakeStartExposedServiceHandler(back types.ServerlessBackend, kubeClientset kubernetes.Interface, cfg *types.Config) gin.HandlerFunc {
+	return makeExposedServiceLifecycleHandler(back, kubeClientset, cfg, startExposedService)
+}
+
+// MakeRestartExposedServiceHandler godoc
+// @Summary Restart exposed service
+// @Description Restart an exposed service by rolling its Deployment pods.
+// @Tags services
+// @Produce json
+// @Param serviceName path string true "Service name"
+// @Success 200 {object} types.ServiceDeploymentStatus
+// @Failure 400 {string} string "Bad Request"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
+// @Failure 404 {string} string "Not Found"
+// @Failure 500 {string} string "Internal Server Error"
+// @Security BasicAuth
+// @Security BearerAuth
+// @Router /system/services/{serviceName}/restart [post]
+func MakeRestartExposedServiceHandler(back types.ServerlessBackend, kubeClientset kubernetes.Interface, cfg *types.Config) gin.HandlerFunc {
+	return makeExposedServiceLifecycleHandler(back, kubeClientset, cfg, restartExposedService)
+}
+
+type exposedServiceLifecycleAction func(context.Context, kubernetes.Interface, *types.Service, *types.Config) error
+
+func makeExposedServiceLifecycleHandler(back types.ServerlessBackend, kubeClientset kubernetes.Interface, cfg *types.Config, action exposedServiceLifecycleAction) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		serviceName, ok := validateServiceName(c, c.Param("serviceName"))
+		if !ok {
+			c.String(http.StatusBadRequest, serviceName)
+			return
+		}
+		service, ok := getAuthorizedServiceOwner(c, back, serviceName)
+		if !ok {
+			return
+		}
+		if service.Expose.APIPort == 0 {
+			c.String(http.StatusBadRequest, "service %q is not exposed", service.Name)
+			return
+		}
+		service.Namespace = resolveLifecycleServiceNamespace(service, cfg)
+
+		if err := action(c.Request.Context(), kubeClientset, service, cfg); err != nil {
+			if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
+				c.Status(http.StatusNotFound)
+			} else {
+				c.String(http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+
+		status, err := inspectExposedDeploymentRuntimeStatusOnly(kubeClientset, service)
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.JSON(http.StatusOK, status)
+	}
+}
+
+func getAuthorizedServiceOwner(c *gin.Context, back types.ServerlessBackend, serviceName string) (*types.Service, bool) {
+	service, err := back.ReadService("", serviceName)
+	if err != nil {
+		if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
+			c.Status(http.StatusNotFound)
+		} else {
+			c.String(http.StatusInternalServerError, err.Error())
+		}
+		return nil, false
+	}
+	if !isBearerRequest(c) {
+		return service, true
+	}
+
+	uid, err := auth.GetUIDFromContext(c)
+	if err != nil {
+		c.String(http.StatusUnauthorized, err.Error())
+		return nil, false
+	}
+	if service.Owner != uid {
+		c.String(http.StatusForbidden, "User %s doesn't have permission to manage this service", uid)
+		return nil, false
+	}
+	return service, true
+}
+
+func stopExposedService(ctx context.Context, kubeClientset kubernetes.Interface, service *types.Service, cfg *types.Config) error {
+	deployment, err := backends.GetExposedServiceDeployment(kubeClientset, service.Namespace, service.Name)
+	if err != nil {
+		return err
+	}
+
+	replicas := currentDeploymentReplicas(deployment)
+	if replicas > 0 {
+		setDeploymentAnnotation(deployment, lifecyclePreviousReplicasAnnotation, strconv.FormatInt(int64(replicas), 10))
+	}
+	setDeploymentAnnotation(deployment, lifecycleStoppedAnnotation, "true")
+
+	zero := int32(0)
+	deployment.Spec.Replicas = &zero
+	if _, err := kubeClientset.AppsV1().Deployments(service.Namespace).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return deleteExposedServiceHPA(ctx, kubeClientset, service.Namespace, service.Name)
+}
+
+func startExposedService(ctx context.Context, kubeClientset kubernetes.Interface, service *types.Service, cfg *types.Config) error {
+	deployment, err := backends.GetExposedServiceDeployment(kubeClientset, service.Namespace, service.Name)
+	if err != nil {
+		return err
+	}
+
+	replicas := desiredStartReplicas(service, deployment)
+	deployment.Spec.Replicas = &replicas
+	setDeploymentAnnotation(deployment, lifecycleStoppedAnnotation, "false")
+	if _, err := kubeClientset.AppsV1().Deployments(service.Namespace).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	if err := resources.EnsureExposeAuthResources(*service, service.Namespace, kubeClientset, cfg); err != nil {
+		return err
+	}
+
+	return ensureExposedServiceHPA(ctx, kubeClientset, service.Namespace, service)
+}
+
+func restartExposedService(ctx context.Context, kubeClientset kubernetes.Interface, service *types.Service, cfg *types.Config) error {
+	deployment, err := backends.GetExposedServiceDeployment(kubeClientset, service.Namespace, service.Name)
+	if err != nil {
+		return err
+	}
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	deployment.Spec.Template.Annotations[lifecycleRestartedAtAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+	_, err = kubeClientset.AppsV1().Deployments(service.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	return err
+}
+
+func resolveLifecycleServiceNamespace(service *types.Service, cfg *types.Config) string {
+	if service.Namespace != "" {
+		return service.Namespace
+	}
+	if cfg != nil {
+		return cfg.ServicesNamespace
+	}
+	return ""
+}
+
+func currentDeploymentReplicas(deployment *appsv1.Deployment) int32 {
+	if deployment.Spec.Replicas != nil {
+		return *deployment.Spec.Replicas
+	}
+	return 0
+}
+
+func desiredStartReplicas(service *types.Service, deployment metav1.Object) int32 {
+	if annotations := deployment.GetAnnotations(); annotations != nil {
+		if value, ok := annotations[lifecyclePreviousReplicasAnnotation]; ok {
+			if replicas, err := strconv.ParseInt(value, 10, 32); err == nil && replicas > 0 {
+				return int32(replicas)
+			}
+		}
+	}
+	if service.Expose.MinScale > 0 {
+		return service.Expose.MinScale
+	}
+	return 1
+}
+
+func setDeploymentAnnotation(deployment metav1.Object, key, value string) {
+	annotations := deployment.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[key] = value
+	deployment.SetAnnotations(annotations)
+}
+
+func deleteExposedServiceHPA(ctx context.Context, kubeClientset kubernetes.Interface, namespace, serviceName string) error {
+	hpas, err := kubeClientset.AutoscalingV1().HorizontalPodAutoscalers(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	targetName := serviceName + "-dpl"
+	for _, hpa := range hpas.Items {
+		if hpa.Spec.ScaleTargetRef.Kind == "Deployment" && hpa.Spec.ScaleTargetRef.Name == targetName {
+			err := kubeClientset.AutoscalingV1().HorizontalPodAutoscalers(namespace).Delete(ctx, hpa.Name, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ensureExposedServiceHPA(ctx context.Context, kubeClientset kubernetes.Interface, namespace string, service *types.Service) error {
+	hpas, err := kubeClientset.AutoscalingV1().HorizontalPodAutoscalers(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	targetName := service.Name + "-dpl"
+	for _, hpa := range hpas.Items {
+		if hpa.Spec.ScaleTargetRef.Kind == "Deployment" && hpa.Spec.ScaleTargetRef.Name == targetName {
+			return nil
+		}
+	}
+
+	hpa := &autosv1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-hpa", service.Name),
+			Namespace: namespace,
+		},
+		Spec: autosv1.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autosv1.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				Name:       targetName,
+				APIVersion: "apps/v1",
+			},
+			MinReplicas:                    &service.Expose.MinScale,
+			MaxReplicas:                    service.Expose.MaxScale,
+			TargetCPUUtilizationPercentage: &service.Expose.CpuThreshold,
+		},
+	}
+	_, err = kubeClientset.AutoscalingV1().HorizontalPodAutoscalers(namespace).Create(ctx, hpa, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/handlers/lifecycle_test.go
+++ b/pkg/handlers/lifecycle_test.go
@@ -1,0 +1,238 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v3/pkg/backends"
+	"github.com/grycap/oscar/v3/pkg/types"
+	appsv1 "k8s.io/api/apps/v1"
+	autosv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestMakeStopExposedServiceHandlerScalesDeploymentToZero(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = exposedLifecycleTestService()
+
+	replicas := int32(3)
+	minReplicas := int32(1)
+	kubeClientset := testclient.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-dpl",
+				Namespace: "ns",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: types.ContainerName}},
+					},
+				},
+			},
+		},
+		&autosv1.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-hpa",
+				Namespace: "ns",
+			},
+			Spec: autosv1.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autosv1.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "svc-dpl",
+				},
+				MinReplicas: &minReplicas,
+				MaxReplicas: 5,
+			},
+		},
+	)
+
+	r := gin.Default()
+	r.POST("/system/services/:serviceName/stop", MakeStopExposedServiceHandler(back, kubeClientset, &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/system/services/svc/stop", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var response types.ServiceDeploymentStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.State != types.DeploymentStateStopped {
+		t.Fatalf("expected stopped state, got %s", response.State)
+	}
+
+	deployment, err := kubeClientset.AppsV1().Deployments("ns").Get(t.Context(), "svc-dpl", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
+		t.Fatalf("expected replicas 0, got %v", deployment.Spec.Replicas)
+	}
+	if deployment.Annotations[lifecyclePreviousReplicasAnnotation] != "3" {
+		t.Fatalf("expected previous replicas annotation to be 3, got %q", deployment.Annotations[lifecyclePreviousReplicasAnnotation])
+	}
+	if _, err := kubeClientset.AutoscalingV1().HorizontalPodAutoscalers("ns").Get(t.Context(), "svc-hpa", metav1.GetOptions{}); err == nil {
+		t.Fatal("expected HPA to be deleted")
+	}
+}
+
+func TestMakeStartExposedServiceHandlerRestoresReplicasAndHPA(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = exposedLifecycleTestService()
+
+	replicas := int32(0)
+	kubeClientset := testclient.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-dpl",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				lifecyclePreviousReplicasAnnotation: "3",
+				lifecycleStoppedAnnotation:          "true",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: types.ContainerName}},
+				},
+			},
+		},
+	})
+
+	r := gin.Default()
+	r.POST("/system/services/:serviceName/start", MakeStartExposedServiceHandler(back, kubeClientset, &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/system/services/svc/start", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	deployment, err := kubeClientset.AppsV1().Deployments("ns").Get(t.Context(), "svc-dpl", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 3 {
+		t.Fatalf("expected replicas 3, got %v", deployment.Spec.Replicas)
+	}
+	if deployment.Annotations[lifecycleStoppedAnnotation] != "false" {
+		t.Fatalf("expected stopped annotation false, got %q", deployment.Annotations[lifecycleStoppedAnnotation])
+	}
+	hpa, err := kubeClientset.AutoscalingV1().HorizontalPodAutoscalers("ns").Get(t.Context(), "svc-hpa", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected HPA to be recreated: %v", err)
+	}
+	if hpa.Spec.MaxReplicas != 5 {
+		t.Fatalf("expected max replicas 5, got %d", hpa.Spec.MaxReplicas)
+	}
+	secret, err := kubeClientset.CoreV1().Secrets("ns").Get(t.Context(), "svc-auth-expose", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected auth secret to be recreated: %v", err)
+	}
+	if secret.StringData["auth"] == "" && len(secret.Data["auth"]) == 0 {
+		t.Fatal("expected auth secret to contain basic auth data")
+	}
+}
+
+func TestMakeRestartExposedServiceHandlerAnnotatesPodTemplate(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = exposedLifecycleTestService()
+
+	replicas := int32(1)
+	kubeClientset := testclient.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-dpl",
+			Namespace: "ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+	})
+
+	r := gin.Default()
+	r.POST("/system/services/:serviceName/restart", MakeRestartExposedServiceHandler(back, kubeClientset, &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/system/services/svc/restart", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	deployment, err := kubeClientset.AppsV1().Deployments("ns").Get(t.Context(), "svc-dpl", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	if deployment.Spec.Template.Annotations[lifecycleRestartedAtAnnotation] == "" {
+		t.Fatal("expected restart annotation on pod template")
+	}
+}
+
+func TestMakeStopExposedServiceHandlerRequiresOwnerForBearer(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = exposedLifecycleTestService()
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("uidOrigin", "other@example.org")
+		c.Next()
+	})
+	r.POST("/system/services/:serviceName/stop", MakeStopExposedServiceHandler(back, testclient.NewSimpleClientset(), &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/system/services/svc/stop", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMakeStopExposedServiceHandlerRejectsNonExposedService(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{
+		Name:      "svc",
+		Namespace: "ns",
+		Owner:     "owner@example.org",
+	}
+
+	r := gin.Default()
+	r.POST("/system/services/:serviceName/stop", MakeStopExposedServiceHandler(back, testclient.NewSimpleClientset(), &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/system/services/svc/stop", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func exposedLifecycleTestService() *types.Service {
+	return &types.Service{
+		Name:      "svc",
+		Namespace: "ns",
+		Owner:     "owner@example.org",
+		Token:     "service-token",
+		Expose: types.Expose{
+			APIPort:      8080,
+			MinScale:     1,
+			MaxScale:     5,
+			CpuThreshold: 80,
+			SetAuth:      true,
+		},
+	}
+}

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -23,6 +23,7 @@ const (
 	DeploymentStateReady       = "ready"
 	DeploymentStateDegraded    = "degraded"
 	DeploymentStateFailed      = "failed"
+	DeploymentStateStopped     = "stopped"
 	DeploymentStateUnavailable = "unavailable"
 
 	DeploymentResourceKindExposedService = "exposed_service"


### PR DESCRIPTION
## Summary
- Add stop, start, and restart endpoints for exposed OSCAR services.
- Stop scales the exposed Deployment to zero replicas and removes the HPA; start restores replicas, recreates auth resources when needed, and recreates the HPA; restart triggers a rolling pod restart.
- Report zero-replica exposed Deployments as `stopped` in deployment status and document the lifecycle behavior.

## Why
Exposed services such as notebooks need a lightweight lifecycle operation that preserves the OSCAR service definition, route, Kubernetes Service, and mounted persistent volumes while allowing the runtime pods to be stopped and started again.

## Validation
- `CGO_ENABLED=0 go test ./...`
- `git diff --check origin/devel..HEAD`