### PR TITLE
fix: restrict bucket deletion only to its owner and admin

### DIFF
--- a/pkg/handlers/buckets/delete_bucket.go
+++ b/pkg/handlers/buckets/delete_bucket.go
@@ -96,8 +96,17 @@ func MakeDeleteHandler(cfg *types.Config) gin.HandlerFunc {
 			c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating MinIO admin client: %v", err))
 			return
 		}
-		v := minIOAdminClient.GetCurrentResourceVisibility(utils.MinIOBucket{BucketName: bucketName, Owner: uid})
-		if (uid == types.DefaultOwner) || (v == utils.PUBLIC || minIOAdminClient.ResourceInPolicy(uid, bucketName)) {
+
+		var bucketOwner string = ""
+		metadata, metaErr := minIOAdminClient.GetTaggedMetadata(bucketName)
+		if metaErr == nil {
+			if owner := strings.TrimSpace(metadata["owner"]); owner != "" {
+				bucketOwner = owner
+			}
+		}
+
+		if (uid == types.DefaultOwner) || (bucketOwner == uid) {
+			v := minIOAdminClient.GetCurrentResourceVisibility(utils.MinIOBucket{BucketName: bucketName, Owner: uid})
 			err := handlers.DeleteMinIOBuckets(s3Client, minIOAdminClient, utils.MinIOBucket{
 				BucketName: bucketName,
 				Visibility: v,

--- a/pkg/handlers/buckets/delete_bucket_test.go
+++ b/pkg/handlers/buckets/delete_bucket_test.go
@@ -104,37 +104,77 @@ func TestMakeDeleteBucketHandlerUnauthorized(t *testing.T) {
 
 func TestMakeDeleteBucketHandlerDeletesWhenAuthorized(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	//testsupport.SkipIfCannotListen(t)
-	bucketNameTest := "alice"
-	//server := startS3Server(t, []string{bucketNameTest})
-	//defer server.Close()
+	bucketNameTest := "alice-bucket"
 	const listXML = `<?xml version="1.0" encoding="UTF-8"?>
-					<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-						<Owner>
-							<ID>owner</ID>
-							<DisplayName>owner</DisplayName>
-						</Owner>
-						<Buckets>
-							<Bucket>
-								<Name>alice</Name>
-								<CreationDate>2024-01-01T00:00:00Z</CreationDate>
-							</Bucket>
-						</Buckets>
-					</ListAllMyBucketsResult>`
+	<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<Owner>
+			<ID>owner</ID>
+			<DisplayName>owner</DisplayName>
+		</Owner>
+		<Buckets>
+			<Bucket>
+				<Name>alice-bucket</Name>
+				<CreationDate>2024-01-01T00:00:00Z</CreationDate>
+			</Bucket>
+		</Buckets>
+	</ListAllMyBucketsResult>`
+	const listObjectsXML = `<?xml version="1.0" encoding="UTF-8"?>
+	<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+		<Name>alice-bucket</Name>
+		<Prefix></Prefix>
+		<Marker></Marker>
+		<MaxKeys>1000</MaxKeys>
+		<IsTruncated>false</IsTruncated>
+	</ListBucketResult>`
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, hreq *http.Request) {
+		bucketPath := strings.TrimSuffix(hreq.URL.Path, "/")
+
+		if strings.Contains(hreq.URL.RawQuery, "location") && hreq.Method == http.MethodGet && bucketPath == "/"+bucketNameTest {
+			rw.Header().Set("Content-Type", "application/xml")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`))
+			return
+		}
+
+		if strings.Contains(hreq.URL.RawQuery, "tagging") && hreq.Method == http.MethodGet && bucketPath == "/"+bucketNameTest {
+			rw.Header().Set("Content-Type", "application/xml")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TagSet><Tag><Key>owner</Key><Value>alice</Value></Tag></TagSet></Tagging>`))
+			return
+		}
+
 		if hreq.URL.Path == "/" && hreq.Method == http.MethodGet {
 			rw.WriteHeader(http.StatusOK)
 			_, _ = rw.Write([]byte(listXML))
 			return
-		} else if strings.HasPrefix(hreq.URL.Path, "/minio/admin/v3/info-canned-policy") && hreq.Method == http.MethodGet {
-			rw.WriteHeader(http.StatusOK)
-			rw.Write([]byte(`{"PolicyName": "testpolicy", "Policy": {"Version": "version","Statement": [{"Resource": ["arn:aws:s3:::alice/*"]}]}}`))
-		} else {
-			rw.WriteHeader(http.StatusOK)
-			_, _ = rw.Write([]byte(`{"status": "success"}`))
 		}
+
+		if strings.HasPrefix(hreq.URL.Path, "/minio/admin/v3/info-canned-policy") && hreq.Method == http.MethodGet {
+			if hreq.URL.Query().Get("name") == "alice" {
+				rw.WriteHeader(http.StatusOK)
+				_, _ = rw.Write([]byte(`{"PolicyName": "alice", "Policy": {"Version": "version","Statement": [{"Resource": ["arn:aws:s3:::alice-bucket/*"]}]}}`))
+				return
+			}
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if bucketPath == "/"+bucketNameTest && hreq.Method == http.MethodGet {
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write([]byte(listObjectsXML))
+			return
+		}
+
+		if bucketPath == "/"+bucketNameTest && hreq.Method == http.MethodDelete {
+			rw.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte(`{"status": "success"}`))
 	}))
+	defer server.Close()
 
 	cfg := &types.Config{
 		Name: "oscar",
@@ -147,25 +187,37 @@ func TestMakeDeleteBucketHandlerDeletesWhenAuthorized(t *testing.T) {
 		},
 	}
 
-	router := gin.New()
-	router.Use(func(c *gin.Context) {
-		c.Set("uidOrigin", "alice")
-		c.Next()
-	})
-
-	router.DELETE("/system/buckets/:bucket", MakeDeleteHandler(cfg))
-	req := httptest.NewRequest(http.MethodDelete, "/system/buckets/"+bucketNameTest, nil)
-	req.Header.Set("Authorization", "Bearer token")
-
-	res := httptest.NewRecorder()
-	router.ServeHTTP(res, req)
-
-	if res.Code != http.StatusNoContent {
-		t.Fatalf("expected status %d, got %d", http.StatusNoContent, res.Code)
+	testCases := []struct {
+		name       string
+		uid        string
+		wantStatus int
+	}{
+		{name: "owner can delete", uid: "alice", wantStatus: http.StatusNoContent},
+		{name: "non owner is forbidden", uid: "bob", wantStatus: http.StatusForbidden},
+		{name: "cluster admin can delete", uid: types.DefaultOwner, wantStatus: http.StatusNoContent},
 	}
 
-	// Close the fake MinIO server
-	defer server.Close()
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("uidOrigin", tc.uid)
+				c.Next()
+			})
+			router.DELETE("/system/buckets/:bucket", MakeDeleteHandler(cfg))
+
+			req := httptest.NewRequest(http.MethodDelete, "/system/buckets/"+bucketNameTest, nil)
+			req.Header.Set("Authorization", "Bearer token")
+
+			res := httptest.NewRecorder()
+			router.ServeHTTP(res, req)
+
+			if res.Code != tc.wantStatus {
+				t.Fatalf("uid %q: expected status %d, got %d", tc.uid, tc.wantStatus, res.Code)
+			}
+		})
+	}
 }
 
 func startS3Server(t *testing.T, buckets []string) *httptest.Server {


### PR DESCRIPTION
Fixes https://github.com/grycap/issue-tracker/issues/374

## Proposed Changes

**Authorization improvements:**

* Updated the `MakeDeleteHandler` in `delete_bucket.go` to check the bucket's tagged metadata for an `owner` field, allowing deletion only if the requester is the bucket owner or the cluster admin (`types.DefaultOwner`).

**Test suite enhancements:**

* Refactored and expanded the test in `delete_bucket_test.go` to:
  - Use a more descriptive bucket name (`alice-bucket`) and update related test data. 
  - Mock S3 and MinIO admin server responses to include bucket tagging and policy endpoints, simulating realistic scenarios for ownership and policy checks.
  - Add table-driven test cases to verify that only the owner, a non-owner, and the cluster admin receive the correct authorization responses when attempting to delete a bucket.