### PR TITLE
fix service secret cleanup errors

### DIFF
--- a/pkg/backends/k8s_test.go
+++ b/pkg/backends/k8s_test.go
@@ -835,6 +835,31 @@ func TestKubeDeleteService(t *testing.T) {
 	})
 }
 
+func TestKubeDeleteServiceRemovesServiceSecret(t *testing.T) {
+	service := types.Service{
+		Name:      "service-with-secret",
+		Namespace: testConfig.ServicesNamespace,
+	}
+	clientset := fake.NewSimpleClientset(
+		&v1.PodTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
+		},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
+		},
+	)
+
+	back := MakeKubeBackend(clientset, testConfig)
+
+	if err := back.DeleteService(service); err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+
+	if utils.SecretExists(service.Name, service.Namespace, clientset) {
+		t.Fatalf("expected service secret to be removed")
+	}
+}
+
 func TestKubeGetKubeClientset(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 

--- a/pkg/backends/knative_test.go
+++ b/pkg/backends/knative_test.go
@@ -802,6 +802,29 @@ func TestKnativeDeleteService(t *testing.T) {
 	}
 }
 
+func TestKnativeDeleteServiceRemovesServiceSecret(t *testing.T) {
+	service := types.Service{
+		Name:      "service-with-secret",
+		Namespace: testConfig.ServicesNamespace,
+	}
+	fakeClientset := fake.NewSimpleClientset(&v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
+	})
+	back := MakeKnativeBackend(fakeClientset, fakeConfig, testConfig)
+	back.knClientset = knFake.NewSimpleClientset(&knv1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
+	})
+
+	if err := back.DeleteService(service); err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+
+	_, err := fakeClientset.CoreV1().Secrets(service.Namespace).Get(t.Context(), service.Name, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected service secret to be removed, got err: %v", err)
+	}
+}
+
 func TestKnativeGetProxyDirector(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -248,10 +248,12 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 		if len(service.Environment.Secrets) > 0 {
 			if utils.SecretExists(service.Name, service.Namespace, back.GetKubeClientset()) {
 				c.String(http.StatusConflict, "A secret with the given name already exists")
+				return
 			}
 			secretsErr := utils.CreateSecret(service.Name, service.Namespace, service.Environment.Secrets, back.GetKubeClientset())
 			if secretsErr != nil {
 				c.String(http.StatusConflict, "Error creating secrets for service: %v", secretsErr)
+				return
 			}
 
 			// Empty the secrets content from the Configmap

--- a/pkg/handlers/update.go
+++ b/pkg/handlers/update.go
@@ -363,11 +363,13 @@ func MakeUpdateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 				secretsErr := utils.UpdateSecretData(newService.Name, serviceNamespace, newService.Environment.Secrets, back.GetKubeClientset())
 				if secretsErr != nil {
 					c.String(http.StatusInternalServerError, "error updating asociated secret: %v", secretsErr)
+					return
 				}
 			} else {
 				secretsErr := utils.CreateSecret(newService.Name, serviceNamespace, newService.Environment.Secrets, back.GetKubeClientset())
 				if secretsErr != nil {
 					c.String(http.StatusInternalServerError, "error adding asociated secret: %v", secretsErr)
+					return
 				}
 			}
 			// Empty the secrets content from the Configmap


### PR DESCRIPTION
## Summary

- Stop service create/update handlers immediately after secret creation or update errors.
- Add backend tests confirming service deletion removes the service-named Kubernetes Secret for both Kubernetes and Knative backends.

## Root Cause

The create handler returned a conflict response when a service-named Secret already existed, but continued execution and attempted to create the Secret again. This produced duplicate/concatenated error output during repeated deploys.

## Validation

- `go test ./pkg/backends ./pkg/handlers`
- `go test ./pkg/backends`