### PR TITLE
Feat add service access check endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,6 +110,10 @@ func main() {
 	// Create the router
 	r := gin.Default()
 
+	r.GET("/system/services/:serviceName/auth",
+		append(auth.BuildServiceAuthMiddlewareChain(cfg, kubeClientset, back), handlers.MakeServiceAuthHandler())...,
+	)
+
 	// Swagger UI endpoint (disabled in production)
 	// r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 

--- a/pkg/handlers/service_auth.go
+++ b/pkg/handlers/service_auth.go
@@ -1,0 +1,43 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MakeServiceAuthHandler godoc
+// @Summary Authenticate service
+// @Description Validate access to a specific service using Basic auth or Bearer token (service token or OIDC token), plus service-level permissions.
+// @Tags services
+// @Param serviceName path string true "Service name"
+// @Success 200 "OK"
+// @Failure 401 "Unauthorized"
+// @Failure 403 "Forbidden"
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Security BasicAuth
+// @Security BearerAuth
+// @Router /system/services/{serviceName}/auth [get]
+func MakeServiceAuthHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Status(http.StatusOK)
+		return
+	}
+}

--- a/pkg/handlers/service_auth_test.go
+++ b/pkg/handlers/service_auth_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMakeServiceAuthHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Decision graph paths for this handler:
+	// 1) Request reaches the handler -> return HTTP 200.
+	tests := []struct {
+		name       string
+		targetPath string
+		wantStatus int
+	}{
+		{
+			name:       "returns 200 when request reaches auth handler",
+			targetPath: "/system/services/example/auth",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.GET("/system/services/:serviceName/auth", MakeServiceAuthHandler())
+
+			req, err := http.NewRequest(http.MethodGet, tt.targetPath, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/pkg/utils/auth/auth.go
+++ b/pkg/utils/auth/auth.go
@@ -39,6 +39,32 @@ func GetAuthMiddleware(cfg *types.Config, kubeClientset kubernetes.Interface) gi
 	return CustomAuth(cfg, kubeClientset)
 }
 
+func BuildServiceAuthMiddlewareChain(cfg *types.Config, kubeClientset kubernetes.Interface, back types.ServerlessBackend) []gin.HandlerFunc {
+	var authHandler gin.HandlerFunc
+	fmt.Printf("OIDC authentication enabled: %v\n", cfg.OIDCEnable)
+	if !cfg.OIDCEnable {
+		authHandler = gin.BasicAuth(gin.Accounts{
+			// Use the config's username and password for basic auth
+			cfg.Username: cfg.Password,
+		})
+	} else {
+		authHandler = CustomAuth(cfg, kubeClientset)
+	}
+
+	var wrapperHandler gin.HandlerFunc = func(c *gin.Context) {
+		if isServiceToken, exists := c.Get(isServiceTokenKey); exists {
+			if validServiceToken, ok := isServiceToken.(bool); ok && validServiceToken {
+				c.Next()
+				return
+			}
+		}
+
+		authHandler(c)
+	}
+
+	return []gin.HandlerFunc{GetServiceTokenMiddleware(back), wrapperHandler, GetServicePermissionsMiddleware(back)}
+}
+
 // CustomAuth returns a custom auth handler (gin middleware)
 func CustomAuth(cfg *types.Config, kubeClientset kubernetes.Interface) gin.HandlerFunc {
 	basicAuthHandler := gin.BasicAuth(gin.Accounts{

--- a/pkg/utils/auth/service_permissions.go
+++ b/pkg/utils/auth/service_permissions.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/grycap/oscar/v4/pkg/utils"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// GetServicePermissionsMiddleware returns a gin middleware that checks if the request has permissions to access the service
+// STRICTLY after the request is authenticated, either by service token, OIDC or basic auth. It checks the service visibility and permissions according to the following rules:
+// - If the service is public, it allows access to everyone.
+// - If the service is private, it allows access only to the owner of the service.
+// - If the service is restricted, it allows access to the owner and the users in the allowed users list.
+func GetServicePermissionsMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// If autenticated with service token
+		if isServiceToken, exists := c.Get(isServiceTokenKey); exists {
+			if validServiceToken, ok := isServiceToken.(bool); ok && validServiceToken {
+				c.Next()
+				return
+			}
+		}
+
+		// Get service if exists
+		service, err := back.ReadService("", c.Param("serviceName"))
+		if err != nil {
+			// Check if error is caused because the service is not found
+			if errors.IsNotFound(err) || errors.IsGone(err) {
+				c.AbortWithStatus(http.StatusNotFound)
+			} else {
+				c.AbortWithStatus(http.StatusInternalServerError)
+			}
+			return
+		}
+
+		// If admin
+		if _, ok := c.Get(gin.AuthUserKey); ok && isBasicAuth(c) {
+			c.Next()
+			return
+		}
+
+		// If authenticated with OIDC
+		// Check permissions to access the service
+		if _, ok := isAuthBearer(c); ok {
+			uid, err := GetUIDFromContext(c)
+			if err != nil {
+				c.AbortWithStatus(http.StatusForbidden)
+				return
+			}
+
+			if hasPermission(service, uid) {
+				c.Next()
+				return
+			}
+		}
+
+		c.AbortWithStatus(http.StatusForbidden)
+		return
+	}
+}
+
+func hasPermission(service *types.Service, uid string) bool {
+	switch service.Visibility {
+	case utils.PUBLIC:
+		return true
+	case utils.PRIVATE:
+		if service.Owner == uid {
+			return true
+		}
+	case utils.RESTRICTED:
+		if service.Owner == uid || slices.Contains(service.AllowedUsers, uid) {
+			return true
+		}
+	default:
+		return false
+	}
+	return false
+}
+
+func isAuthBearer(c *gin.Context) (string, bool) {
+	authHeader := c.GetHeader("Authorization")
+	splitToken := strings.Split(authHeader, "Bearer ")
+	if len(splitToken) == 2 {
+		return strings.TrimSpace(splitToken[1]), true
+	}
+	return "", false
+}
+
+func isBasicAuth(c *gin.Context) bool {
+	if _, _, ok := c.Request.BasicAuth(); ok {
+		return true
+	}
+	return false
+}

--- a/pkg/utils/auth/service_permissions.go
+++ b/pkg/utils/auth/service_permissions.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (

--- a/pkg/utils/auth/service_permissions_test.go
+++ b/pkg/utils/auth/service_permissions_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (

--- a/pkg/utils/auth/service_permissions_test.go
+++ b/pkg/utils/auth/service_permissions_test.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/grycap/oscar/v4/pkg/utils"
+)
+
+func TestHasPermission(t *testing.T) {
+	// Decision graph paths for hasPermission:
+	// 1) public -> allow
+	// 2) private + owner -> allow
+	// 3) private + non-owner -> deny
+	// 4) restricted + owner -> allow
+	// 5) restricted + allowed user -> allow
+	// 6) restricted + non-owner + not allowed -> deny
+	// 7) unknown visibility -> deny
+	tests := []struct {
+		name    string
+		service *types.Service
+		uid     string
+		want    bool
+	}{
+		{
+			name: "public service allows everyone",
+			service: &types.Service{
+				Visibility: utils.PUBLIC,
+				Owner:      "owner",
+			},
+			uid:  "any-user",
+			want: true,
+		},
+		{
+			name: "private service allows owner",
+			service: &types.Service{
+				Visibility: utils.PRIVATE,
+				Owner:      "owner",
+			},
+			uid:  "owner",
+			want: true,
+		},
+		{
+			name: "private service denies non-owner",
+			service: &types.Service{
+				Visibility: utils.PRIVATE,
+				Owner:      "owner",
+			},
+			uid:  "other-user",
+			want: false,
+		},
+		{
+			name: "restricted service allows owner",
+			service: &types.Service{
+				Visibility:   utils.RESTRICTED,
+				Owner:        "owner",
+				AllowedUsers: []string{"allowed-user"},
+			},
+			uid:  "owner",
+			want: true,
+		},
+		{
+			name: "restricted service allows listed user",
+			service: &types.Service{
+				Visibility:   utils.RESTRICTED,
+				Owner:        "owner",
+				AllowedUsers: []string{"allowed-user"},
+			},
+			uid:  "allowed-user",
+			want: true,
+		},
+		{
+			name: "restricted service denies non-listed user",
+			service: &types.Service{
+				Visibility:   utils.RESTRICTED,
+				Owner:        "owner",
+				AllowedUsers: []string{"allowed-user"},
+			},
+			uid:  "other-user",
+			want: false,
+		},
+		{
+			name: "unknown visibility denies access",
+			service: &types.Service{
+				Visibility: "custom",
+				Owner:      "owner",
+			},
+			uid:  "owner",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasPermission(tt.service, tt.uid)
+			if got != tt.want {
+				t.Errorf("hasPermission() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAuthBearer(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{name: "valid bearer header", header: "Bearer token-123", want: true},
+		{name: "missing authorization header", header: "", want: false},
+		{name: "non bearer scheme", header: "Basic dXNlcjpwYXNz", want: false},
+		{name: "incomplete bearer prefix", header: "Bearer", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Authorization", tt.header)
+			c.Request = req
+
+			_, got := isAuthBearer(c)
+			if got != tt.want {
+				t.Errorf("isAuthBearer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBasicAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		setAuth    bool
+		username   string
+		password   string
+		wantResult bool
+	}{
+		{name: "request with basic auth", setAuth: true, username: "user", password: "pass", wantResult: true},
+		{name: "request without basic auth", setAuth: false, wantResult: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			if tt.setAuth {
+				req.SetBasicAuth(tt.username, tt.password)
+			}
+			c.Request = req
+
+			got := isBasicAuth(c)
+			if got != tt.wantResult {
+				t.Errorf("isBasicAuth() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}

--- a/pkg/utils/auth/service_token.go
+++ b/pkg/utils/auth/service_token.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v4/pkg/types"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const tokenLength = 64
+const isServiceTokenKey = "isServiceToken"
+
+// GetServiceTokenMiddleware returns a gin middleware that checks if the request is authenticated with a service token
+// APPLY ONLY before auth.GetAuthMiddleware, since it relies on the fact that if a service token is provided, the user authentication will not be performed
+func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if isBasicAuth(c) {
+			c.Next()
+			return
+		}
+
+		// Check if reqToken is the service token
+		if token, ok := isAuthBearer(c); ok && len(token) == tokenLength {
+			serviceList, err := back.ListServicesByName(c.Param("serviceName"), "")
+			if err != nil {
+				// Check if error is caused because the service is not found
+				if errors.IsNotFound(err) || errors.IsGone(err) {
+					c.AbortWithStatus(http.StatusNotFound)
+				} else {
+					c.AbortWithStatus(http.StatusInternalServerError)
+				}
+				return
+			}
+
+			for _, serviceIter := range serviceList {
+				if token == serviceIter.Token {
+					c.Set(isServiceTokenKey, true)
+					c.Next()
+					return
+				}
+			}
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
+		c.Next()
+		return
+	}
+}

--- a/pkg/utils/auth/service_token.go
+++ b/pkg/utils/auth/service_token.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (

--- a/pkg/utils/auth/service_token_test.go
+++ b/pkg/utils/auth/service_token_test.go
@@ -1,0 +1,198 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v4/pkg/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+)
+
+type serviceTokenMockBackend struct {
+	listServicesByNameResult []*types.Service
+	listServicesByNameErr    error
+	listServicesByNameCalled bool
+}
+
+func (m *serviceTokenMockBackend) GetInfo() *types.ServerlessBackendInfo {
+	return &types.ServerlessBackendInfo{}
+}
+
+func (m *serviceTokenMockBackend) ListServices(namespaces ...string) ([]*types.Service, error) {
+	return nil, nil
+}
+
+func (m *serviceTokenMockBackend) ListServicesByName(name string, namespaces ...string) ([]*types.Service, error) {
+	m.listServicesByNameCalled = true
+	return m.listServicesByNameResult, m.listServicesByNameErr
+}
+
+func (m *serviceTokenMockBackend) CreateService(service types.Service) error {
+	return nil
+}
+
+func (m *serviceTokenMockBackend) ReadService(namespace, name string) (*types.Service, error) {
+	return nil, nil
+}
+
+func (m *serviceTokenMockBackend) UpdateService(service types.Service) error {
+	return nil
+}
+
+func (m *serviceTokenMockBackend) DeleteService(service types.Service) error {
+	return nil
+}
+
+func (m *serviceTokenMockBackend) GetKubeClientset() kubernetes.Interface {
+	return nil
+}
+
+func TestGetServiceTokenMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	validToken := strings.Repeat("a", tokenLength)
+
+	// Decision graph paths for GetServiceTokenMiddleware:
+	// 1) basic auth -> pass through
+	// 2) no bearer token -> pass through
+	// 3) bearer token with invalid length -> pass through
+	// 4) valid bearer + backend not found -> 404
+	// 5) valid bearer + backend error -> 500
+	// 6) valid bearer + token match -> set context + pass through
+	// 7) valid bearer + no match -> 401
+	tests := []struct {
+		name                string
+		basicAuth           bool
+		authHeader          string
+		backendServices     []*types.Service
+		backendErr          error
+		wantLookup          bool
+		wantStatus          int
+		wantNextHandler     bool
+		wantServiceTokenCtx bool
+	}{
+		{
+			name:                "allows request with basic auth",
+			basicAuth:           true,
+			wantLookup:          false,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: false,
+		},
+		{
+			name:                "allows request without bearer token",
+			authHeader:          "",
+			wantLookup:          false,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: false,
+		},
+		{
+			name:                "allows request with bearer token of invalid length",
+			authHeader:          "Bearer short-token",
+			wantLookup:          false,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: false,
+		},
+		{
+			name:                "returns not found when backend returns not found",
+			authHeader:          "Bearer " + validToken,
+			backendErr:          apierrors.NewNotFound(schema.GroupResource{Resource: "services"}, "svc"),
+			wantLookup:          true,
+			wantStatus:          http.StatusNotFound,
+			wantNextHandler:     false,
+			wantServiceTokenCtx: false,
+		},
+		{
+			name:                "returns internal server error on backend failure",
+			authHeader:          "Bearer " + validToken,
+			backendErr:          errors.New("backend exploded"),
+			wantLookup:          true,
+			wantStatus:          http.StatusInternalServerError,
+			wantNextHandler:     false,
+			wantServiceTokenCtx: false,
+		},
+		{
+			name:       "sets service token context and allows when token matches",
+			authHeader: "Bearer " + validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
+		},
+		{
+			name:       "returns unauthorized when token does not match",
+			authHeader: "Bearer " + validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: strings.Repeat("b", tokenLength)},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusUnauthorized,
+			wantNextHandler:     false,
+			wantServiceTokenCtx: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			back := &serviceTokenMockBackend{
+				listServicesByNameResult: tt.backendServices,
+				listServicesByNameErr:    tt.backendErr,
+			}
+
+			router := gin.New()
+			nextHandlerCalled := false
+			serviceTokenInContext := false
+
+			router.GET("/system/services/:serviceName/auth",
+				GetServiceTokenMiddleware(back),
+				func(c *gin.Context) {
+					nextHandlerCalled = true
+					if isServiceToken, exists := c.Get(isServiceTokenKey); exists {
+						if validServiceToken, ok := isServiceToken.(bool); ok {
+							serviceTokenInContext = validServiceToken
+						}
+					}
+					c.Status(http.StatusOK)
+				},
+			)
+
+			req, err := http.NewRequest(http.MethodGet, "/system/services/svc/auth", nil)
+			if err != nil {
+				t.Fatalf("unexpected error creating request: %v", err)
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			if tt.basicAuth {
+				req.SetBasicAuth("user", "password")
+			}
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Errorf("expected status %d, got %d", tt.wantStatus, resp.Code)
+			}
+			if nextHandlerCalled != tt.wantNextHandler {
+				t.Errorf("expected next handler called = %v, got %v", tt.wantNextHandler, nextHandlerCalled)
+			}
+			if serviceTokenInContext != tt.wantServiceTokenCtx {
+				t.Errorf("expected isServiceToken in context = %v, got %v", tt.wantServiceTokenCtx, serviceTokenInContext)
+			}
+			if back.listServicesByNameCalled != tt.wantLookup {
+				t.Errorf("expected ListServicesByName called = %v, got %v", tt.wantLookup, back.listServicesByNameCalled)
+			}
+		})
+	}
+}

--- a/pkg/utils/auth/service_token_test.go
+++ b/pkg/utils/auth/service_token_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (

--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -635,7 +635,7 @@ func buildKserveName(serviceName string) string {
 // which will be used in the HTTPRoute to protect the KServe service.
 // TO DO: change implementation when decided how to handle authentication for KServe services
 func createTraefikOIDCMiddleware(gatewayClientset dynamic.Interface, service *types.Service, knSvc *knv1.Service, cfg *types.Config) error {
-	authEndpointAddress := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/system/services/%s", cfg.Name, cfg.Namespace, cfg.ServicePort, service.Name)
+	authEndpointAddress := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/system/services/%s/auth", cfg.Name, cfg.Namespace, cfg.ServicePort, service.Name)
 	middleware := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "traefik.io/v1alpha1",
 		"kind":       "Middleware",


### PR DESCRIPTION
This pull request introduces a new authentication and authorization mechanism for service endpoints, with a focus on per-service access control. It adds a dedicated `/system/services/:serviceName/auth` endpoint, implements middleware for service token and permission checks, and provides comprehensive tests for the new logic. Additionally, it updates related internal and KServe integration code to use the new authentication flow.

**New Service Authentication Endpoint and Middleware:**

* Added a new `GET /system/services/:serviceName/auth` endpoint, protected by a chain of authentication and authorization middlewares, to validate access to a specific service using Basic auth, Bearer tokens (service or OIDC), and service-level permissions. (`main.go`, `pkg/handlers/service_auth.go`, [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R113-R116) [[2]](diffhunk://#diff-2dbebfa9ead523df0d74de7bfc6b10b54c90ead5a150225f1faeeaf9652377a2R1-R43)
* Introduced `BuildServiceAuthMiddlewareChain` to compose the service token, authentication, and permission middleware for the new endpoint. (`pkg/utils/auth/auth.go`, [pkg/utils/auth/auth.goR42-R67](diffhunk://#diff-afc5e1dbf156c072a0c2d976f84ab1b227c10d0c7e70cdecff764d3b38e958f1R42-R67))

**Service Token and Permission Middleware:**

* Implemented `GetServiceTokenMiddleware` to validate requests authenticated with a service token, allowing access if the token matches a service's configured token. (`pkg/utils/auth/service_token.go`, [pkg/utils/auth/service_token.goR1-R50](diffhunk://#diff-c2b5ea99391370e44bd9316efdc733fd157b0b141c36d006ba811c13f92bbb58R1-R50))
* Added `GetServicePermissionsMiddleware` to enforce service-level access rules based on service visibility (public, private, restricted) and user identity. (`pkg/utils/auth/service_permissions.go`, [pkg/utils/auth/service_permissions.goR1-R99](diffhunk://#diff-2cf6d98f5409879e26e1d36c9eba6327bcd70f024b1b88a0f49c2feb738424c0R1-R99))

**Testing and Coverage:**

* Added comprehensive unit tests for the new middleware and permission logic, including all decision branches for token and permission checks. (`pkg/utils/auth/service_token_test.go`, [[1]](diffhunk://#diff-14b5c3f2e6977b8d6ff68160ebe8069242bee2aea181719a3afbe737df54f7f8R1-R198); `pkg/utils/auth/service_permissions_test.go`, [[2]](diffhunk://#diff-045937ef8c5c9348d88e7218aeb02a26600c0f10dd4813f7eb87bf7168938f9dR1-R160); `pkg/handlers/service_auth_test.go`, [[3]](diffhunk://#diff-d91967788289749b140d77f20c742f99c806ab02fe24ae98faf8e7c24d7edf8bR1-R62)

**Integration and Endpoint Updates:**

* Updated the KServe Traefik middleware integration to use the new `/auth` endpoint for service authentication. (`pkg/utils/kserve.go`, [pkg/utils/kserve.goL638-R638](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bL638-R638))
* Removed unused POST endpoints for service start/stop/restart, as access control is now handled via the new authentication flow. (`main.go`, [main.goL129-L131](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L129-L131))