### PR TITLE
Update kserve integration

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -334,26 +334,108 @@ checkIngressStatus(){
     echo -e "\n[$GREEN$CHECK$END_COLOR] ingress-controller pod running correctly"
 }
 
+checkTraefikStatus(){
+    timeout=500
+    echo -e "\n[*] Waiting for Traefik pod to be running ..."
+    sleep 5
+    start=$(date +%s)
+    while [ "$traefik_status" != "Running" ]; do
+        traefik_status=$(kubectl get pods -n traefik 2>/dev/null | awk '/traefik/ {print $3}' | head -1)
+        actual=$(date +%s)
+        if [ $((actual - start)) -gt $timeout ]; then
+            echo -e "\n$RED[!]$END_COLOR Error: Timeout: Traefik pod status: $traefik_status"
+            exit
+        fi
+        sleep 5
+    done
+    echo -e "\n[$GREEN$CHECK$END_COLOR] Traefik pod running correctly"
+}
+
+deployCertManager(){
+        echo -e "\n[*] Deploying cert-manager ..."
+        if ! kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml"; then
+                echo -e "$RED[!]$END_COLOR Failed to deploy cert-manager"
+                exit 1
+        fi
+
+        echo -e "\n[*] Waiting for cert-manager components to be ready ..."
+        if ! kubectl wait --namespace cert-manager --for=condition=Available deployment/cert-manager --timeout=300s; then
+                echo -e "$RED[!]$END_COLOR cert-manager deployment is not ready"
+                exit 1
+        fi
+}
+
+createTraefikGatewayCertificate(){
+        echo -e "\n[*] Creating self-signed certificate for Traefik Gateway ..."
+
+        if ! cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+    name: self-signed-issuer
+spec:
+    selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: self-signed-cert
+    namespace: traefik
+spec:
+    secretName: traefik-gateway-tls
+    commonName: localhost
+    dnsNames:
+        - localhost
+    ipAddresses:
+        - 127.0.0.1
+    issuerRef:
+        name: self-signed-issuer
+        kind: ClusterIssuer
+EOF
+        then
+                echo -e "$RED[!]$END_COLOR Failed to create cert-manager issuer/certificate for Traefik"
+                exit 1
+        fi
+
+        if ! kubectl wait --namespace traefik --for=condition=Ready certificate/self-signed-cert --timeout=180s; then
+                echo -e "$RED[!]$END_COLOR Traefik TLS certificate was not issued in time"
+                exit 1
+        fi
+}
+
 deployGatewayController(){
   if [ "$GATEWAY_CONTROLLER" == "ingress" ]; then
       echo -e "\n[*] Deploying NGINX Ingress ..."
       kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
       checkIngressStatus
   else
+      deployCertManager
+      kubectl create namespace traefik >/dev/null 2>&1 || true
+      createTraefikGatewayCertificate
+      echo -e "\n[*] Deploying Gateway API CRDs ..."
+      kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
       echo -e "\n[*] Installing Traefik Gateway ..."
-      kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
       helm repo add --force-update  traefik https://traefik.github.io/charts
-      helm install --namespace=traefik traefik traefik/traefik --wait --create-namespace \
+      helm install --namespace=traefik traefik traefik/traefik --create-namespace \
+        --version 39.0.9 \
         --set providers.kubernetesGateway.enabled=true \
         --set providers.kubernetesCRD.allowCrossNamespace=true \
         --set gateway.enabled=true \
         --set gateway.listeners.web.namespacePolicy.from=All \
+        --set gateway.listeners.websecure.port=8443 \
+        --set gateway.listeners.websecure.protocol=HTTPS \
+        --set gateway.listeners.websecure.certificateRefs[0].name=traefik-gateway-tls \
+        --set gateway.listeners.websecure.certificateRefs[0].kind=Secret \
+        --set gateway.listeners.websecure.namespacePolicy.from=All \
         --set service.type=NodePort \
         --set ports.web.nodePort=30080 \
         --set ports.websecure.nodePort=30443 \
-        --set ports.traefik.expose.default=true --set ports.traefik.nodePort=31080 --set ports.traefik.exposedPort=31080 \
+        --set ports.traefik.expose.default=true \
+        --set ports.traefik.nodePort=31080 \
+        --set ports.traefik.exposedPort=31080 \
         --set api.dashboard=true \
         --set api.insecure=true
+        checkTraefikStatus
   fi
 }
 
@@ -823,6 +905,9 @@ nodes:
 - role: control-plane
   kubeadmConfigPatches:
   - |
+    kind: ClusterConfiguration
+    controlPlaneEndpoint: "${CLUSTER_NAME}-control-plane:6443"
+  - |
     kind: InitConfiguration
     nodeRegistration:
       kubeletExtraArgs:
@@ -876,6 +961,9 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    controlPlaneEndpoint: "${CLUSTER_NAME}-control-plane:6443"
   - |
     kind: InitConfiguration
     nodeRegistration:

--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -907,7 +907,7 @@ deployGatewayController
 #Deploy MinIO
 echo -e "\n[*] Deploying MinIO storage provider ..."
 helm repo add --force-update minio https://charts.min.io
-helm install minio minio/minio --namespace minio --set rootUser=minio,rootPassword=$MINIO_PASSWORD,service.type=NodePort,service.nodePort=$HOST_MINIO_API_PORT,consoleService.type=NodePort,consoleService.nodePort=$HOST_MINIO_CONSOLE_PORT,mode=standalone,resources.requests.memory=512Mi,environment.MINIO_BROWSER_REDIRECT_URL=http://localhost:$HOST_MINIO_CONSOLE_PORT --create-namespace --version 4.0.7
+helm install minio minio/minio --namespace minio --set rootUser=minio,rootPassword=$MINIO_PASSWORD,service.type=NodePort,service.nodePort=$HOST_MINIO_API_PORT,consoleService.type=NodePort,consoleService.nodePort=$HOST_MINIO_CONSOLE_PORT,mode=standalone,resources.requests.memory=512Mi,environment.MINIO_BROWSER_REDIRECT_URL=http://localhost:$HOST_MINIO_CONSOLE_PORT --create-namespace --version 5.4.0
 
 
 #Deploy NFS server provisioner

--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -341,9 +341,9 @@ deployGatewayController(){
       checkIngressStatus
   else
       echo -e "\n[*] Installing Traefik Gateway ..."
-      kubectl create namespace traefik >/dev/null 2>&1 || true
+      kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
       helm repo add --force-update  traefik https://traefik.github.io/charts
-      helm install --namespace=traefik traefik traefik/traefik --wait \
+      helm install --namespace=traefik traefik traefik/traefik --wait --create-namespace \
         --set providers.kubernetesGateway.enabled=true \
         --set providers.kubernetesCRD.allowCrossNamespace=true \
         --set gateway.enabled=true \
@@ -781,7 +781,7 @@ if [ "$HOST_MINIO_CONSOLE_PORT" != "$DEFAULT_MINIO_CONSOLE_PORT" ]; then
     echo -e "$ORANGE[*]$END_COLOR Port $DEFAULT_MINIO_CONSOLE_PORT is busy. Using $HOST_MINIO_CONSOLE_PORT for MinIO console instead."
 fi
 
-fi [ "$GATEWAY_CONTROLLER" == "traefik" ] && [ "$HOST_TRAEFIK_DASHBOARD_PORT" != "$DEFAULT_TRAEFIK_DASHBOARD_PORT" ]; then
+if [ "$GATEWAY_CONTROLLER" == "traefik" ] && [ "$HOST_TRAEFIK_DASHBOARD_PORT" != "$DEFAULT_TRAEFIK_DASHBOARD_PORT" ]; then
     echo -e "$ORANGE[*]$END_COLOR Port $DEFAULT_TRAEFIK_DASHBOARD_PORT is busy. Using $HOST_TRAEFIK_DASHBOARD_PORT for Traefik dashboard instead."
 fi
 

--- a/deploy/kind-oscar-kserve.sh
+++ b/deploy/kind-oscar-kserve.sh
@@ -24,6 +24,7 @@ helm upgrade --install kserve-resources oci://ghcr.io/kserve/charts/kserve-resou
   --namespace kserve \
   --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.disableIngressCreation=true \
+  --set kserve.controller.gateway.disableIstioVirtualHost=true \
   --set 'kserve.controller.gateway.domainTemplate=\{\{ .Name \}\}.\{\{ .IngressDomain \}\}' \
   --set kserve.controller.gateway.ingressGateway.enableGatewayApi=true \
   --set kserve.controller.gateway.ingressGateway.kserveGateway="traefik/traefik-gateway" \

--- a/examples/kserve-isvc-sklearn/oscar-svc-sklearn.yaml
+++ b/examples/kserve-isvc-sklearn/oscar-svc-sklearn.yaml
@@ -8,7 +8,9 @@ functions:
       script: script.sh
       alpine: true
       kserve:
-        model_format: sklearn
+        type: inference
+        inference:
+          model_format: sklearn
         storage_uri: "gs://kfserving-examples/models/sklearn/1.0/model"
         min_scale: 1
       log_level: CRITICAL

--- a/examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml
+++ b/examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml
@@ -7,7 +7,9 @@ functions:
       image: ghcr.io/grycap/kserve-yolo8n-onnx-script
       script: script.sh
       kserve:
-        model_format: onnx
+        type: inference
+        inference:
+          model_format: onnx
         storage_uri: "oci://ghcr.io/grycap/kserve-yolo8n-onnx"
         min_scale: 1
         api_version: "v2"

--- a/pkg/backends/k8s.go
+++ b/pkg/backends/k8s.go
@@ -385,8 +385,8 @@ func ListExposedServicePods(kubeClientset kubernetes.Interface, namespace, servi
 	})
 }
 
-func GetKserveServiceDeployment(kubeClientset kubernetes.Interface, namespace, serviceName, kserveModelFormat string) (*appsv1.Deployment, error) {
-	return kubeClientset.AppsV1().Deployments(namespace).Get(context.TODO(), utils.GetKservePodAndDplName(serviceName, kserveModelFormat), metav1.GetOptions{})
+func GetKserveServiceDeployment(kubeClientset kubernetes.Interface, namespace, serviceName, kserveType string) (*appsv1.Deployment, error) {
+	return kubeClientset.AppsV1().Deployments(namespace).Get(context.TODO(), utils.GetKservePodAndDplName(serviceName, kserveType), metav1.GetOptions{})
 }
 
 func ListKserveServicePods(kubeClientset kubernetes.Interface, namespace, serviceName string) (*v1.PodList, error) {

--- a/pkg/backends/knative.go
+++ b/pkg/backends/knative.go
@@ -134,7 +134,7 @@ func (kn *KnativeBackend) CreateService(service types.Service) error {
 		if service.Environment.Vars == nil {
 			service.Environment.Vars = make(map[string]string)
 		}
-		service.Environment.Vars["KSERVE_HOST"] = fmt.Sprintf("%s.%s.svc.cluster.local", utils.GetKserveSvcName(service.Name, service.Kserve.ModelFormat), namespace)
+		service.Environment.Vars["KSERVE_HOST"] = fmt.Sprintf("%s.%s.svc.cluster.local", utils.GetKserveSvcName(service.Name, service.Kserve.Type), namespace)
 	}
 
 	// Check if there is some user defined settings for OSCAR

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -236,7 +236,7 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 			}
 			service.Labels["kueue.x-k8s.io/queue-name"] = utils.BuildLocalQueueName(service.Name)
 			// At the moment check only for KServe service
-			if cfg.KserveEnable && service.Kserve != nil && !utils.VerifyWorkloadByResources(service, cfg) {
+			if utils.IsKserveService(&service) && utils.IsKserveSupported(cfg) && !utils.VerifyWorkloadByResources(service, cfg) {
 				if err := utils.DeleteKueueLocalQueue(context.TODO(), cfg, service.Namespace, service.Name); err != nil {
 					createLogger.Printf("Error deleting Kueue local queue: %v", err)
 				}

--- a/pkg/handlers/deployment.go
+++ b/pkg/handlers/deployment.go
@@ -269,7 +269,7 @@ func inspectKserveDeploymentRuntime(kubeClientset kubernetes.Interface, service 
 		return deploymentRuntimeContext{}, err
 	}
 
-	deployment, err := backends.GetKserveServiceDeployment(kubeClientset, service.Namespace, service.Name, service.Kserve.ModelFormat)
+	deployment, err := backends.GetKserveServiceDeployment(kubeClientset, service.Namespace, service.Name, service.Kserve.Type)
 	if err != nil {
 		if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
 			items := podItems(pods)
@@ -759,7 +759,7 @@ func inspectExposedDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interfac
 }
 
 func inspectKserveDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interface, service *types.Service) (types.ServiceDeploymentStatus, error) {
-	deployment, err := backends.GetKserveServiceDeployment(kubeClientset, service.Namespace, service.Name, service.Kserve.ModelFormat)
+	deployment, err := backends.GetKserveServiceDeployment(kubeClientset, service.Namespace, service.Name, service.Kserve.Type)
 	if err != nil {
 		if apierrors.IsNotFound(err) || apierrors.IsGone(err) {
 			return unavailableDeploymentStatus(service, "Current deployment resources are unavailable."), nil

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -334,60 +334,123 @@ type Service struct {
 }
 
 type Kserve struct {
-	// ModelFormat the model format to use for KServe InferenceService
-	// ("onnx", "sklearn", "xgboost", "pytorch", "tensorflow", "triton", "huggingface").
-	ModelFormat string `json:"model_format"`
+	// Type the type of KServe service to deploy
+	// Required. Set the type of KServe service, either "inference" for a standard InferenceService
+	// or "llm_inference" for an LLMInferenceService
+	Type string `json:"type,omitempty" default:"inference"`
+
+	// Inference configuration for KServe InferenceService.
+	// It is required when Type is set to "inference"
+	Inference *KserveInference `json:"inference,omitempty"`
+
+	// LLMInference configuration for KServe LLMInferenceService.
+	// It is required when Type is set to "llm_inference"
+	LLMInference *KserveLLMInference `json:"llm_inference,omitempty"`
+
 	// StorageUri the URI of the model storage for KServe
+	// Required. It should follow the format expected by KServe, for example:
 	StorageUri string `json:"storage_uri"`
+
 	// Can be used to specify the protocol version for KServe (e.g., "v1", "v2").
 	// Optional. (default: "v1")
 	APIVersion string `json:"api_version,omitempty" default:"v1"`
+
 	// MinScale minimum number of active replicas (pods) for the service
 	// Optional. (default: 0)
 	MinScale int32 `json:"min_scale,omitempty" default:"0"`
+
 	// MaxScale maximum number of active replicas (pods) for the service
-	// Optional. (default: 0 [Unlimited])
-	MaxScale int32 `json:"max_scale,omitempty" default:"0"`
+	// Optional. (default: 10)
+	MaxScale int32 `json:"max_scale,omitempty" default:"10"`
+
 	// CPU cpu limit for the service following the kubernetes format
 	// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
 	// Optional. (default: 0.2)
 	CPU string `json:"cpu" default:"0.2"`
+
 	// Memory memory limit for the service following the kubernetes format
 	// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
 	// Optional. (default: 256Mi)
 	Memory string `json:"memory" default:"256Mi"`
+
 	// Args command-line arguments to be passed to the container
 	// Optional
 	Args []string `json:"args,omitempty"`
+
 	// Environment variables to be passed to the container
 	// Optional
 	Env map[string]string `json:"env,omitempty"`
+
 	// EnableGPU parameter to request gpu usage in KServe InferenceService
 	// Optional. (default: false)
 	EnableGPU bool `json:"enable_gpu,omitempty" default:"false"`
+
 	// SetAuth parameter to set the authentication for the KServe InferenceService
-	// Optional. (default: true)
-	SetAuth bool `json:"set_auth,omitempty" default:"true"`
-	// LLM configuration for LLM-specific KServe deployments
-	// Only if ModelFormat is "llm"
-	// Optional
-	LLM *LLMConfig `json:"llm,omitempty"`
+	// Optional. (default: false)
+	SetAuth bool `json:"set_auth,omitempty" default:"false"`
 }
 
 // UnmarshalJSON sets KServe defaults for fields that may be omitted in API requests.
 func (k *Kserve) UnmarshalJSON(data []byte) error {
-	type kserveAlias Kserve
+	type Alias Kserve
 
-	// Keep auth enabled by default unless it is explicitly set to false.
-	k.SetAuth = true
-	k.CPU = "0.2"
-	k.Memory = "256Mi"
+	// Set default values for optional fields
+	aux := Alias{
+		APIVersion: "v1",
+		CPU:        "0.2",
+		Memory:     "256Mi",
+		SetAuth:    false,
+		MinScale:   0,
+		MaxScale:   10,
+		EnableGPU:  false,
+	}
 
-	return json.Unmarshal(data, (*kserveAlias)(k))
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	// Validate required fields
+	if strings.TrimSpace(aux.StorageUri) == "" {
+		return fmt.Errorf("Kserve StorageUri is required")
+	}
+	if strings.TrimSpace(aux.Type) == "" {
+		return fmt.Errorf("Kserve Type is required")
+	}
+
+	*k = Kserve(aux)
+	return nil
 }
 
-type LLMConfig struct {
-	ModelName    string `json:"model_name,omitempty"`
+type KserveInference struct {
+	// ModelFormat the model format to use for KServe InferenceService
+	// ("onnx", "sklearn", "xgboost", "pytorch", "tensorflow", "triton", "huggingface").
+	ModelFormat string `json:"model_format,omitempty"`
+	// Runtime the KServe runtime to use
+	// Optional.
+	Runtime string `json:"runtime,omitempty"`
+}
+
+func (k *KserveInference) UnmarshalJSON(data []byte) error {
+	type Alias KserveInference
+
+	aux := Alias{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// ModelFormat is required for KServe InferenceService
+	if strings.TrimSpace(aux.ModelFormat) == "" {
+		return fmt.Errorf("Kserve Inference ModelFormat is required")
+	}
+
+	*k = KserveInference(aux)
+	return nil
+}
+
+type KserveLLMInference struct {
+	// At the moment only supported for LLMInferenceService,
+	// the runtime image to use for KServe when IsLLM is true
+	// Optional. (default: a custom image based on vLLM for CPU and another one with GPU support)
 	RuntimeImage string `json:"runtime_image,omitempty"`
 }
 

--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -31,14 +31,20 @@ const (
 
 const (
 	//	defaultAuthMiddlewareName = "oidc-auth"
-	httpRouteSuffix      = "-route"
-	authMiddlewareSuffix = "-auth-mdw"
-	authSecretSuffix     = "-auth-traefik" // #nosec G101
-	corsMiddlewareSuffix = "-cors-mdw"
-	defaultLLMCPUimage   = "vllm/vllm-openai-cpu:latest"
-	defaultLLMGPUimage   = "vllm/vllm-openai:latest"
-	kserveKeyLabelApp    = "oscar-app"
-	prefixLabelApp       = "oscar-svc-ksv-"
+	httpRouteSuffix               = "-route"
+	authMiddlewareSuffix          = "-auth-mdw"
+	authSecretSuffix              = "-auth-traefik" // #nosec G101
+	corsMiddlewareSuffix          = "-cors-mdw"
+	defaultLLMCPUimage            = "vllm/vllm-openai-cpu:latest"
+	defaultLLMGPUimage            = "vllm/vllm-openai:latest"
+	kserveKeyLabelApp             = "oscar-app"
+	prefixLabelApp                = "oscar-svc-ksv-"
+	kserveIsvcSuffix              = "-predictor"
+	kserveIsvcPodDplSuffix        = "-predictor"
+	kserveLLMIsvcSuffix           = "-kserve-workload-svc"
+	kserveLLMIsvcPodDplSuffix     = "-kserve"
+	KserveTypeInferenceService    = "inference"
+	KserveTypeLLMInferenceService = "llm_inference"
 )
 
 var (
@@ -47,18 +53,6 @@ var (
 	kserveHTTPRouteGVR         = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
 	kserveTraefikMiddlewareGVR = schema.GroupVersionResource{Group: "traefik.io", Version: "v1alpha1", Resource: "middlewares"}
 	kserveSecretGVR            = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-	// Mapping of supported model formats to their corresponding KServe runtime types and frameworks
-	kserveTypeByFormat = map[string]kserveRuntime{
-		"onnx":        {kserveType: "predictor", framework: "triton", protocolV1: false, protocolV2: true},
-		"sklearn":     {kserveType: "predictor", framework: "mlserver", protocolV1: true, protocolV2: true},
-		"xgboost":     {kserveType: "predictor", framework: "mlserver", protocolV1: true, protocolV2: true},
-		"pytorch":     {kserveType: "predictor", framework: "mlserver", protocolV1: true, protocolV2: true},
-		"tensorflow":  {kserveType: "predictor", framework: "mlserver", protocolV1: true, protocolV2: true},
-		"triton":      {kserveType: "predictor", framework: "triton", protocolV1: true, protocolV2: true},
-		"huggingface": {kserveType: "predictor", framework: "vllm", protocolV1: true, protocolV2: false},
-		"llm":         {kserveType: "llm", framework: "vllm", protocolV1: true, protocolV2: false},
-	}
-
 	defaultKserveCpuRequest    = resource.MustParse("0.2")
 	defaultKserveMemoryRequest = resource.MustParse("256Mi")
 )
@@ -75,18 +69,14 @@ var newDynamicClient dynamicClientFactory = func() (*dynamic.DynamicClient, erro
 
 var kserveLogger = log.New(os.Stdout, "[KSERVE-SERVICE] ", log.Flags())
 
-type kserveRuntime struct {
-	kserveType string
-	framework  string
-	protocolV1 bool
-	protocolV2 bool
-}
-
 func IsKserveService(service *types.Service) bool {
 	// If the service has KServe configuration
-	if service.Kserve == nil || (service.Kserve.ModelFormat == "" || service.Kserve.StorageUri == "") {
+	if service.Kserve == nil /* || service.Kserve.StorageUri == "" || service.Kserve.Type == ""*/ {
 		return false
 	}
+	/*if service.Kserve.Type == KserveTypeInferenceService && (service.Kserve.Inference == nil || service.Kserve.Inference.ModelFormat == "") {
+		return false
+	}*/
 	return true
 }
 
@@ -99,11 +89,35 @@ func ValidateKserveService(service *types.Service) error {
 	if !IsKserveService(service) {
 		return fmt.Errorf("service does not have KServe configuration")
 	}
-	if !validModelFormat(service) {
-		return fmt.Errorf("invalid ModelFormat: %s", service.Kserve.ModelFormat)
+
+	if service.Kserve.Type == "" {
+		return fmt.Errorf("missing KServe service type %s | %s", KserveTypeInferenceService, KserveTypeLLMInferenceService)
 	}
-	if service.Kserve.APIVersion != "" && service.Kserve.APIVersion != protocolVersion(service) {
-		return fmt.Errorf("invalid APIVersion: %s for ModelFormat: %s", service.Kserve.APIVersion, service.Kserve.ModelFormat)
+
+	if service.Kserve.StorageUri == "" {
+		return fmt.Errorf("missing model storage URI in KServe configuration")
+	}
+
+	if service.Kserve.Type == KserveTypeInferenceService {
+		if service.Kserve.Inference == nil {
+			return fmt.Errorf("missing Inference configuration for KServe service")
+		}
+		if service.Kserve.Inference.ModelFormat == "" {
+			return fmt.Errorf("missing model format in KServe configuration")
+		}
+		if service.Kserve.LLMInference != nil {
+			return fmt.Errorf("LLMInference configuration should be nil for Inference type")
+		}
+	}
+
+	if service.Kserve.Type == KserveTypeLLMInferenceService {
+		if service.Kserve.Inference != nil {
+			return fmt.Errorf("Inference configuration should be nil for LLMInference type")
+		}
+	}
+
+	if service.Kserve.APIVersion != "" && !(service.Kserve.APIVersion == "v1" || service.Kserve.APIVersion == "v2") {
+		return fmt.Errorf("invalid APIVersion: %s", service.Kserve.APIVersion)
 	}
 	return nil
 }
@@ -128,7 +142,7 @@ func CreateKserveService(service *types.Service, knativeService *knv1.Service, c
 	}
 	//kserveLogger.Printf("Creating KServe service '%s' for user '%s' with model format %s", service.Name, service.Owner, service.Kserve.ModelFormat)
 
-	if getKserveType(service.Kserve.ModelFormat) == "llm" {
+	if service.Kserve.Type == KserveTypeLLMInferenceService {
 		// For LLM services, we use a different InferenceService definition (LLMInferenceService)
 		llmIsvc, err := NewKserveLLMInferenceServiceDefinition(service, knativeService, cfg)
 		if err != nil {
@@ -176,7 +190,7 @@ func UpdateKserveService(service *types.Service, oldService *types.Service, name
 		return fmt.Errorf("failed to create dynamic client: %v", err)
 	}
 
-	if getKserveType(service.Kserve.ModelFormat) == "llm" {
+	if service.Kserve.Type == KserveTypeLLMInferenceService {
 		// For LLM services, we use a different InferenceService definition (LLMInferenceService)
 		// Get existing object to preserve resourceVersion
 		oldLLMIsvc, err := dynClient.Resource(llmInferenceServiceGVR).Namespace(namespace).Get(context.Background(), buildKserveName(service.Name), metav1.GetOptions{})
@@ -226,10 +240,19 @@ func NewKserveInferenceServiceDefinition(service *types.Service, knSvc *knv1.Ser
 		return nil, err
 	}
 
+	apiVersion := "v1"
+	if service.Kserve.APIVersion != "" {
+		apiVersion = service.Kserve.APIVersion
+	}
+
 	modelSpec := map[string]any{
-		"modelFormat":     map[string]any{"name": service.Kserve.ModelFormat},
+		"modelFormat":     map[string]any{"name": service.Kserve.Inference.ModelFormat},
 		"storageUri":      service.Kserve.StorageUri,
-		"protocolVersion": protocolVersion(service),
+		"protocolVersion": apiVersion,
+	}
+
+	if service.Kserve.Inference.Runtime != "" {
+		modelSpec["runtime"] = service.Kserve.Inference.Runtime
 	}
 	// TO DO: consider if we want to inject root path for LLM services as well, and if so, how to handle the case when the framework is vllm that expects the prefix to be preserved for routing
 	//injectRootPath(service)
@@ -286,11 +309,25 @@ func UpdateKserveInferenceServiceDefinition(service *types.Service, oldIsvc *uns
 		return nil, err
 	}
 
-	modelSpec := map[string]any{
-		"modelFormat":     map[string]any{"name": service.Kserve.ModelFormat},
-		"storageUri":      service.Kserve.StorageUri,
-		"protocolVersion": protocolVersion(service),
+	apiVersion := service.Kserve.APIVersion
+	if apiVersion == "" {
+		oldApiVersion, ok := oldIsvc.Object["spec"].(map[string]any)["predictor"].(map[string]any)["model"].(map[string]any)["protocolVersion"]
+		if !ok {
+			apiVersion = "v1"
+		} else {
+			apiVersion = oldApiVersion.(string)
+		}
 	}
+
+	modelSpec := map[string]any{
+		"modelFormat":     map[string]any{"name": service.Kserve.Inference.ModelFormat},
+		"storageUri":      service.Kserve.StorageUri,
+		"protocolVersion": apiVersion,
+	}
+	if service.Kserve.Inference.Runtime != "" {
+		modelSpec["runtime"] = service.Kserve.Inference.Runtime
+	}
+
 	modelSpec["resources"] = resources
 	modelSpec["args"] = service.Kserve.Args
 	modelSpec["env"] = types.ConvertEnvVars(service.Kserve.Env)
@@ -342,24 +379,15 @@ func NewKserveLLMInferenceServiceDefinition(service *types.Service, knSvc *knv1.
 	if err := ValidateKserveService(service); err != nil {
 		return nil, err
 	}
-	if service.Kserve.ModelFormat != "llm" {
-		return nil, fmt.Errorf("invalid ModelFormat for LLMInferenceService: %s", service.Kserve.ModelFormat)
-	}
 
 	runtimeImage := defaultLLMCPUimage
 	if service.Kserve.EnableGPU {
 		runtimeImage = defaultLLMGPUimage
 	}
-
-	modelName := service.Name
-	if service.Kserve.LLM != nil {
-		if service.Kserve.LLM.ModelName != "" {
-			modelName = service.Kserve.LLM.ModelName
-		}
-		if service.Kserve.LLM.RuntimeImage != "" {
-			runtimeImage = service.Kserve.LLM.RuntimeImage
-		}
+	if service.Kserve.LLMInference != nil && service.Kserve.LLMInference.RuntimeImage != "" {
+		runtimeImage = service.Kserve.LLMInference.RuntimeImage
 	}
+
 	// TO DO: consider if we want to inject root path for LLM services as well, and if so, how to handle the case when the framework is vllm that expects the prefix to be preserved for routing
 	//injectRootPath(service)
 
@@ -411,7 +439,7 @@ func NewKserveLLMInferenceServiceDefinition(service *types.Service, knSvc *knv1.
 		"spec": map[string]any{
 			"model": map[string]any{
 				"uri":  service.Kserve.StorageUri,
-				"name": modelName,
+				"name": service.Name,
 			},
 			"replicas": minScale,
 			"labels":   labels,
@@ -434,15 +462,8 @@ func UpdateKserveLLMInferenceServiceDefinition(service *types.Service, oldLLMIsv
 	if service.Kserve.EnableGPU {
 		runtimeImage = defaultLLMGPUimage
 	}
-
-	modelName := service.Name
-	if service.Kserve.LLM != nil {
-		if service.Kserve.LLM.ModelName != "" {
-			modelName = service.Kserve.LLM.ModelName
-		}
-		if service.Kserve.LLM.RuntimeImage != "" {
-			runtimeImage = service.Kserve.LLM.RuntimeImage
-		}
+	if service.Kserve.LLMInference != nil && service.Kserve.LLMInference.RuntimeImage != "" {
+		runtimeImage = service.Kserve.LLMInference.RuntimeImage
 	}
 
 	container := map[string]any{
@@ -470,7 +491,7 @@ func UpdateKserveLLMInferenceServiceDefinition(service *types.Service, oldLLMIsv
 	oldLLMIsvc.Object["spec"] = map[string]any{
 		"model": map[string]any{
 			"uri":  service.Kserve.StorageUri,
-			"name": modelName,
+			"name": service.Name,
 		},
 		"replicas": minScale,
 		"labels":   labels,
@@ -485,71 +506,33 @@ func GetKserveLabelSelector(serviceName string) string {
 	return fmt.Sprintf("%s=%s", kserveKeyLabelApp, prefixLabelApp+serviceName)
 }
 
-func GetKserveSvcName(serviceName, kserveModelFormat string) string {
+func GetKserveSvcName(serviceName, kserveType string) string {
 	if serviceName == "" {
 		return ""
 	}
 
-	switch getKserveType(kserveModelFormat) {
-	case "predictor":
-		return serviceName + "-predictor"
-	case "llm":
-		return serviceName + "-kserve-workload-svc"
+	switch kserveType {
+	case KserveTypeInferenceService:
+		return serviceName + kserveIsvcSuffix
+	case KserveTypeLLMInferenceService:
+		return serviceName + kserveLLMIsvcSuffix
 	default:
 		return ""
 	}
 }
 
-func GetKservePodAndDplName(serviceName, kserveModelFormat string) string {
+func GetKservePodAndDplName(serviceName, kserveType string) string {
 	if serviceName == "" {
 		return ""
 	}
 
-	switch getKserveType(kserveModelFormat) {
-	case "predictor":
-		return serviceName + "-predictor"
-	case "llm":
-		return serviceName + "-kserve"
+	switch kserveType {
+	case KserveTypeInferenceService:
+		return serviceName + kserveIsvcPodDplSuffix
+	case KserveTypeLLMInferenceService:
+		return serviceName + kserveLLMIsvcPodDplSuffix
 	default:
 		return ""
-	}
-}
-
-func getKserveType(kserveModelFormat string) string {
-	modelFormat := strings.ToLower(strings.TrimSpace(kserveModelFormat))
-	if modelFormat == "" {
-		return ""
-	}
-
-	if kserveType, ok := kserveTypeByFormat[modelFormat]; ok {
-		return kserveType.kserveType
-	}
-
-	return ""
-}
-
-func getKserveFramework(kserveModelFormat string) string {
-	modelFormat := strings.ToLower(strings.TrimSpace(kserveModelFormat))
-	if modelFormat == "" {
-		return ""
-	}
-
-	if kserveType, ok := kserveTypeByFormat[modelFormat]; ok {
-		return kserveType.framework
-	}
-
-	return ""
-}
-
-func validModelFormat(service *types.Service) bool {
-	KserveDef := service.Kserve
-	switch getKserveType(KserveDef.ModelFormat) {
-	case "predictor":
-		return true
-	case "llm": // TO DO: add more validation for LLM services
-		return true
-	default:
-		return false
 	}
 }
 
@@ -563,7 +546,7 @@ func exposeKserveInferenceService(service *types.Service, knSvc *knv1.Service, c
 		if err = createTraefikAuthMiddleware(gatewayClientset, service, knSvc); err != nil {
 			return fmt.Errorf("failed to create OIDC middleware: %v", err)
 		}
-		// Create OIDC forwardAuth Traefik Middleware
+		// TO DO: Create OIDC forwardAuth Traefik Middleware
 		/*
 			if err = createTraefikOIDCMiddleware(gatewayClientset, service, knSvc, cfg); err != nil {
 				return fmt.Errorf("failed to create OIDC middleware: %v", err)
@@ -594,22 +577,28 @@ func CheckKserveUpdate(oldService *types.Service, newService *types.Service) err
 	// it's a not allowed change in KServe configuration
 	if oldKserve == nil || newKserve == nil {
 		return fmt.Errorf("cannot add or remove KServe configuration")
-
-	}
-	// ModelFormat is the only field we allow to be set at creation
-	// and not changed afterwards, so if it changes we return false
-	// We also check StorageUri and SetAuth because changing them would require changes to the InferenceService spec
-	// that are not supported in an update, and we want to prevent users from making changes that would lead to an
-	// inconsistent state where the spec does not match the service configuration
-	if oldKserve.ModelFormat != newKserve.ModelFormat {
-		return fmt.Errorf("cannot update model format for KServe")
 	}
 	if oldKserve.StorageUri != newKserve.StorageUri {
 		return fmt.Errorf("cannot update model storage configuration for KServe")
 	}
+	if oldKserve.Inference.Runtime != newKserve.Inference.Runtime {
+		return fmt.Errorf("cannot update runtime for KServe")
+	}
 	if oldKserve.SetAuth != newKserve.SetAuth {
 		return fmt.Errorf("cannot update authentication configuration for KServe")
 	}
+	if oldKserve.Type != newKserve.Type {
+		return fmt.Errorf("cannot change KServe service type")
+
+	} else if newKserve.Type == KserveTypeInferenceService {
+		if oldKserve.Inference == nil || newKserve.Inference == nil {
+			return fmt.Errorf("inference configuration cannot be nil for KServe service")
+
+		} else if oldKserve.Inference.ModelFormat != newKserve.Inference.ModelFormat {
+			return fmt.Errorf("cannot update model format for KServe")
+		}
+	}
+
 	return nil
 }
 
@@ -633,7 +622,7 @@ func normalizeScaleFromKserveService(service *types.Kserve) (int32, int32) {
 	if minScale > maxScale {
 		maxScale = minScale
 	}
-	if service.ModelFormat == "llm" && minScale == 0 {
+	if service.Type == KserveTypeLLMInferenceService && minScale == 0 {
 		minScale = 1
 	}
 	return minScale, maxScale
@@ -642,23 +631,6 @@ func normalizeScaleFromKserveService(service *types.Kserve) (int32, int32) {
 func buildKserveName(serviceName string) string {
 	// TODO
 	return serviceName
-}
-
-// Helper function to determine the protocol version for KServe based on service configuration
-// Defaults to "v1" if not specified or invalid
-func protocolVersion(service *types.Service) string {
-	modelFormat := strings.ToLower(strings.TrimSpace(service.Kserve.ModelFormat))
-	switch {
-	case service.Kserve.APIVersion == "v1" && kserveTypeByFormat[modelFormat].protocolV1:
-		return "v1"
-	case service.Kserve.APIVersion == "v2" && kserveTypeByFormat[modelFormat].protocolV2:
-		return "v2"
-	// For model formats that do not support v1, default to v2
-	case (service.Kserve.APIVersion == "" || service.Kserve.APIVersion == "v1") && !kserveTypeByFormat[modelFormat].protocolV1:
-		return "v2"
-	default:
-		return "v1"
-	}
 }
 
 // createTraefikOIDCMiddleware creates a Traefik Middleware of type ForwardAuth for OIDC authentication,
@@ -764,7 +736,7 @@ func createHTTPRoute(gatewayClientset dynamic.Interface, service *types.Service,
 	httpRouteName := isvcName + httpRouteSuffix
 	namespace := knSvc.Namespace
 	apiPath := getAPIPath(isvcName)
-	svcName := GetKserveSvcName(isvcName, service.Kserve.ModelFormat)
+	svcName := GetKserveSvcName(isvcName, service.Kserve.Type)
 	gwName := strings.TrimSpace(cfg.HTTPRouteGatewayName)
 	gwNamespace := strings.TrimSpace(cfg.HTTPRouteGatewayNamespace)
 	if gwNamespace == "" || gwName == "" {
@@ -964,7 +936,7 @@ func getKserveLLMServiceRouterSpec(service *types.Service, namespace string, cfg
 		map[string]any{
 			"group": "",
 			"kind":  "Service",
-			"name":  GetKserveSvcName(service.Name, service.Kserve.ModelFormat),
+			"name":  GetKserveSvcName(service.Name, service.Kserve.Type),
 			"port":  8000,
 		},
 	}
@@ -1041,6 +1013,7 @@ func formatUID(uid string) string {
 	return uid
 }
 
+/*
 func injectRootPath(service *types.Service) {
 	kserveServiceFramework := getKserveFramework(service.Kserve.ModelFormat)
 	if kserveServiceFramework != "triton" {
@@ -1054,7 +1027,7 @@ func injectRootPath(service *types.Service) {
 		}
 	}
 }
-
+*/
 // existsKserveHTTPRouteByServiceName checks whether there is any HTTPRoute in the
 // cluster that matches the expected name and API path for the given service name, and returns an error if there are any conflicts (e.g. same name but different path, or same path but different name). It returns true if a matching HTTPRoute exists in the same namespace, false if no matching HTTPRoute exists, and an error if there is a conflict.
 func existsKserveHTTPRouteByServiceName(serviceName, namespace string) (bool, error) {

--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -55,8 +55,8 @@ var (
 		"pytorch":     {kserveType: "predictor", framework: "mlserver", protocolV1: true, protocolV2: true},
 		"tensorflow":  {kserveType: "predictor", framework: "mlserver", protocolV1: true, protocolV2: true},
 		"triton":      {kserveType: "predictor", framework: "triton", protocolV1: true, protocolV2: true},
-		"huggingface": {kserveType: "predictor", framework: "vllm", protocolV1: true, protocolV2: true},
-		"llm":         {kserveType: "llm", framework: "vllm", protocolV1: true, protocolV2: true},
+		"huggingface": {kserveType: "predictor", framework: "vllm", protocolV1: true, protocolV2: false},
+		"llm":         {kserveType: "llm", framework: "vllm", protocolV1: true, protocolV2: false},
 	}
 
 	defaultKserveCpuRequest    = resource.MustParse("0.2")
@@ -232,10 +232,6 @@ func NewKserveInferenceServiceDefinition(service *types.Service, knSvc *knv1.Ser
 
 	predictor := map[string]any{
 		"model": modelSpec,
-		"labels": map[string]any{
-			types.KueueOwnerLabel:       formatUID(service.Owner),
-			"kueue.x-k8s.io/queue-name": BuildLocalQueueName(service.Name),
-		},
 	}
 	minScale, maxScale := normalizeScaleFromKserveService(service.Kserve)
 	predictor["minReplicas"] = minScale
@@ -245,8 +241,14 @@ func NewKserveInferenceServiceDefinition(service *types.Service, knSvc *knv1.Ser
 		kserveKeyLabelApp:           prefixLabelApp + service.Name,
 		types.OscarUserServiceLabel: "true",
 	}
+
 	if cfg.KueueEnable {
-		labels["kueue.x-k8s.io/queue-name"] = BuildLocalQueueName(service.Name)
+		localQueueName, ok := service.Labels["kueue.x-k8s.io/queue-name"]
+		if ok && localQueueName != "" {
+			labels["kueue.x-k8s.io/queue-name"] = localQueueName
+		} else if service.Owner != types.DefaultOwner {
+			return nil, fmt.Errorf("missing required label 'kueue.x-k8s.io/queue-name' for KServe service with Kueue enabled")
+		}
 	}
 
 	return &unstructured.Unstructured{Object: map[string]any{
@@ -287,14 +289,15 @@ func UpdateKserveInferenceServiceDefinition(service *types.Service, oldIsvc *uns
 
 	predictor := map[string]any{
 		"model": modelSpec,
-		"labels": map[string]any{
-			types.KueueOwnerLabel:       formatUID(service.Owner),
-			"kueue.x-k8s.io/queue-name": BuildLocalQueueName(service.Name),
-		},
 	}
 	minScale, maxScale := normalizeScaleFromKserveService(service.Kserve)
 	predictor["minReplicas"] = minScale
 	predictor["maxReplicas"] = maxScale
+
+	oldLabels, ok := oldIsvc.Object["spec"].(map[string]any)["predictor"].(map[string]any)["labels"]
+	if ok {
+		predictor["labels"] = oldLabels
+	}
 
 	oldIsvc.Object["spec"] = map[string]any{
 		"predictor": predictor,
@@ -379,8 +382,14 @@ func NewKserveLLMInferenceServiceDefinition(service *types.Service, knSvc *knv1.
 		kserveKeyLabelApp:           prefixLabelApp + service.Name,
 		types.OscarUserServiceLabel: "true",
 	}
+
 	if cfg.KueueEnable {
-		labels["kueue.x-k8s.io/queue-name"] = BuildLocalQueueName(service.Name)
+		localQueueName, ok := service.Labels["kueue.x-k8s.io/queue-name"]
+		if ok && localQueueName != "" {
+			labels["kueue.x-k8s.io/queue-name"] = localQueueName
+		} else if service.Owner != types.DefaultOwner {
+			return nil, fmt.Errorf("missing required label 'kueue.x-k8s.io/queue-name' for KServe service with Kueue enabled")
+		}
 	}
 
 	return &unstructured.Unstructured{Object: map[string]any{
@@ -445,13 +454,18 @@ func UpdateKserveLLMInferenceServiceDefinition(service *types.Service, oldLLMIsv
 
 	minScale, _ := normalizeScaleFromKserveService(service.Kserve)
 
+	labels := map[string]any{}
+	if oldlabels, ok := oldLLMIsvc.Object["spec"].(map[string]any)["labels"]; ok {
+		labels = oldlabels.(map[string]any)
+	}
+
 	oldLLMIsvc.Object["spec"] = map[string]any{
 		"model": map[string]any{
 			"uri":  service.Kserve.StorageUri,
 			"name": modelName,
 		},
 		"replicas": minScale,
-		"labels":   oldLLMIsvc.Object["spec"].(map[string]any)["labels"],
+		"labels":   labels,
 		"template": map[string]any{
 			"containers": []any{container},
 		},
@@ -743,6 +757,11 @@ func createHTTPRoute(gatewayClientset dynamic.Interface, service *types.Service,
 	namespace := knSvc.Namespace
 	apiPath := getAPIPath(isvcName)
 	svcName := GetKserveSvcName(isvcName, service.Kserve.ModelFormat)
+	gwName := strings.TrimSpace(cfg.HTTPRouteGatewayName)
+	gwNamespace := strings.TrimSpace(cfg.HTTPRouteGatewayNamespace)
+	if gwNamespace == "" || gwName == "" {
+		return fmt.Errorf("gateway namespace and name must be provided in config to create HTTPRoute for KServe service")
+	}
 
 	filters := []any{
 		map[string]any{
@@ -806,12 +825,10 @@ func createHTTPRoute(gatewayClientset dynamic.Interface, service *types.Service,
 	}
 
 	parentRef := map[string]any{
-		"group": "gateway.networking.k8s.io",
-		"kind":  "Gateway",
-		"name":  strings.TrimSpace(cfg.HTTPRouteGatewayName),
-	}
-	if gwNamespace := strings.TrimSpace(cfg.HTTPRouteGatewayNamespace); gwNamespace != "" {
-		parentRef["namespace"] = gwNamespace
+		"group":     "gateway.networking.k8s.io",
+		"kind":      "Gateway",
+		"name":      gwName,
+		"namespace": gwNamespace,
 	}
 	spec["parentRefs"] = []any{parentRef}
 
@@ -868,13 +885,19 @@ func createKserveResources(service *types.Kserve) (v1.ResourceRequirements, erro
 		if err != nil {
 			return resources, err
 		}
-		resources.Limits["nvidia.com/gpu"] = gpu
+		resources.Requests["nvidia.com/gpu"] = gpu
 	}
 
 	return resources, nil
 }
 
 func buildKserveLLMServiceRouter(service *types.Service, knSvc *knv1.Service, cfg *types.Config) (map[string]any, error) {
+	gwName := strings.TrimSpace(cfg.HTTPRouteGatewayName)
+	gwNamespace := strings.TrimSpace(cfg.HTTPRouteGatewayNamespace)
+	if gwNamespace == "" || gwName == "" {
+		return nil, fmt.Errorf("gateway namespace and name must be provided in config to create HTTPRoute for KServe service")
+	}
+
 	if service.Kserve.SetAuth {
 		gatewayClientset, err := getDynamicClient()
 		if err != nil {
@@ -887,12 +910,12 @@ func buildKserveLLMServiceRouter(service *types.Service, knSvc *knv1.Service, cf
 			return nil, fmt.Errorf("failed to create Auth middleware: %v", err)
 		}
 	}
-	return getKserveLLMServiceRouterSpec(service, knSvc.Namespace), nil
+	return getKserveLLMServiceRouterSpec(service, knSvc.Namespace, cfg), nil
 }
 
 // getKserveLLMServiceRouterSpec returns a router configuration for LLM InferenceServices
 // to route requests based on the service name (use inference Pool).
-func getKserveLLMServiceRouterSpec(service *types.Service, namespace string) map[string]any {
+func getKserveLLMServiceRouterSpec(service *types.Service, namespace string, cfg *types.Config) map[string]any {
 	filters := []any{
 		map[string]any{
 			"type": "RequestHeaderModifier",
@@ -926,24 +949,49 @@ func getKserveLLMServiceRouterSpec(service *types.Service, namespace string) map
 		},
 	})
 
-	return map[string]any{
-		"route": map[string]any{
-			"http": map[string]any{
-				"spec": map[string]any{
-					"rules": []any{
-						map[string]any{
-							"matches": []any{
-								map[string]any{
-									"path": map[string]any{
-										"type":  "PathPrefix",
-										"value": getAPIPath(service.Name),
-									},
-								},
-							},
-							"filters": filters,
+	// TO DO: Evaluate the use of InferencePool
+	// Traefik do not support InferencePool
+	// https://gateway-api-inference-extension.sigs.k8s.io/implementations/gateways/
+	backendRefs := []any{
+		map[string]any{
+			"group": "",
+			"kind":  "Service",
+			"name":  GetKserveSvcName(service.Name, service.Kserve.ModelFormat),
+			"port":  8000,
+		},
+	}
+
+	spec := map[string]any{
+		"rules": []any{
+			map[string]any{
+				"matches": []any{
+					map[string]any{
+						"path": map[string]any{
+							"type":  "PathPrefix",
+							"value": getAPIPath(service.Name),
 						},
 					},
 				},
+				"filters":     filters,
+				"backendRefs": backendRefs,
+			},
+		},
+	}
+
+	if cfg != nil {
+		if host := strings.TrimSpace(cfg.IngressHost); host != "" {
+			spec["hostnames"] = []any{host}
+		}
+	}
+
+	return map[string]any{
+		"gateway": map[string]any{
+			"name":      strings.TrimSpace(cfg.HTTPRouteGatewayName),
+			"namespace": strings.TrimSpace(cfg.HTTPRouteGatewayNamespace),
+		},
+		"route": map[string]any{
+			"http": map[string]any{
+				"spec": spec,
 			},
 		},
 	}

--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -114,6 +114,14 @@ func CreateKserveService(service *types.Service, knativeService *knv1.Service, c
 		return err
 	}
 
+	ok, err := existsKserveHTTPRouteByServiceName(service.Name, service.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to check HTTPRoute availability for service %s: %v", service.Name, err)
+	}
+	if ok {
+		return fmt.Errorf("HTTPRoute for service %s already taken, change the service name", service.Name)
+	}
+
 	dynClient, err := getDynamicClient()
 	if err != nil {
 		return fmt.Errorf("failed to create dynamic client: %v", err)
@@ -844,7 +852,7 @@ func createHTTPRoute(gatewayClientset dynamic.Interface, service *types.Service,
 	}}
 
 	_, err := gatewayClientset.Resource(kserveHTTPRouteGVR).Namespace(namespace).Create(context.Background(), httpRoute, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err != nil {
 		return fmt.Errorf("failed to create HTTPRoute: %v", err)
 	}
 	return nil
@@ -1047,12 +1055,20 @@ func injectRootPath(service *types.Service) {
 	}
 }
 
-/*
-if service.Expose.SetAuth {
-		if err := createTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
-			return err
-		}
-		if err := createTraefikAuthMiddleware(service, namespace); err != nil {
-			return err
-		}
-	}*/
+// existsKserveHTTPRouteByServiceName checks whether there is any HTTPRoute in the
+// cluster that matches the expected name and API path for the given service name, and returns an error if there are any conflicts (e.g. same name but different path, or same path but different name). It returns true if a matching HTTPRoute exists in the same namespace, false if no matching HTTPRoute exists, and an error if there is a conflict.
+func existsKserveHTTPRouteByServiceName(serviceName, namespace string) (bool, error) {
+	routeName := getHTTPRouteName(serviceName)
+
+	dynClient, err := getDynamicClient()
+	if err != nil {
+		return false, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
+	routeList, err := dynClient.Resource(kserveHTTPRouteGVR).Namespace(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{FieldSelector: "metadata.name=" + routeName})
+	if err != nil {
+		return false, fmt.Errorf("failed to list HTTPRoutes: %v", err)
+	}
+
+	return (len(routeList.Items) > 0), nil
+}

--- a/pkg/utils/kserve_test.go
+++ b/pkg/utils/kserve_test.go
@@ -16,6 +16,7 @@ import (
 // knativeServiceWithUID returns a minimal Knative service with the given UID.
 func knativeServiceWithUID(uid types.UID) *knv1.Service {
 	return &knv1.Service{
+
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-kn-svc",
 			Namespace: "oscar-svc",
@@ -322,7 +323,10 @@ func TestNewKserveLLMInferenceServiceDefinition(t *testing.T) {
 			tt.mutateService(svc)
 			knSvc := knativeServiceWithUID("uid-llm")
 
-			isvc, err := NewKserveLLMInferenceServiceDefinition(svc, knSvc, &oscarType.Config{})
+			isvc, err := NewKserveLLMInferenceServiceDefinition(svc, knSvc, &oscarType.Config{
+				HTTPRouteGatewayName:      "name",
+				HTTPRouteGatewayNamespace: "namespace",
+			})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -793,9 +797,9 @@ func TestCreateKserveResources(t *testing.T) {
 				t.Errorf("requests.memory = %q, want %q", got, tt.wantMem)
 			}
 
-			_, hasGPU := resources.Limits[corev1.ResourceName("nvidia.com/gpu")]
+			_, hasGPU := resources.Requests[corev1.ResourceName("nvidia.com/gpu")]
 			if hasGPU != tt.wantGPU {
-				t.Errorf("gpu limit present = %v, want %v", hasGPU, tt.wantGPU)
+				t.Errorf("gpu request present = %v, want %v", hasGPU, tt.wantGPU)
 			}
 		})
 	}
@@ -986,12 +990,14 @@ func TestUpdateKserveLLMInferenceServiceDefinition_InvalidCPU(t *testing.T) {
 
 func TestGetKserveLLMServiceRouterSpec(t *testing.T) {
 	tests := []struct {
-		name     string
-		setAuth  bool
-		wantAuth bool
+		name          string
+		setAuth       bool
+		ingressHost   string
+		wantAuth      bool
+		wantHostnames bool
 	}{
-		{name: "without auth", setAuth: false, wantAuth: false},
-		{name: "with auth", setAuth: true, wantAuth: true},
+		{name: "without auth and without host", setAuth: false, ingressHost: "", wantAuth: false, wantHostnames: false},
+		{name: "with auth and host", setAuth: true, ingressHost: "example.org", wantAuth: true, wantHostnames: true},
 	}
 
 	for _, tt := range tests {
@@ -999,11 +1005,26 @@ func TestGetKserveLLMServiceRouterSpec(t *testing.T) {
 			svc := llmKserveService()
 			svc.Name = "router-service"
 			svc.Kserve.SetAuth = tt.setAuth
+			cfg := &oscarType.Config{IngressHost: tt.ingressHost}
 
-			routerSpec := getKserveLLMServiceRouterSpec(svc, "router-ns")
+			routerSpec := getKserveLLMServiceRouterSpec(svc, "router-ns", cfg)
 			routerObj := &unstructured.Unstructured{Object: routerSpec}
 
-			rulesAny := getRawNested(t, routerObj, "route", "http", "spec", "rules")
+			specAny := getRawNested(t, routerObj, "route", "http", "spec")
+			spec, ok := specAny.(map[string]any)
+			if !ok {
+				t.Fatalf("expected spec map, got %T", specAny)
+			}
+
+			_, hasHostnames := spec["hostnames"]
+			if hasHostnames != tt.wantHostnames {
+				t.Errorf("hostnames present = %v, want %v", hasHostnames, tt.wantHostnames)
+			}
+
+			rulesAny, ok := spec["rules"]
+			if !ok {
+				t.Fatal("expected rules in router spec")
+			}
 			rules, ok := rulesAny.([]any)
 			if !ok || len(rules) != 1 {
 				t.Fatalf("expected one rule, got %T (%v)", rulesAny, rulesAny)

--- a/pkg/utils/kserve_test.go
+++ b/pkg/utils/kserve_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -39,13 +38,16 @@ func kserveService() *oscarType.Service {
 		CPU:       "500m",
 		Memory:    "1Gi",
 		Kserve: &oscarType.Kserve{
-			ModelFormat: "sklearn",
-			StorageUri:  "s3://my-bucket/model",
-			MinScale:    minScale,
-			MaxScale:    maxScale,
-			APIVersion:  "v1",
-			CPU:         "1.0",
-			Memory:      "2Gi",
+			Type: KserveTypeInferenceService,
+			Inference: &oscarType.KserveInference{
+				ModelFormat: "sklearn",
+			},
+			StorageUri: "s3://my-bucket/model",
+			MinScale:   minScale,
+			MaxScale:   maxScale,
+			APIVersion: "v1",
+			CPU:        "1.0",
+			Memory:     "2Gi",
 		},
 	}
 }
@@ -56,12 +58,12 @@ func llmKserveService() *oscarType.Service {
 		Namespace: "oscar-svc",
 		Token:     "llm-token",
 		Kserve: &oscarType.Kserve{
-			ModelFormat: "llm",
-			StorageUri:  "s3://my-bucket/llm-model",
-			MinScale:    2,
-			MaxScale:    4,
-			CPU:         "1",
-			Memory:      "2Gi",
+			Type:       KserveTypeLLMInferenceService,
+			StorageUri: "s3://my-bucket/llm-model",
+			MinScale:   2,
+			MaxScale:   4,
+			CPU:        "1",
+			Memory:     "2Gi",
 		},
 	}
 }
@@ -130,22 +132,23 @@ func TestIsKserveService_ValidConfig(t *testing.T) {
 	}
 }
 
-func TestIsKserveService_MissingModelFormat(t *testing.T) {
-	svc := kserveService()
-	svc.Kserve.ModelFormat = ""
-	if IsKserveService(svc) {
-		t.Error("expected IsKserveService to return false when ModelFormat is empty")
+/*
+	func TestIsKserveService_MissingModelFormat(t *testing.T) {
+		svc := kserveService()
+		svc.Kserve.Inference.ModelFormat = ""
+		if IsKserveService(svc) {
+			t.Error("expected IsKserveService to return false when ModelFormat is empty")
+		}
 	}
-}
 
-func TestIsKserveService_MissingStorageUri(t *testing.T) {
-	svc := kserveService()
-	svc.Kserve.StorageUri = ""
-	if IsKserveService(svc) {
-		t.Error("expected IsKserveService to return false when StorageUri is empty")
+	func TestIsKserveService_MissingStorageUri(t *testing.T) {
+		svc := kserveService()
+		svc.Kserve.StorageUri = ""
+		if IsKserveService(svc) {
+			t.Error("expected IsKserveService to return false when StorageUri is empty")
+		}
 	}
-}
-
+*/
 func TestIsKserveService_BothMissing(t *testing.T) {
 	svc := &oscarType.Service{}
 	if IsKserveService(svc) {
@@ -196,8 +199,8 @@ func TestNewKserveInferenceServiceDefinition_Success(t *testing.T) {
 	}
 
 	// predictor model fields
-	if v := getNestedString(t, isvc, "spec", "predictor", "model", "modelFormat", "name"); v != svc.Kserve.ModelFormat {
-		t.Errorf("modelFormat.name = %q, want %q", v, svc.Kserve.ModelFormat)
+	if v := getNestedString(t, isvc, "spec", "predictor", "model", "modelFormat", "name"); v != svc.Kserve.Inference.ModelFormat {
+		t.Errorf("modelFormat.name = %q, want %q", v, svc.Kserve.Inference.ModelFormat)
 	}
 	if v := getNestedString(t, isvc, "spec", "predictor", "model", "storageUri"); v != svc.Kserve.StorageUri {
 		t.Errorf("storageUri = %q, want %q", v, svc.Kserve.StorageUri)
@@ -310,14 +313,6 @@ func TestNewKserveLLMInferenceServiceDefinition(t *testing.T) {
 			wantImage:     defaultLLMGPUimage,
 			wantModelName: "my-llm-service",
 		},
-		{
-			name: "custom runtime and model name",
-			mutateService: func(svc *oscarType.Service) {
-				svc.Kserve.LLM = &oscarType.LLMConfig{ModelName: "custom-model", RuntimeImage: "repo/custom:v1"}
-			},
-			wantImage:     "repo/custom:v1",
-			wantModelName: "custom-model",
-		},
 	}
 
 	for _, tt := range tests {
@@ -401,7 +396,7 @@ func TestUpdateKserveInferenceServiceDefinition_Success(t *testing.T) {
 	}
 
 	updated := kserveService()
-	updated.Kserve.ModelFormat = "tensorflow"
+	updated.Kserve.Inference.ModelFormat = "tensorflow"
 	updated.Kserve.StorageUri = "s3://new-bucket/model"
 	updated.Kserve.MinScale = 2
 	updated.Kserve.MaxScale = 5
@@ -489,94 +484,6 @@ func TestUpdateKserveInferenceServiceDefinition_InvalidCPU(t *testing.T) {
 	}
 }
 
-// ─── validModelFormat ────────────────────────────────────────────────────────
-
-func TestValidModelFormat(t *testing.T) {
-	tests := []struct {
-		service *oscarType.Service
-		valid   bool
-	}{
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "onnx"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "sklearn"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "xgboost"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "pytorch"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "tensorflow"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "triton"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "huggingface"}}, true},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: ""}}, false}, // empty string should be invalid
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "unknown"}}, false},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "SKLEARN"}}, true}, // case-insensitive
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "torch"}}, false},
-		{&oscarType.Service{Kserve: &oscarType.Kserve{ModelFormat: "llm"}}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.service.Kserve.ModelFormat, func(t *testing.T) {
-			got := validModelFormat(tt.service)
-			if got != tt.valid {
-				t.Errorf("validModelFormat(%q) = %v, want %v", tt.service.Kserve.ModelFormat, got, tt.valid)
-			}
-		})
-	}
-}
-
-// ─── getKserveType ────────────────────────────────────────────────────────
-
-func TestGetKserveType(t *testing.T) {
-	tests := []struct {
-		modelFormat string
-		expected    string
-	}{
-		{"onnx", "predictor"},
-		{"sklearn", "predictor"},
-		{"xgboost", "predictor"},
-		{"pytorch", "predictor"},
-		{"tensorflow", "predictor"},
-		{"triton", "predictor"},
-		{"huggingface", "predictor"},
-		{"llm", "llm"},
-		{" SKLEARN ", "predictor"},
-		{"", ""},
-		{"unknown", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.modelFormat, func(t *testing.T) {
-			got := getKserveType(tt.modelFormat)
-			if got != tt.expected {
-				t.Errorf("getKserveType(%q) = %v, want %v", tt.modelFormat, got, tt.expected)
-			}
-		})
-	}
-}
-
-// ─── protocolVersion ─────────────────────────────────────────────────────────
-
-func TestProtocolVersion(t *testing.T) {
-	tests := []struct {
-		name        string
-		modelFormat string
-		apiVersion  string
-		expected    string
-	}{
-		{"v1 explicit", "sklearn", "v1", "v1"},
-		{"v2 explicit", "sklearn", "v2", "v2"},
-		{"default to v1 when empty", "sklearn", "", "v1"},
-		{"onnx forces v2 regardless of apiVersion", "onnx", "v1", "v2"},
-		{"onnx forces v2 when apiVersion empty", "onnx", "", "v2"},
-		{"invalid apiVersion defaults to v1", "sklearn", "v3", "v1"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc := kserveService()
-			svc.Kserve.ModelFormat = tt.modelFormat
-			svc.Kserve.APIVersion = tt.apiVersion
-			got := protocolVersion(svc)
-			if got != tt.expected {
-				t.Errorf("protocolVersion() = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}
-
 // ─── ValidateKserveService ───────────────────────────────────────────────────
 
 func TestValidateKserveService_Valid(t *testing.T) {
@@ -590,14 +497,6 @@ func TestValidateKserveService_NoKserveConfig(t *testing.T) {
 	svc := &oscarType.Service{Name: "bare"}
 	if err := ValidateKserveService(svc); err == nil {
 		t.Error("expected error when service has no KServe configuration, got nil")
-	}
-}
-
-func TestValidateKserveService_InvalidModelFormat(t *testing.T) {
-	svc := kserveService()
-	svc.Kserve.ModelFormat = "unsupported-format"
-	if err := ValidateKserveService(svc); err == nil {
-		t.Error("expected error for invalid model format, got nil")
 	}
 }
 
@@ -633,30 +532,6 @@ func TestIsKserveSupported(t *testing.T) {
 	}
 }
 
-func TestGetKserveFramework(t *testing.T) {
-	tests := []struct {
-		modelFormat string
-		expected    string
-	}{
-		{modelFormat: "onnx", expected: "triton"},
-		{modelFormat: "sklearn", expected: "mlserver"},
-		{modelFormat: " triton ", expected: "triton"},
-		{modelFormat: "HUGGINGFACE", expected: "vllm"},
-		{modelFormat: "llm", expected: "vllm"},
-		{modelFormat: "unknown", expected: ""},
-		{modelFormat: "", expected: ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.modelFormat, func(t *testing.T) {
-			got := getKserveFramework(tt.modelFormat)
-			if got != tt.expected {
-				t.Errorf("getKserveFramework(%q) = %q, want %q", tt.modelFormat, got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestKserveNamingHelpers(t *testing.T) {
 	if got := GetKserveLabelSelector("svc"); got != "oscar-app=oscar-svc-ksv-svc" {
 		t.Errorf("GetKserveLabelSelector() = %q, want %q", got, "oscar-app=oscar-svc-ksv-svc")
@@ -665,24 +540,24 @@ func TestKserveNamingHelpers(t *testing.T) {
 	type nameCase struct {
 		name        string
 		serviceName string
-		modelFormat string
+		kserveType  string
 		wantSvcName string
 		wantPodName string
 	}
 
 	tests := []nameCase{
-		{name: "predictor service", serviceName: "demo", modelFormat: "sklearn", wantSvcName: "demo-predictor", wantPodName: "demo-predictor"},
-		{name: "llm service", serviceName: "demo", modelFormat: "llm", wantSvcName: "demo-kserve-workload-svc", wantPodName: "demo-kserve"},
-		{name: "unknown format", serviceName: "demo", modelFormat: "unknown", wantSvcName: "", wantPodName: ""},
-		{name: "empty service name", serviceName: "", modelFormat: "llm", wantSvcName: "", wantPodName: ""},
+		{name: "predictor service", serviceName: "demo", kserveType: KserveTypeInferenceService, wantSvcName: "demo-predictor", wantPodName: "demo-predictor"},
+		{name: "llm service", serviceName: "demo", kserveType: KserveTypeLLMInferenceService, wantSvcName: "demo-kserve-workload-svc", wantPodName: "demo-kserve"},
+		{name: "unknown format", serviceName: "demo", kserveType: "unknown", wantSvcName: "", wantPodName: ""},
+		{name: "empty service name", serviceName: "", kserveType: KserveTypeInferenceService, wantSvcName: "", wantPodName: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetKserveSvcName(tt.serviceName, tt.modelFormat); got != tt.wantSvcName {
+			if got := GetKserveSvcName(tt.serviceName, tt.kserveType); got != tt.wantSvcName {
 				t.Errorf("GetKserveSvcName() = %q, want %q", got, tt.wantSvcName)
 			}
-			if got := GetKservePodAndDplName(tt.serviceName, tt.modelFormat); got != tt.wantPodName {
+			if got := GetKservePodAndDplName(tt.serviceName, tt.kserveType); got != tt.wantPodName {
 				t.Errorf("GetKservePodAndDplName() = %q, want %q", got, tt.wantPodName)
 			}
 		})
@@ -830,7 +705,7 @@ func TestCheckKserveUpdate(t *testing.T) {
 		{
 			name: "cannot change model format",
 			mutate: func(oldSvc, newSvc *oscarType.Service) {
-				newSvc.Kserve.ModelFormat = "tensorflow"
+				newSvc.Kserve.Inference.ModelFormat = "tensorflow"
 			},
 			wantErr: true,
 		},
@@ -911,14 +786,6 @@ func TestUpdateKserveLLMInferenceServiceDefinition(t *testing.T) {
 			},
 			wantImage:     defaultLLMGPUimage,
 			wantModelName: "my-llm-service",
-		},
-		{
-			name: "custom llm runtime and model name",
-			mutateService: func(svc *oscarType.Service) {
-				svc.Kserve.LLM = &oscarType.LLMConfig{ModelName: "custom-model", RuntimeImage: "repo/custom:v1"}
-			},
-			wantImage:     "repo/custom:v1",
-			wantModelName: "custom-model",
 		},
 	}
 
@@ -1111,89 +978,6 @@ func TestKserveFormatUID(t *testing.T) {
 			if got != tt.expected {
 				t.Errorf("formatUID(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
-		})
-	}
-}
-
-func TestKserveInjectRootPath(t *testing.T) {
-	pathForService := func(serviceName string) string {
-		return fmt.Sprintf("--root-path=%s", getAPIPath(serviceName))
-	}
-
-	tests := []struct {
-		name  string
-		svc   *oscarType.Service
-		check func(t *testing.T, svc *oscarType.Service)
-	}{
-		{
-			name: "mlserver env var injected",
-			svc: &oscarType.Service{
-				Name: "ml-service",
-				Kserve: &oscarType.Kserve{
-					ModelFormat: "sklearn",
-				},
-			},
-			check: func(t *testing.T, svc *oscarType.Service) {
-				t.Helper()
-				if svc.Kserve.Env == nil {
-					t.Fatal("expected env map to be initialized")
-				}
-				if got := svc.Kserve.Env["MLSERVER_ROOT_PATH"]; got != getAPIPath(svc.Name) {
-					t.Errorf("MLSERVER_ROOT_PATH = %q, want %q", got, getAPIPath(svc.Name))
-				}
-			},
-		},
-		{
-			name: "vllm argument injected",
-			svc: &oscarType.Service{
-				Name: "vllm-service",
-				Kserve: &oscarType.Kserve{
-					ModelFormat: "huggingface",
-					Args:        []string{"--port=8080"},
-				},
-			},
-			check: func(t *testing.T, svc *oscarType.Service) {
-				t.Helper()
-				expectedArg := pathForService(svc.Name)
-				found := false
-				for _, arg := range svc.Kserve.Args {
-					if arg == expectedArg {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected args to contain %q, got %v", expectedArg, svc.Kserve.Args)
-				}
-			},
-		},
-		{
-			name: "triton unchanged",
-			svc: &oscarType.Service{
-				Name: "triton-service",
-				Kserve: &oscarType.Kserve{
-					ModelFormat: "triton",
-					Args:        []string{"--strict=true"},
-				},
-			},
-			check: func(t *testing.T, svc *oscarType.Service) {
-				t.Helper()
-				if len(svc.Kserve.Args) != 1 || svc.Kserve.Args[0] != "--strict=true" {
-					t.Errorf("expected args unchanged, got %v", svc.Kserve.Args)
-				}
-				if svc.Kserve.Env != nil {
-					if _, exists := svc.Kserve.Env["MLSERVER_ROOT_PATH"]; exists {
-						t.Error("did not expect MLSERVER_ROOT_PATH for triton")
-					}
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			injectRootPath(tt.svc)
-			tt.check(t, tt.svc)
 		})
 	}
 }

--- a/pkg/utils/kserve_test.go
+++ b/pkg/utils/kserve_test.go
@@ -9,7 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types" // for UID
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	knv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -1193,4 +1196,52 @@ func TestKserveInjectRootPath(t *testing.T) {
 			tt.check(t, tt.svc)
 		})
 	}
+}
+
+func setDynamicClientFactoryForTest(t *testing.T, factory dynamicClientFactory) {
+	t.Helper()
+	original := newDynamicClient
+	newDynamicClient = factory
+	t.Cleanup(func() {
+		newDynamicClient = original
+	})
+}
+
+func newHTTPRouteForTest(name, namespace, path string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"matches": []any{
+						map[string]any{
+							"path": map[string]any{
+								"type":  "PathPrefix",
+								"value": path,
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func newFakeDynamicClientForHTTPRoutes(routes ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	objects := make([]runtime.Object, 0, len(routes))
+	for _, route := range routes {
+		objects = append(objects, route)
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{kserveHTTPRouteGVR: "HTTPRouteList"},
+		objects...,
+	)
 }

--- a/pkg/utils/kserve_test.go
+++ b/pkg/utils/kserve_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types" // for UID
+	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	knv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -283,6 +285,88 @@ func TestNewKserveInferenceServiceDefinition_InvalidMemory(t *testing.T) {
 	}
 }
 
+func TestNewKserveInferenceServiceDefinition_KueueLabels(t *testing.T) {
+	knSvc := knativeServiceWithUID("uid-kueue")
+
+	tests := []struct {
+		name      string
+		owner     string
+		labels    map[string]string
+		cfg       *oscarType.Config
+		wantQueue string
+		wantErr   string
+	}{
+		{
+			name:    "kueue disabled",
+			owner:   "user-a",
+			labels:  nil,
+			cfg:     &oscarType.Config{KueueEnable: false},
+			wantErr: "",
+		},
+		{
+			name:      "kueue enabled with queue label",
+			owner:     "user-a",
+			labels:    map[string]string{"kueue.x-k8s.io/queue-name": "team-a"},
+			cfg:       &oscarType.Config{KueueEnable: true},
+			wantQueue: "team-a",
+			wantErr:   "",
+		},
+		{
+			name:    "kueue enabled missing queue for non-default owner",
+			owner:   "user-a",
+			labels:  nil,
+			cfg:     &oscarType.Config{KueueEnable: true},
+			wantErr: "missing required label 'kueue.x-k8s.io/queue-name'",
+		},
+		{
+			name:    "kueue enabled missing queue for default owner",
+			owner:   oscarType.DefaultOwner,
+			labels:  nil,
+			cfg:     &oscarType.Config{KueueEnable: true},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := kserveService()
+			svc.Owner = tt.owner
+			svc.Labels = tt.labels
+
+			isvc, err := NewKserveInferenceServiceDefinition(svc, knSvc, tt.cfg)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			labels := getNestedMap(t, isvc, "metadata", "labels")
+			queue, hasQueue := labels["kueue.x-k8s.io/queue-name"]
+			if tt.wantQueue == "" {
+				if hasQueue {
+					t.Fatalf("did not expect queue label, got %v", queue)
+				}
+				return
+			}
+
+			if !hasQueue {
+				t.Fatalf("expected queue label %q, got none", tt.wantQueue)
+			}
+			if queue != tt.wantQueue {
+				t.Fatalf("queue label = %v, want %q", queue, tt.wantQueue)
+			}
+		})
+	}
+}
+
 func TestValidateKserveService_InvalidAPIVersion(t *testing.T) {
 	svc := kserveService()
 	svc.Kserve.APIVersion = "v3"
@@ -374,13 +458,132 @@ func TestNewKserveLLMInferenceServiceDefinition(t *testing.T) {
 	}
 }
 
-func TestNewKserveLLMInferenceServiceDefinition_InvalidModelFormat(t *testing.T) {
-	svc := kserveService()
-	knSvc := knativeServiceWithUID("uid-llm-invalid")
+func TestNewKserveLLMInferenceServiceDefinition_CustomRuntimeImage(t *testing.T) {
+	svc := llmKserveService()
+	svc.Kserve.LLMInference = &oscarType.KserveLLMInference{RuntimeImage: "ghcr.io/example/custom-runtime:v1"}
+	knSvc := knativeServiceWithUID("uid-llm-custom-runtime")
+
+	isvc, err := NewKserveLLMInferenceServiceDefinition(svc, knSvc, &oscarType.Config{
+		HTTPRouteGatewayName:      "name",
+		HTTPRouteGatewayNamespace: "namespace",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	containersAny := getRawNested(t, isvc, "spec", "template", "containers")
+	containers, ok := containersAny.([]any)
+	if !ok || len(containers) != 1 {
+		t.Fatalf("expected one container, got %T (%v)", containersAny, containersAny)
+	}
+	container, ok := containers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected container map, got %T", containers[0])
+	}
+	if got, ok := container["image"].(string); !ok || got != "ghcr.io/example/custom-runtime:v1" {
+		t.Fatalf("container.image = %v, want %q", container["image"], "ghcr.io/example/custom-runtime:v1")
+	}
+}
+
+func TestNewKserveLLMInferenceServiceDefinition_KueueLabels(t *testing.T) {
+	knSvc := knativeServiceWithUID("uid-llm-kueue")
+
+	tests := []struct {
+		name      string
+		owner     string
+		labels    map[string]string
+		cfg       *oscarType.Config
+		wantQueue string
+		wantErr   string
+	}{
+		{
+			name:  "kueue enabled with queue label",
+			owner: "user-a",
+			labels: map[string]string{
+				"kueue.x-k8s.io/queue-name": "team-llm",
+			},
+			cfg: &oscarType.Config{
+				KueueEnable:               true,
+				HTTPRouteGatewayName:      "name",
+				HTTPRouteGatewayNamespace: "namespace",
+			},
+			wantQueue: "team-llm",
+			wantErr:   "",
+		},
+		{
+			name:   "kueue enabled missing queue for non-default owner",
+			owner:  "user-a",
+			labels: nil,
+			cfg: &oscarType.Config{
+				KueueEnable:               true,
+				HTTPRouteGatewayName:      "name",
+				HTTPRouteGatewayNamespace: "namespace",
+			},
+			wantErr: "missing required label 'kueue.x-k8s.io/queue-name'",
+		},
+		{
+			name:   "kueue enabled missing queue for default owner",
+			owner:  oscarType.DefaultOwner,
+			labels: nil,
+			cfg: &oscarType.Config{
+				KueueEnable:               true,
+				HTTPRouteGatewayName:      "name",
+				HTTPRouteGatewayNamespace: "namespace",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := llmKserveService()
+			svc.Owner = tt.owner
+			svc.Labels = tt.labels
+
+			isvc, err := NewKserveLLMInferenceServiceDefinition(svc, knSvc, tt.cfg)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			labels := getNestedMap(t, isvc, "spec", "labels")
+			queue, hasQueue := labels["kueue.x-k8s.io/queue-name"]
+			if tt.wantQueue == "" {
+				if hasQueue {
+					t.Fatalf("did not expect queue label, got %v", queue)
+				}
+				return
+			}
+
+			if !hasQueue {
+				t.Fatalf("expected queue label %q, got none", tt.wantQueue)
+			}
+			if queue != tt.wantQueue {
+				t.Fatalf("queue label = %v, want %q", queue, tt.wantQueue)
+			}
+		})
+	}
+}
+
+func TestNewKserveLLMInferenceServiceDefinition_MissingGatewayConfig(t *testing.T) {
+	svc := llmKserveService()
+	knSvc := knativeServiceWithUID("uid-llm-missing-gateway")
 
 	_, err := NewKserveLLMInferenceServiceDefinition(svc, knSvc, &oscarType.Config{})
 	if err == nil {
-		t.Fatal("expected error when ModelFormat is not llm, got nil")
+		t.Fatal("expected error when gateway configuration is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "gateway namespace and name must be provided") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -484,7 +687,165 @@ func TestUpdateKserveInferenceServiceDefinition_InvalidCPU(t *testing.T) {
 	}
 }
 
+func TestUpdateKserveInferenceServiceDefinition_DefaultProtocolVersionWhenMissing(t *testing.T) {
+	svc := kserveService()
+	svc.Kserve.APIVersion = ""
+
+	oldIsvc := &unstructured.Unstructured{Object: map[string]any{
+		"spec": map[string]any{
+			"predictor": map[string]any{
+				"model": map[string]any{},
+			},
+		},
+	}}
+
+	updated, err := UpdateKserveInferenceServiceDefinition(svc, oldIsvc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := getNestedString(t, updated, "spec", "predictor", "model", "protocolVersion"); got != "v1" {
+		t.Fatalf("protocolVersion = %q, want %q", got, "v1")
+	}
+}
+
+func TestUpdateKserveInferenceServiceDefinition_PreservesPredictorLabels(t *testing.T) {
+	knSvc := knativeServiceWithUID("uid-update-labels")
+	oldIsvc, err := NewKserveInferenceServiceDefinition(kserveService(), knSvc, &oscarType.Config{})
+	if err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	predictorAny := getRawNested(t, oldIsvc, "spec", "predictor")
+	predictor, ok := predictorAny.(map[string]any)
+	if !ok {
+		t.Fatalf("expected predictor map, got %T", predictorAny)
+	}
+	predictor["labels"] = map[string]any{"preserve": "yes"}
+
+	updated, err := UpdateKserveInferenceServiceDefinition(kserveService(), oldIsvc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	labels := getNestedMap(t, updated, "spec", "predictor", "labels")
+	if labels["preserve"] != "yes" {
+		t.Fatalf("labels.preserve = %v, want %q", labels["preserve"], "yes")
+	}
+}
+
 // ─── ValidateKserveService ───────────────────────────────────────────────────
+
+func TestValidateKserveService_DecisionPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		build   func() *oscarType.Service
+		wantErr string
+	}{
+		{
+			name: "missing kserve config",
+			build: func() *oscarType.Service {
+				return &oscarType.Service{Name: "bare"}
+			},
+			wantErr: "service does not have KServe configuration",
+		},
+		{
+			name: "missing kserve type",
+			build: func() *oscarType.Service {
+				svc := kserveService()
+				svc.Kserve.Type = ""
+				return svc
+			},
+			wantErr: "missing KServe service type",
+		},
+		{
+			name: "missing storage uri",
+			build: func() *oscarType.Service {
+				svc := kserveService()
+				svc.Kserve.StorageUri = ""
+				return svc
+			},
+			wantErr: "missing model storage URI",
+		},
+		{
+			name: "inference type missing inference block",
+			build: func() *oscarType.Service {
+				svc := kserveService()
+				svc.Kserve.Inference = nil
+				return svc
+			},
+			wantErr: "missing Inference configuration",
+		},
+		{
+			name: "inference type missing model format",
+			build: func() *oscarType.Service {
+				svc := kserveService()
+				svc.Kserve.Inference.ModelFormat = ""
+				return svc
+			},
+			wantErr: "missing model format",
+		},
+		{
+			name: "inference type with llm inference block",
+			build: func() *oscarType.Service {
+				svc := kserveService()
+				svc.Kserve.LLMInference = &oscarType.KserveLLMInference{RuntimeImage: "x"}
+				return svc
+			},
+			wantErr: "LLMInference configuration should be nil",
+		},
+		{
+			name: "llm inference type with inference block",
+			build: func() *oscarType.Service {
+				svc := llmKserveService()
+				svc.Kserve.Inference = &oscarType.KserveInference{ModelFormat: "sklearn"}
+				return svc
+			},
+			wantErr: "Inference configuration should be nil",
+		},
+		{
+			name: "invalid api version",
+			build: func() *oscarType.Service {
+				svc := kserveService()
+				svc.Kserve.APIVersion = "v3"
+				return svc
+			},
+			wantErr: "invalid APIVersion",
+		},
+		{
+			name: "valid inference service",
+			build: func() *oscarType.Service {
+				return kserveService()
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid llm service",
+			build: func() *oscarType.Service {
+				return llmKserveService()
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateKserveService(tt.build())
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestValidateKserveService_Valid(t *testing.T) {
 	svc := kserveService()
@@ -577,6 +938,40 @@ func TestKserveNamingHelpers(t *testing.T) {
 	}
 }
 
+func TestBuildKserveName(t *testing.T) {
+	if got := buildKserveName("demo-service"); got != "demo-service" {
+		t.Fatalf("buildKserveName() = %q, want %q", got, "demo-service")
+	}
+}
+
+func TestGetOwnerReference(t *testing.T) {
+	knSvc := knativeServiceWithUID("uid-owner")
+	refs := getOwnerReference(knSvc)
+	if len(refs) != 1 {
+		t.Fatalf("expected exactly one owner reference, got %d", len(refs))
+	}
+
+	ref := refs[0]
+	if ref.APIVersion != "serving.knative.dev/v1" {
+		t.Fatalf("APIVersion = %q, want %q", ref.APIVersion, "serving.knative.dev/v1")
+	}
+	if ref.Kind != "Service" {
+		t.Fatalf("Kind = %q, want %q", ref.Kind, "Service")
+	}
+	if ref.Name != knSvc.Name {
+		t.Fatalf("Name = %q, want %q", ref.Name, knSvc.Name)
+	}
+	if ref.UID != knSvc.UID {
+		t.Fatalf("UID = %q, want %q", ref.UID, knSvc.UID)
+	}
+	if ref.Controller == nil || *ref.Controller {
+		t.Fatalf("Controller = %v, want false", ref.Controller)
+	}
+	if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+		t.Fatalf("BlockOwnerDeletion = %v, want true", ref.BlockOwnerDeletion)
+	}
+}
+
 func TestNormalizeScaleFromKserveService(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -589,6 +984,7 @@ func TestNormalizeScaleFromKserveService(t *testing.T) {
 		{name: "max respected", input: &oscarType.Kserve{MaxScale: 5}, wantMin: 0, wantMax: 5},
 		{name: "min greater than max", input: &oscarType.Kserve{MinScale: 4, MaxScale: 2}, wantMin: 4, wantMax: 4},
 		{name: "both set", input: &oscarType.Kserve{MinScale: 1, MaxScale: 3}, wantMin: 1, wantMax: 3},
+		{name: "llm min forced to one", input: &oscarType.Kserve{Type: KserveTypeLLMInferenceService}, wantMin: 1, wantMax: 1},
 	}
 
 	for _, tt := range tests {
@@ -720,6 +1116,21 @@ func TestCheckKserveUpdate(t *testing.T) {
 			name: "cannot change auth",
 			mutate: func(oldSvc, newSvc *oscarType.Service) {
 				newSvc.Kserve.SetAuth = true
+			},
+			wantErr: true,
+		},
+		{
+			name: "cannot change runtime",
+			mutate: func(oldSvc, newSvc *oscarType.Service) {
+				oldSvc.Kserve.Inference.Runtime = "kserve-runtime-a"
+				newSvc.Kserve.Inference.Runtime = "kserve-runtime-b"
+			},
+			wantErr: true,
+		},
+		{
+			name: "cannot change kserve type",
+			mutate: func(oldSvc, newSvc *oscarType.Service) {
+				newSvc.Kserve.Type = KserveTypeLLMInferenceService
 			},
 			wantErr: true,
 		},
@@ -989,6 +1400,23 @@ func setDynamicClientFactoryForTest(t *testing.T, factory dynamicClientFactory) 
 	t.Cleanup(func() {
 		newDynamicClient = original
 	})
+}
+
+func TestExistsKserveHTTPRouteByServiceName_DynamicClientError(t *testing.T) {
+	setDynamicClientFactoryForTest(t, func() (*dynamic.DynamicClient, error) {
+		return nil, errors.New("dynamic client failure")
+	})
+
+	exists, err := existsKserveHTTPRouteByServiceName("svc", "ns")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if exists {
+		t.Fatal("exists should be false when dynamic client creation fails")
+	}
+	if !strings.Contains(err.Error(), "failed to create dynamic client") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func newHTTPRouteForTest(name, namespace, path string) *unstructured.Unstructured {

--- a/pkg/utils/kueue.go
+++ b/pkg/utils/kueue.go
@@ -439,9 +439,14 @@ func buildResourceCheckPodSet(name string, replicas int32, requests v1.ResourceL
 		Count: replicas,
 		Template: v1.PodTemplateSpec{
 			Spec: v1.PodSpec{
-				Containers: []v1.Container{{Name: "resource-check"}},
-				Resources: &v1.ResourceRequirements{
-					Requests: requests,
+				Containers: []v1.Container{
+					{
+						Name: "resource-check",
+						Resources: v1.ResourceRequirements{
+							Requests: requests,
+							Limits:   requests,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/utils/kueue_test.go
+++ b/pkg/utils/kueue_test.go
@@ -505,12 +505,15 @@ func TestGetResourceOnlyWorkloadSpecWithKServePodSet(t *testing.T) {
 	service := newTestService("test-service", "testuser")
 	service.Expose.MinScale = 2
 	service.Kserve = &types.Kserve{
-		ModelFormat: "sklearn",
-		StorageUri:  "s3://models/sklearn",
-		MinScale:    3,
-		CPU:         "1",
-		Memory:      "2Gi",
-		EnableGPU:   true,
+		Type: KserveTypeInferenceService,
+		Inference: &types.KserveInference{
+			ModelFormat: "sklearn",
+		},
+		StorageUri: "s3://models/sklearn",
+		MinScale:   3,
+		CPU:        "1",
+		Memory:     "2Gi",
+		EnableGPU:  true,
 	}
 
 	cfg := newTestConfig()
@@ -883,7 +886,7 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			name: "kserve service but unsupported route kind",
 			service: func() *types.Service {
 				s := newTestService("svc-kserve-ingress", "owner")
-				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn"}
+				s.Kserve = &types.Kserve{Type: KserveTypeInferenceService, Inference: &types.KserveInference{ModelFormat: "sklearn"}, StorageUri: "s3://models/sklearn"}
 				return &s
 			}(),
 			cfg: func() *types.Config {
@@ -895,10 +898,28 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			wantHasSet: false,
 		},
 		{
-			name: "kserve defaults and min scale fallback",
+			name: "kserve Inference defaults and min scale fallback",
 			service: func() *types.Service {
 				s := newTestService("svc-kserve-default", "owner")
-				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", MinScale: 0}
+				s.Kserve = &types.Kserve{Type: KserveTypeInferenceService, Inference: &types.KserveInference{ModelFormat: "sklearn"}, StorageUri: "s3://models/sklearn", MinScale: 0}
+				return &s
+			}(),
+			cfg: func() *types.Config {
+				c := newTestConfig()
+				c.KserveEnable = true
+				c.ExposedServicesRouteKind = "httproute"
+				return c
+			}(),
+			wantHasSet: true,
+			wantScale:  1,
+			wantCPU:    defaultKserveCpuRequest.String(),
+			wantMemory: defaultKserveMemoryRequest.String(),
+		},
+		{
+			name: "kserve LLMInference defaults and min scale fallback",
+			service: func() *types.Service {
+				s := newTestService("svc-kserve-default", "owner")
+				s.Kserve = &types.Kserve{Type: KserveTypeLLMInferenceService, StorageUri: "s3://models/llama", MinScale: 0}
 				return &s
 			}(),
 			cfg: func() *types.Config {
@@ -916,7 +937,7 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			name: "kserve custom resources and gpu",
 			service: func() *types.Service {
 				s := newTestService("svc-kserve-custom", "owner")
-				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", MinScale: 3, CPU: "1", Memory: "2Gi", EnableGPU: true}
+				s.Kserve = &types.Kserve{Type: KserveTypeInferenceService, Inference: &types.KserveInference{ModelFormat: "sklearn"}, StorageUri: "s3://models/sklearn", MinScale: 3, CPU: "1", Memory: "2Gi", EnableGPU: true}
 				return &s
 			}(),
 			cfg: func() *types.Config {
@@ -935,7 +956,7 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			name: "kserve invalid cpu",
 			service: func() *types.Service {
 				s := newTestService("svc-kserve-badcpu", "owner")
-				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", CPU: "bad-cpu"}
+				s.Kserve = &types.Kserve{Type: KserveTypeInferenceService, Inference: &types.KserveInference{ModelFormat: "sklearn"}, StorageUri: "s3://models/sklearn", CPU: "bad-cpu"}
 				return &s
 			}(),
 			cfg: func() *types.Config {
@@ -951,7 +972,7 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			name: "kserve invalid memory",
 			service: func() *types.Service {
 				s := newTestService("svc-kserve-badmem", "owner")
-				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", Memory: "bad-memory"}
+				s.Kserve = &types.Kserve{Type: KserveTypeInferenceService, Inference: &types.KserveInference{ModelFormat: "sklearn"}, StorageUri: "s3://models/sklearn", Memory: "bad-memory"}
 				return &s
 			}(),
 			cfg: func() *types.Config {

--- a/pkg/utils/kueue_test.go
+++ b/pkg/utils/kueue_test.go
@@ -3,7 +3,9 @@ package utils
 import (
 	"context"
 	"math"
+	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/grycap/oscar/v3/pkg/types"
@@ -675,5 +677,369 @@ func TestCreateKueueUserQueuesIfDontExistIntegration(t *testing.T) {
 	err := CreateKueueUserQueuesIfDontExist(cfg, "testuser")
 	if err != nil {
 		t.Errorf("CreateKueueUserQueuesIfDontExist() failed with disabled kueue: %v", err)
+	}
+}
+
+func TestSanitizeKueueNameExported(t *testing.T) {
+	inputs := []string{"User@Test.Com", "", "name-with-valid-chars", "@@invalid@@"}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			got := SanitizeKueueName(input)
+			want := sanitizeKueueName(input)
+			if got != want {
+				t.Fatalf("SanitizeKueueName(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestGetWorkloadSpecInvalidResources(t *testing.T) {
+	cfg := newTestConfig()
+	namespace := "test-ns"
+	templateFunc := func(s types.Service, ns string, c *types.Config) v1.PodTemplateSpec {
+		return v1.PodTemplateSpec{Spec: v1.PodSpec{Containers: []v1.Container{{Name: s.Name, Image: s.Image}}}}
+	}
+
+	tests := []struct {
+		name    string
+		service types.Service
+	}{
+		{
+			name: "invalid cpu returns nil workload",
+			service: func() types.Service {
+				s := newTestService("svc-cpu", "owner")
+				s.CPU = "invalid-cpu"
+				return s
+			}(),
+		},
+		{
+			name: "invalid memory returns nil workload",
+			service: func() types.Service {
+				s := newTestService("svc-mem", "owner")
+				s.Memory = "invalid-memory"
+				return s
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workload := getWorkloadSpec(tt.service, namespace, cfg, templateFunc)
+			if workload != nil {
+				t.Fatalf("expected nil workload for invalid resources, got %#v", workload)
+			}
+		})
+	}
+}
+
+func TestGetServiceResourceRequestsDecisionGraph(t *testing.T) {
+	cfg := newTestConfig()
+
+	// Decision paths covered:
+	// P1: default CPU/memory when empty
+	// P2: custom CPU/memory accepted
+	// P3: invalid CPU -> error
+	// P4: invalid memory -> error
+	// P5: GPU request appended
+	// P6: SGX request appended
+	tests := []struct {
+		name        string
+		service     *types.Service
+		wantErr     bool
+		wantErrText string
+		wantCPU     string
+		wantMemory  string
+		wantGPU     bool
+		wantSGX     bool
+	}{
+		{
+			name: "defaults when cpu and memory empty",
+			service: func() *types.Service {
+				s := newTestService("svc-default", "owner")
+				s.CPU = ""
+				s.Memory = ""
+				return &s
+			}(),
+			wantCPU:    defaultCpuRequest.String(),
+			wantMemory: defaultMemoryRequest.String(),
+		},
+		{
+			name: "custom cpu and memory",
+			service: func() *types.Service {
+				s := newTestService("svc-custom", "owner")
+				s.CPU = "750m"
+				s.Memory = "768Mi"
+				return &s
+			}(),
+			wantCPU:    "750m",
+			wantMemory: "768Mi",
+		},
+		{
+			name: "invalid cpu",
+			service: func() *types.Service {
+				s := newTestService("svc-invalid-cpu", "owner")
+				s.CPU = "bad-cpu"
+				return &s
+			}(),
+			wantErr:     true,
+			wantErrText: "invalid service CPU",
+		},
+		{
+			name: "invalid memory",
+			service: func() *types.Service {
+				s := newTestService("svc-invalid-memory", "owner")
+				s.Memory = "bad-memory"
+				return &s
+			}(),
+			wantErr:     true,
+			wantErrText: "invalid service memory",
+		},
+		{
+			name: "gpu and sgx resources included",
+			service: func() *types.Service {
+				s := newTestService("svc-accel", "owner")
+				s.EnableGPU = true
+				s.EnableSGX = true
+				return &s
+			}(),
+			wantCPU:    "500m",
+			wantMemory: "1Gi",
+			wantGPU:    true,
+			wantSGX:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests, err := getServiceResourceRequests(tt.service, cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrText)
+				}
+				if tt.wantErrText != "" && !regexp.MustCompile(regexp.QuoteMeta(tt.wantErrText)).MatchString(err.Error()) {
+					t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantErrText)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			cpuReq, ok := requests[v1.ResourceCPU]
+			if !ok {
+				t.Fatal("expected CPU request")
+			}
+			if cpuReq.String() != tt.wantCPU {
+				t.Fatalf("cpu request = %s, want %s", cpuReq.String(), tt.wantCPU)
+			}
+
+			memReq, ok := requests[v1.ResourceMemory]
+			if !ok {
+				t.Fatal("expected memory request")
+			}
+			if memReq.String() != tt.wantMemory {
+				t.Fatalf("memory request = %s, want %s", memReq.String(), tt.wantMemory)
+			}
+
+			_, hasGPU := requests["nvidia.com/gpu"]
+			if hasGPU != tt.wantGPU {
+				t.Fatalf("gpu request present = %v, want %v", hasGPU, tt.wantGPU)
+			}
+
+			_, hasSGX := requests["sgx.intel.com/enclave"]
+			if hasSGX != tt.wantSGX {
+				t.Fatalf("sgx request present = %v, want %v", hasSGX, tt.wantSGX)
+			}
+		})
+	}
+}
+
+func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
+	tests := []struct {
+		name        string
+		service     *types.Service
+		cfg         *types.Config
+		wantErr     bool
+		wantErrText string
+		wantHasSet  bool
+		wantScale   int32
+		wantCPU     string
+		wantMemory  string
+		wantGPU     bool
+	}{
+		{
+			name: "not a kserve service",
+			service: func() *types.Service {
+				s := newTestService("svc-non-kserve", "owner")
+				s.Kserve = nil
+				return &s
+			}(),
+			cfg:        newTestConfig(),
+			wantHasSet: false,
+		},
+		{
+			name: "kserve service but unsupported route kind",
+			service: func() *types.Service {
+				s := newTestService("svc-kserve-ingress", "owner")
+				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn"}
+				return &s
+			}(),
+			cfg: func() *types.Config {
+				c := newTestConfig()
+				c.KserveEnable = true
+				c.ExposedServicesRouteKind = "ingress"
+				return c
+			}(),
+			wantHasSet: false,
+		},
+		{
+			name: "kserve defaults and min scale fallback",
+			service: func() *types.Service {
+				s := newTestService("svc-kserve-default", "owner")
+				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", MinScale: 0}
+				return &s
+			}(),
+			cfg: func() *types.Config {
+				c := newTestConfig()
+				c.KserveEnable = true
+				c.ExposedServicesRouteKind = "httproute"
+				return c
+			}(),
+			wantHasSet: true,
+			wantScale:  1,
+			wantCPU:    defaultKserveCpuRequest.String(),
+			wantMemory: defaultKserveMemoryRequest.String(),
+		},
+		{
+			name: "kserve custom resources and gpu",
+			service: func() *types.Service {
+				s := newTestService("svc-kserve-custom", "owner")
+				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", MinScale: 3, CPU: "1", Memory: "2Gi", EnableGPU: true}
+				return &s
+			}(),
+			cfg: func() *types.Config {
+				c := newTestConfig()
+				c.KserveEnable = true
+				c.ExposedServicesRouteKind = "httproute"
+				return c
+			}(),
+			wantHasSet: true,
+			wantScale:  3,
+			wantCPU:    "1",
+			wantMemory: "2Gi",
+			wantGPU:    true,
+		},
+		{
+			name: "kserve invalid cpu",
+			service: func() *types.Service {
+				s := newTestService("svc-kserve-badcpu", "owner")
+				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", CPU: "bad-cpu"}
+				return &s
+			}(),
+			cfg: func() *types.Config {
+				c := newTestConfig()
+				c.KserveEnable = true
+				c.ExposedServicesRouteKind = "httproute"
+				return c
+			}(),
+			wantErr:     true,
+			wantErrText: "invalid KServe service CPU",
+		},
+		{
+			name: "kserve invalid memory",
+			service: func() *types.Service {
+				s := newTestService("svc-kserve-badmem", "owner")
+				s.Kserve = &types.Kserve{ModelFormat: "sklearn", StorageUri: "s3://models/sklearn", Memory: "bad-memory"}
+				return &s
+			}(),
+			cfg: func() *types.Config {
+				c := newTestConfig()
+				c.KserveEnable = true
+				c.ExposedServicesRouteKind = "httproute"
+				return c
+			}(),
+			wantErr:     true,
+			wantErrText: "invalid KServe service memory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests, scale, hasSet, err := getKserveResourceRequests(tt.service, tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrText)
+				}
+				if tt.wantErrText != "" && !regexp.MustCompile(regexp.QuoteMeta(tt.wantErrText)).MatchString(err.Error()) {
+					t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantErrText)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hasSet != tt.wantHasSet {
+				t.Fatalf("hasKservePodSet = %v, want %v", hasSet, tt.wantHasSet)
+			}
+			if !tt.wantHasSet {
+				return
+			}
+			if scale != tt.wantScale {
+				t.Fatalf("kserve min scale = %d, want %d", scale, tt.wantScale)
+			}
+
+			cpuReq, ok := requests[v1.ResourceCPU]
+			if !ok {
+				t.Fatal("expected KServe CPU request")
+			}
+			if cpuReq.String() != tt.wantCPU {
+				t.Fatalf("KServe CPU request = %s, want %s", cpuReq.String(), tt.wantCPU)
+			}
+
+			memReq, ok := requests[v1.ResourceMemory]
+			if !ok {
+				t.Fatal("expected KServe memory request")
+			}
+			if memReq.String() != tt.wantMemory {
+				t.Fatalf("KServe memory request = %s, want %s", memReq.String(), tt.wantMemory)
+			}
+
+			_, hasGPU := requests["nvidia.com/gpu"]
+			if hasGPU != tt.wantGPU {
+				t.Fatalf("KServe GPU request present = %v, want %v", hasGPU, tt.wantGPU)
+			}
+		})
+	}
+}
+
+func TestBuildVerificationWorkloadName(t *testing.T) {
+	name := buildVerificationWorkloadName("My_Service.With#Chars")
+
+	if len(name) > 63 {
+		t.Fatalf("buildVerificationWorkloadName() length = %d, want <= 63", len(name))
+	}
+
+	if !regexp.MustCompile(`^[a-z0-9-]+$`).MatchString(name) {
+		t.Fatalf("buildVerificationWorkloadName() = %q, expected DNS label compatible characters", name)
+	}
+
+	if !strings.HasPrefix(name, "verify-my-service-with-chars-") {
+		t.Fatalf("buildVerificationWorkloadName() = %q, expected prefix %q", name, "verify-my-service-with-chars-")
+	}
+
+	if !regexp.MustCompile(`-\d+$`).MatchString(name) {
+		t.Fatalf("buildVerificationWorkloadName() = %q, expected numeric timestamp suffix", name)
+	}
+}
+
+func TestVerifyWorkloadByResourcesNilConfig(t *testing.T) {
+	service := newTestService("test-service", "testuser")
+
+	result := VerifyWorkloadByResources(service, nil)
+	if result {
+		t.Error("Expected VerifyWorkloadByResources() to return false for nil config")
 	}
 }

--- a/pkg/utils/kueue_test.go
+++ b/pkg/utils/kueue_test.go
@@ -422,10 +422,7 @@ func TestGetResourceOnlyWorkloadSpec(t *testing.T) {
 		t.Fatalf("service podset replicas = %d, want %d", workload.Spec.PodSets[0].Count, service.Expose.MinScale)
 	}
 
-	resources := workload.Spec.PodSets[0].Template.Spec.Resources
-	if resources == nil {
-		t.Fatal("expected pod-level resources to be set")
-	}
+	resources := workload.Spec.PodSets[0].Template.Spec.Containers[0].Resources
 
 	if _, ok := resources.Requests[v1.ResourceCPU]; !ok {
 		t.Fatal("expected CPU request in resource-only workload")
@@ -483,10 +480,7 @@ func TestGetResourceOnlyWorkloadSpecWithoutResources(t *testing.T) {
 		t.Fatal("getResourceOnlyWorkloadSpec() returned nil workload")
 	}
 
-	resources := workload.Spec.PodSets[0].Template.Spec.Resources
-	if resources == nil {
-		t.Fatal("expected pod-level resources to be set")
-	}
+	resources := workload.Spec.PodSets[0].Template.Spec.Containers[0].Resources
 
 	cpuReq, ok := resources.Requests[v1.ResourceCPU]
 	if !ok {
@@ -543,10 +537,7 @@ func TestGetResourceOnlyWorkloadSpecWithKServePodSet(t *testing.T) {
 		t.Fatalf("kserve podset replicas = %d, want %d", kservePodSet.Count, service.Kserve.MinScale)
 	}
 
-	kserveResources := kservePodSet.Template.Spec.Resources
-	if kserveResources == nil {
-		t.Fatal("expected KServe podset resources to be set")
-	}
+	kserveResources := kservePodSet.Template.Spec.Containers[0].Resources
 
 	cpuReq, ok := kserveResources.Requests[v1.ResourceCPU]
 	if !ok {


### PR DESCRIPTION
This pull request introduces a significant refactor and extension of the KServe integration, enabling support for both standard inference and LLM inference services. The changes include a redesigned KServe configuration structure, improved validation, and updated deployment logic to accommodate the new types. Additionally, there are updates to deployment scripts and example manifests to align with these changes.

**KServe integration refactor and extension:**

* The `Kserve` struct in `pkg/types/service.go` is refactored to support a new `type` field, distinguishing between `"inference"` and `"llm_inference"` services, with corresponding configuration sections for each. Validation logic is updated to enforce required fields and correct configuration for each type. 
* Helper and deployment functions are updated to use the new `type` and configuration layout, replacing the previous `ModelFormat`-centric approach. This includes changes in deployment, update, and runtime inspection logic. 
* Validation and utility functions are improved to enforce correct configuration for each service type and to simplify service detection. 

**Deployment and configuration updates:**

* Example KServe service manifests are updated to use the new `type: inference` and nested `inference` configuration for model format. 
* The KServe Helm chart configuration is extended to disable Istio virtual host creation and enable Gateway API integration.
* The MinIO Helm chart version is bumped from `4.0.7` to `5.4.0` for storage provider deployment.
* The Traefik Gateway installation is updated to use server-side apply and the latest Gateway API manifests, with improved namespace handling.

**General improvements and bug fixes:**

* Improved error handling for port conflicts and HTTPRoute existence, and minor fixes in shell scripting. 
* Removal of outdated mapping and type logic for model formats in KServe utility code.

These changes collectively provide a more flexible, robust, and future-proof KServe integration, supporting both standard and LLM inference scenarios.

## IMPORTANT 

**New Kserve FDL structure**

```yaml
...
kserve:
  type: ("inference" or "llm_inference")
  inference: # Apply only when "type" is "inference"
    model_format: # Refer to https://kserve.github.io/website/docs/next/concepts/resources/servingruntime
    runtime: # (Optional) Refer to https://kserve.github.io/website/docs/next/concepts/resources/servingruntime
  llm_inference: # (Optional) Apply only when "type" is "llm_inference"
    runtime_image: # (Optional) Custom runtime image if needed
  storage_uri: (hf://... , oci://... , etc)
  api_version: ("v1", "v2") # (Optional) Default v1 depends of model_format
  min_scale: # (Optional) 
  max_scale: # (Optional) Only for  InferenceService
  cpu: # (Optional) 
  memory: # (Optional) 
  env: # (Optional) 
    - VAR: value
  args: # (Optional) 
    - "value"
  enable_gpu: # default false
  set_auth: # default true
...
```
Refs:
* Runtimes and Model formats https://kserve.github.io/website/docs/next/concepts/resources/servingruntime
