### PR TITLE
fix: add support for virtual-node.interlink/type label in InterLink availability check

### DIFF
--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -541,7 +541,7 @@ func (cfg *Config) CheckAvailableGPUs(kubeClientset kubernetes.Interface) {
 	}
 }
 
-// CheckAvailableInterLink checks if there is a node with the virtual kubelet annotation
+// CheckAvailableInterLink checks if there is a node with a virtual-kubelet label
 func (cfg *Config) CheckAvailableInterLink(kubeClientset kubernetes.Interface) {
 	selectors := []string{
 		"!node-role.kubernetes.io/control-plane,!node-role.kubernetes.io/master,type=virtual-kubelet",
@@ -550,7 +550,8 @@ func (cfg *Config) CheckAvailableInterLink(kubeClientset kubernetes.Interface) {
 	for _, selector := range selectors {
 		nodes, err := kubeClientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
 		if err != nil {
-			log.Printf("Error getting list of nodes: %v\n", err)
+			log.Printf("Error listing nodes with selector %q: %v\n", selector, err)
+			continue
 		}
 		if len(nodes.Items) > 0 {
 			cfg.InterLinkAvailable = true

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -543,17 +543,22 @@ func (cfg *Config) CheckAvailableGPUs(kubeClientset kubernetes.Interface) {
 
 // CheckAvailableInterLink checks if there is a node with the virtual kubelet annotation
 func (cfg *Config) CheckAvailableInterLink(kubeClientset kubernetes.Interface) {
-	nodes, err := kubeClientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane,!node-role.kubernetes.io/master,type=virtual-kubelet"})
-	if err != nil {
-		log.Printf("Error getting list of nodes: %v\n", err)
+	selectors := []string{
+		"!node-role.kubernetes.io/control-plane,!node-role.kubernetes.io/master,type=virtual-kubelet",
+		"!node-role.kubernetes.io/control-plane,!node-role.kubernetes.io/master,virtual-node.interlink/type=virtual-kubelet",
 	}
-	if len(nodes.Items) > 0 {
-		cfg.InterLinkAvailable = true
-		log.Printf("INFO: InterLink Available")
-	} else {
-		cfg.InterLinkAvailable = false
-		log.Printf("INFO: InterLink Unavailable")
+	for _, selector := range selectors {
+		nodes, err := kubeClientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			log.Printf("Error getting list of nodes: %v\n", err)
+		}
+		if len(nodes.Items) > 0 {
+			cfg.InterLinkAvailable = true
+			log.Printf("INFO: InterLink Available")
+			return
+		}
 	}
-	//cfg.InterLinkAvailable = true
+	cfg.InterLinkAvailable = false
+	log.Printf("INFO: InterLink Unavailable")
 
 }

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -84,6 +85,75 @@ func TestCheckAvailableResources(t *testing.T) {
 	cfg.CheckAvailableInterLink(client)
 	if !cfg.InterLinkAvailable {
 		t.Fatalf("expected InterLink availability to be detected")
+	}
+}
+
+func TestCheckAvailableInterLink(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		nodes    []*v1.Node
+		expected bool
+	}{
+		{
+			name: "detected via type label",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vk-node",
+						Labels: map[string]string{
+							"type": "virtual-kubelet",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "detected via virtual-node.interlink/type label",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "interlink-node",
+						Labels: map[string]string{
+							"virtual-node.interlink/type": "virtual-kubelet",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not detected without matching labels",
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "regular-node",
+						Labels: map[string]string{"some-other-label": "value"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "not detected with no nodes",
+			nodes:    []*v1.Node{},
+			expected: false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			cfg := &Config{}
+			objects := make([]runtime.Object, len(s.nodes))
+			for i, node := range s.nodes {
+				objects[i] = node
+			}
+			client := fake.NewSimpleClientset(objects...)
+			cfg.CheckAvailableInterLink(client)
+			if cfg.InterLinkAvailable != s.expected {
+				t.Errorf("expected InterLinkAvailable = %v, got %v", s.expected, cfg.InterLinkAvailable)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/grycap/issue-tracker/issues/396


## Summary
The `CheckAvailableInterLink` function in `pkg/types/config.go` previously used a single hardcoded label selector (`type=virtual-kubelet`) to detect virtual-kubelet nodes. This caused InterLink to not be detected in environments where nodes use the `virtual-node.interlink/type` label instead.
## Changes
- Replaced the single label selector with a list of two selectors:
  1. `!node-role.kubernetes.io/control-plane,!node-role.kubernetes.io/master,type=virtual-kubelet`
  2. `!node-role.kubernetes.io/control-plane,!node-role.kubernetes.io/master,virtual-node.interlink/type=virtual-kubelet`
- The function now iterates over both selectors and returns early (`InterLinkAvailable = true`) as soon as a matching node is found.
- Only if neither selector matches, it falls back to `InterLinkAvailable = false`.
- Removed the commented-out line `//cfg.InterLinkAvailable = true`.'