### PR TITLE
Fix KServe gpu limit

### DIFF
--- a/examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml
+++ b/examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml
@@ -13,6 +13,8 @@ functions:
         storage_uri: "oci://ghcr.io/grycap/kserve-yolo8n-onnx"
         min_scale: 1
         api_version: "v2"
+        cpu: '1.0'
+        memory: 2Gi
       log_level: CRITICAL
       input:
       - storage_provider: minio

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -359,8 +359,8 @@ type Kserve struct {
 	MinScale int32 `json:"min_scale,omitempty" default:"0"`
 
 	// MaxScale maximum number of active replicas (pods) for the service
-	// Optional. (default: 10)
-	MaxScale int32 `json:"max_scale,omitempty" default:"10"`
+	// Optional. (default: 1)
+	MaxScale int32 `json:"max_scale,omitempty" default:"1"`
 
 	// CPU cpu limit for the service following the kubernetes format
 	// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
@@ -400,7 +400,7 @@ func (k *Kserve) UnmarshalJSON(data []byte) error {
 		Memory:     "256Mi",
 		SetAuth:    false,
 		MinScale:   0,
-		MaxScale:   10,
+		MaxScale:   1,
 		EnableGPU:  false,
 	}
 

--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -865,6 +865,7 @@ func createKserveResources(service *types.Kserve) (v1.ResourceRequirements, erro
 		if err != nil {
 			return resources, err
 		}
+		resources.Limits["nvidia.com/gpu"] = gpu
 		resources.Requests["nvidia.com/gpu"] = gpu
 	}
 


### PR DESCRIPTION
This pull request introduces changes to resource allocation and scaling defaults for KServe services, as well as an adjustment to GPU resource handling. The main focus is on refining default values for scaling, explicitly specifying resource requirements, and ensuring correct GPU limit assignment.

**Resource and scaling configuration improvements:**

* Changed the default value of `MaxScale` from 10 to 1 in the `Kserve` struct, its JSON unmarshalling logic, and documentation to better reflect typical usage and avoid over-provisioning by default. [[1]](diffhunk://#diff-eea8336f4a56071c9879b7deb268ccad4f70fd9c485b395f27cb6db2285db3d7L362-R363) [[2]](diffhunk://#diff-eea8336f4a56071c9879b7deb268ccad4f70fd9c485b395f27cb6db2285db3d7L403-R403)
* Explicitly set `cpu: '1.0'` and `memory: 2Gi` in the `oscar-svc-yolo8n.yaml` example, ensuring resource requirements are clearly defined for the service.

**GPU resource management:**

* Added assignment of GPU limits (`resources.Limits["nvidia.com/gpu"]`) when creating KServe resources, ensuring both requests and limits are set for GPU resources.