### PR TITLE
fix: use indexed pod port names for expose probes

### DIFF
--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -535,7 +535,7 @@ func getPodTemplateSpec(service types.Service, namespace string, cfg *types.Conf
 		containerPorts := []v1.ContainerPort{}
 		for index, port := range service.Expose.APIPort {
 			containerPorts = append(containerPorts, v1.ContainerPort{
-				Name:          fmt.Sprintf("%s-%d", podPortName, index),
+				Name:          getPodPortName(index),
 				ContainerPort: int32(port), // #nosec G115
 			})
 		}
@@ -555,7 +555,7 @@ func getPodTemplateSpec(service types.Service, namespace string, cfg *types.Conf
 		probeHandler := v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{
 				Path: probePath,
-				Port: intstr.FromString(podPortName),
+				Port: intstr.FromString(getPodPortName(0)),
 			},
 		}
 
@@ -1461,6 +1461,10 @@ func getHTTPRouteName(name_container string) string {
 
 func getTraefikCORSMiddlewareName(name_container string) string {
 	return name_container + "-cors-mdw"
+}
+
+func getPodPortName(index int) string {
+	return fmt.Sprintf("%s-%d", podPortName, index)
 }
 
 func getTraefikAuthMiddlewareName(name_container string) string {


### PR DESCRIPTION
## Summary

This PR fixes the port name used by the HTTP liveness, readiness, and startup probes generated for exposed services.

After the expose model started supporting multiple API ports, container ports are emitted with indexed Kubernetes names such as `podport-0`, `podport-1`, and so on. However, the probe configuration was still pointing to the previous fixed name, `podport`.

## Problem

When a service is deployed with HTTP probes enabled, OSCAR currently generates a Deployment where:

- the container port is named `podport-0`
- the HTTP probes reference `podport`

Because `podport` no longer matches any named container port, Kubernetes cannot resolve the probe target correctly. In a local deployment this made the service pod remain unhealthy even though the application process had started successfully. The pod events showed errors like:

```text
Startup probe errored and resulted in unknown state: strconv.Atoi: parsing "podport": invalid syntax
```

This was observed while deploying an OSCAR Hub service that exposes port `9119`: the container and application were running, but the pod stayed red because all probes referenced the stale port name.

## Root cause

The container port naming logic had already been updated to use indexed names for the `Expose.APIPort` slice, but the probe generation path still used the legacy `podPortName` constant directly.

That leaves the generated Deployment internally inconsistent whenever probes are configured for exposed services.

## Changes

- Adds a small helper to generate the indexed pod port name consistently.
- Uses that helper when defining container ports.
- Uses the first indexed port name, `podport-0`, for HTTP probes.

The probe behavior remains the same for single-port services, but the generated Kubernetes object now refers to an existing named port.

## Validation

Ran the package test suite for the touched backend resources package:

```bash
go test ./pkg/backends/resources
```

The test passed.

I also verified the fix manually in a local cluster by patching an affected Deployment to point probes at `podport-0`; the rollout completed and the pod became `1/1 Running`.
