### PR TITLE
fix: use stable kind control-plane endpoint

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -823,6 +823,9 @@ nodes:
 - role: control-plane
   kubeadmConfigPatches:
   - |
+    kind: ClusterConfiguration
+    controlPlaneEndpoint: "${CLUSTER_NAME}-control-plane:6443"
+  - |
     kind: InitConfiguration
     nodeRegistration:
       kubeletExtraArgs:
@@ -876,6 +879,9 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    controlPlaneEndpoint: "${CLUSTER_NAME}-control-plane:6443"
   - |
     kind: InitConfiguration
     nodeRegistration:


### PR DESCRIPTION
## What changed

This updates the generated kind cluster configuration in `deploy/kind-deploy.sh` to set `ClusterConfiguration.controlPlaneEndpoint` to the stable control-plane container DNS name:

```yaml
controlPlaneEndpoint: "${CLUSTER_NAME}-control-plane:6443"
```

The setting is added for both local-registry and default kind cluster configurations.

## Why

Local kind nodes run as Docker containers, and their internal Docker network IPs are not stable. After Docker Desktop or the kind network changes, the control-plane container can receive a different `172.x.x.x` address. If kubelet is configured with the old IP in `/etc/kubernetes/kubelet.conf`, it can no longer reach the API server and the node becomes `NotReady` even though the control-plane container and Kubernetes components are otherwise running.

Using the control-plane container DNS name gives kubeadm/kubelet a stable endpoint that survives Docker IP changes.

## Validation

- `git diff --check -- deploy/kind-deploy.sh`