### PR TITLE
Fix go-m1cpu SIGSEGV during Go tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/rs/xid v1.4.0 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,11 @@ github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/i
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=


### PR DESCRIPTION
## Summary

Updates the selected `github.com/shoenig/go-m1cpu` version from `v0.1.6` to `v0.2.1` while keeping the existing `gopsutil/v3` dependency in place.

## Problem

Running `go test ./...` on macOS/arm64 with Go 1.26.3 crashes before package tests execute. The crash happens during package initialization inside `github.com/shoenig/go-m1cpu@v0.1.6`, while cgo calls its CPU detection initialization routine:

```text
SIGSEGV: segmentation violation
signal arrived during cgo execution
github.com/shoenig/go-m1cpu._Cfunc_initialize()
github.com/shoenig/go-m1cpu.init.0()
```

The dependency is pulled through the existing MinIO admin/gopsutil path:

```text
pkg/utils -> github.com/minio/madmin-go -> github.com/shirou/gopsutil/v3/cpu -> github.com/shoenig/go-m1cpu
```

A similar upstream fix in `projectdiscovery/utils` avoids this failure by moving away from the `go-m1cpu@v0.1.6` path through a larger `gopsutil` upgrade. In OSCAR, the smaller and lower-risk change is to pin `go-m1cpu` directly to a fixed version.

## Changes

- Select `github.com/shoenig/go-m1cpu@v0.2.1` in `go.mod`.
- Update `go.sum` with the new module checksums.

## Validation

- `go test ./...`