### PR TITLE
Add ForwardAuth support for exposed services

### DIFF
--- a/docs/exposed-services.md
+++ b/docs/exposed-services.md
@@ -52,6 +52,7 @@ Additional options can be defined in the "expose" section of the FDL (some previ
 - `NodePort`: The access method from the domain name to the public ip `<cluster_ip>:<NodePort>`.
 - `default_command`: Selects between executing the container's default command and executing the script inside the container. (default: false, it executes the script)
 - `set_auth`: The credentials are composed of the service name as the user and the service token as the password. Turn off this field if the container provides its own authentication method. It does not work with `NodePort` (default: false, it has no authentication).
+- `auth_type`: Authentication middleware used when `set_auth` is enabled. `basic` keeps the existing Basic Auth behavior. `forward` uses Traefik ForwardAuth to delegate checks to OSCAR service authorization and can bootstrap browser sessions from `?token=<service-token>` on Gateway API/Traefik exposed services.
 - `health_path`: The path where the service readiness and liveness status are checked. Only if the root path `/` returns status 4XX or 5XX.
 
 

--- a/docs/fdl.md
+++ b/docs/fdl.md
@@ -158,6 +158,7 @@ storage_providers:
 | `cpu_threshold` </br> *integer* | Percent of use of CPU before creating other pod (default: 80 max:100). Optional.  |
 | `nodePort` </br> *integer* | Change the access method from the domain name to the public ip. Optional.   |
 | `set_auth` </br> *bool* | Create credentials for the service, composed of the service name as the user and the service token as the password. (default: false). Optional.  |
+| `auth_type` </br> *string* | Authentication middleware used when `set_auth` is enabled. Supported values are `basic` (default) and `forward`. `forward` is only supported for Gateway API/Traefik exposed services and delegates checks to OSCAR service authorization. Optional. |
 | `rewrite_target` </br> *bool* | It is an expose boolean in the FDL that controls how OSCAR configures the NGINX Ingress/HTTProute rewrite for exposed services. If rewrite_target: false, ingress rewrites to /$1. If rewrite_target: true, ingress rewrites to /system/services/<service>/exposed/$1 (default: false). Optional.  |
 | `default_command` </br> *bool* | Select between executing the container's default command and executing the script inside the container. (default: false). Optional.  |
 | `health_path` </br> *string* | Change the service readiness and liveness check path/endpoint. (default: "/"). Optional.  |

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -52,6 +52,8 @@ const (
 	servicePortNumber  = 80
 	routeKindIngress   = "ingress"
 	routeKindHTTPRoute = "httproute"
+	authTypeBasic      = "basic"
+	authTypeForward    = "forward"
 
 	livenessInitialDelaySeconds  = 60
 	livenessFailureThreshold     = 12
@@ -257,6 +259,9 @@ func getRouteKind(cfg *types.Config) string {
 }
 
 func createRoute(service types.Service, namespace string, kubeClientset kubernetes.Interface, cfg *types.Config) error {
+	if err := validateExposeAuthConfig(service, cfg); err != nil {
+		return err
+	}
 	if getRouteKind(cfg) == routeKindHTTPRoute {
 		return createHTTPRoute(service, namespace, kubeClientset, cfg)
 	}
@@ -311,10 +316,12 @@ func EnsureExposeAuthResources(service types.Service, namespace string, kubeClie
 		return nil
 	}
 	if getRouteKind(cfg) == routeKindHTTPRoute {
-		if err := upsertTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
-			return err
+		if normalizeExposeAuthType(service.Expose.AuthType) == authTypeBasic {
+			if err := upsertTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
+				return err
+			}
 		}
-		return upsertTraefikAuthMiddleware(service, namespace)
+		return upsertTraefikAuthMiddleware(service, namespace, cfg)
 	}
 	if existsSecret(service.Name, namespace, kubeClientset, cfg) {
 		return updateSecret(service, namespace, kubeClientset, cfg)
@@ -379,6 +386,18 @@ func validateHTTPRouteConfig(service types.Service, cfg *types.Config) error {
 
 	if strings.TrimSpace(cfg.HTTPRouteGatewayName) == "" {
 		return fmt.Errorf("HTTPROUTE_GATEWAY_NAME must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute")
+	}
+
+	return validateExposeAuthConfig(service, cfg)
+}
+
+func validateExposeAuthConfig(service types.Service, cfg *types.Config) error {
+	authType := normalizeExposeAuthType(service.Expose.AuthType)
+	if authType != authTypeBasic && authType != authTypeForward {
+		return fmt.Errorf("unsupported expose auth_type %q", service.Expose.AuthType)
+	}
+	if service.Expose.SetAuth && authType == authTypeForward && getRouteKind(cfg) != routeKindHTTPRoute {
+		return fmt.Errorf("expose auth_type %q requires EXPOSED_SERVICES_ROUTE_KIND=httproute", authTypeForward)
 	}
 
 	return nil
@@ -864,10 +883,12 @@ func createHTTPRoute(service types.Service, namespace string, kubeClientset kube
 	}
 
 	if service.Expose.SetAuth {
-		if err := createTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
-			return err
+		if normalizeExposeAuthType(service.Expose.AuthType) == authTypeBasic {
+			if err := createTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
+				return err
+			}
 		}
-		if err := createTraefikAuthMiddleware(service, namespace); err != nil {
+		if err := createTraefikAuthMiddleware(service, namespace, cfg); err != nil {
 			return err
 		}
 	}
@@ -892,10 +913,12 @@ func updateHTTPRoute(service types.Service, namespace string, kubeClientset kube
 	}
 
 	if service.Expose.SetAuth {
-		if err := upsertTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
-			return err
+		if normalizeExposeAuthType(service.Expose.AuthType) == authTypeBasic {
+			if err := upsertTraefikAuthSecret(service, namespace, kubeClientset); err != nil {
+				return err
+			}
 		}
-		if err := upsertTraefikAuthMiddleware(service, namespace); err != nil {
+		if err := upsertTraefikAuthMiddleware(service, namespace, cfg); err != nil {
 			return err
 		}
 	} else {
@@ -1175,24 +1198,24 @@ func upsertTraefikCORSMiddleware(service types.Service, namespace string, cfg *t
 	return createTraefikCORSMiddleware(service, namespace, cfg)
 }
 
-func createTraefikAuthMiddleware(service types.Service, namespace string) error {
+func createTraefikAuthMiddleware(service types.Service, namespace string, cfg *types.Config) error {
 	gatewayClientset, err := gatewayClientsetProvider()
 	if err != nil {
 		return err
 	}
 
-	middleware := getTraefikAuthMiddlewareSpec(service, namespace)
+	middleware := getTraefikAuthMiddlewareSpec(service, namespace, cfg)
 	_, err = gatewayClientset.Resource(traefikMiddlewareGVR).Namespace(namespace).Create(context.TODO(), middleware, metav1.CreateOptions{})
 	return err
 }
 
-func updateTraefikAuthMiddleware(service types.Service, namespace string) error {
+func updateTraefikAuthMiddleware(service types.Service, namespace string, cfg *types.Config) error {
 	gatewayClientset, err := gatewayClientsetProvider()
 	if err != nil {
 		return err
 	}
 
-	middleware := getTraefikAuthMiddlewareSpec(service, namespace)
+	middleware := getTraefikAuthMiddlewareSpec(service, namespace, cfg)
 	currentMiddleware, err := gatewayClientset.Resource(traefikMiddlewareGVR).Namespace(namespace).Get(context.TODO(), middleware.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -1203,12 +1226,12 @@ func updateTraefikAuthMiddleware(service types.Service, namespace string) error 
 	return err
 }
 
-func upsertTraefikAuthMiddleware(service types.Service, namespace string) error {
+func upsertTraefikAuthMiddleware(service types.Service, namespace string, cfg *types.Config) error {
 	if existsTraefikAuthMiddleware(service.Name, namespace) {
-		return updateTraefikAuthMiddleware(service, namespace)
+		return updateTraefikAuthMiddleware(service, namespace, cfg)
 	}
 
-	return createTraefikAuthMiddleware(service, namespace)
+	return createTraefikAuthMiddleware(service, namespace, cfg)
 }
 
 func getTraefikCORSMiddlewareSpec(service types.Service, namespace string, cfg *types.Config) *unstructured.Unstructured {
@@ -1232,8 +1255,23 @@ func getTraefikCORSMiddlewareSpec(service types.Service, namespace string, cfg *
 	}}
 }
 
-func getTraefikAuthMiddlewareSpec(service types.Service, namespace string) *unstructured.Unstructured {
+func getTraefikAuthMiddlewareSpec(service types.Service, namespace string, cfg *types.Config) *unstructured.Unstructured {
 	nameMiddleware := getTraefikAuthMiddlewareName(service.Name)
+	authSpec := map[string]any{
+		"basicAuth": map[string]any{
+			"secret": getTraefikAuthSecretName(service.Name),
+		},
+	}
+
+	if normalizeExposeAuthType(service.Expose.AuthType) == authTypeForward {
+		authSpec = map[string]any{
+			"forwardAuth": map[string]any{
+				"address":                  getServiceAuthEndpoint(service, cfg),
+				"trustForwardHeader":       true,
+				"addAuthCookiesToResponse": []any{getServiceAuthCookieName(service.Name)},
+			},
+		}
+	}
 
 	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "traefik.io/v1alpha1",
@@ -1242,11 +1280,7 @@ func getTraefikAuthMiddlewareSpec(service types.Service, namespace string) *unst
 			"name":      nameMiddleware,
 			"namespace": namespace,
 		},
-		"spec": map[string]any{
-			"basicAuth": map[string]any{
-				"secret": getTraefikAuthSecretName(service.Name),
-			},
-		},
+		"spec": authSpec,
 	}}
 }
 
@@ -1473,6 +1507,25 @@ func getTraefikAuthMiddlewareName(name_container string) string {
 
 func getTraefikAuthSecretName(name_container string) string {
 	return name_container + "-auth-traefik"
+}
+
+func getServiceAuthCookieName(name_container string) string {
+	return "oscar_service_" + strings.ReplaceAll(name_container, "-", "_") + "_auth"
+}
+
+func normalizeExposeAuthType(authType string) string {
+	authType = strings.ToLower(strings.TrimSpace(authType))
+	if authType == "" {
+		return authTypeBasic
+	}
+	return authType
+}
+
+func getServiceAuthEndpoint(service types.Service, cfg *types.Config) string {
+	if cfg == nil {
+		return "/system/services/" + service.Name + "/auth"
+	}
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/system/services/%s/auth", cfg.Name, cfg.Namespace, cfg.ServicePort, service.Name)
 }
 
 func getAPIPath(name_container string) string {

--- a/pkg/backends/resources/expose_test.go
+++ b/pkg/backends/resources/expose_test.go
@@ -680,6 +680,17 @@ func TestValidateHTTPRouteConfig(t *testing.T) {
 	if err := validateHTTPRouteConfig(svc, cfg); err != nil {
 		t.Fatalf("expected valid config, got error: %v", err)
 	}
+
+	svc.Expose.SetAuth = true
+	svc.Expose.AuthType = "forward"
+	if err := validateHTTPRouteConfig(svc, cfg); err != nil {
+		t.Fatalf("expected forward auth_type to be valid, got: %v", err)
+	}
+
+	svc.Expose.AuthType = "unknown"
+	if err := validateHTTPRouteConfig(svc, cfg); err == nil {
+		t.Fatalf("expected invalid auth_type to fail")
+	}
 }
 
 func TestGetHTTPRouteSpecWithAuth(t *testing.T) {
@@ -867,7 +878,7 @@ func TestUpdateHTTPRouteSetsResourceVersion(t *testing.T) {
 func TestGetTraefikAuthMiddlewareSpec(t *testing.T) {
 	cfg := newTestConfig()
 	svc := newExposeService("auth-svc", 0, true)
-	middleware := getTraefikAuthMiddlewareSpec(svc, cfg.ServicesNamespace)
+	middleware := getTraefikAuthMiddlewareSpec(svc, cfg.ServicesNamespace, cfg)
 
 	if middleware.GetName() != getTraefikAuthMiddlewareName(svc.Name) {
 		t.Fatalf("expected middleware name %s, got %s", getTraefikAuthMiddlewareName(svc.Name), middleware.GetName())
@@ -880,6 +891,33 @@ func TestGetTraefikAuthMiddlewareSpec(t *testing.T) {
 
 	if secretName != getTraefikAuthSecretName(svc.Name) {
 		t.Fatalf("expected basicAuth secret %s, got %s", getTraefikAuthSecretName(svc.Name), secretName)
+	}
+}
+
+func TestGetTraefikAuthMiddlewareSpecForward(t *testing.T) {
+	cfg := newTestConfig()
+	svc := newExposeService("forward-auth-svc", 0, true)
+	svc.Expose.AuthType = "forward"
+
+	middleware := getTraefikAuthMiddlewareSpec(svc, cfg.ServicesNamespace, cfg)
+
+	address, found, err := unstructured.NestedString(middleware.Object, "spec", "forwardAuth", "address")
+	if err != nil || !found {
+		t.Fatalf("expected forwardAuth.address in middleware")
+	}
+
+	expectedAddress := "http://oscar.oscar.svc.cluster.local:8080/system/services/forward-auth-svc/auth"
+	if address != expectedAddress {
+		t.Fatalf("expected forwardAuth address %s, got %s", expectedAddress, address)
+	}
+
+	cookies, found, err := unstructured.NestedStringSlice(middleware.Object, "spec", "forwardAuth", "addAuthCookiesToResponse")
+	if err != nil || !found || len(cookies) != 1 {
+		t.Fatalf("expected one addAuthCookiesToResponse entry, got %v", cookies)
+	}
+
+	if cookies[0] != getServiceAuthCookieName(svc.Name) {
+		t.Fatalf("expected auth cookie %s, got %s", getServiceAuthCookieName(svc.Name), cookies[0])
 	}
 }
 

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -482,6 +482,7 @@ type Expose struct {
 	NodePort       []int32 `json:"nodePort,omitempty" `
 	DefaultCommand bool    `json:"default_command" `
 	SetAuth        bool    `json:"set_auth" `
+	AuthType       string  `json:"auth_type,omitempty" default:"basic" `
 	HealthPath     string  `json:"health_path" default:"/" `
 	ProbeMode      string  `json:"probe_mode,omitempty" default:"legacy" `
 }

--- a/pkg/utils/auth/service_token.go
+++ b/pkg/utils/auth/service_token.go
@@ -18,6 +18,8 @@ package auth
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/grycap/oscar/v4/pkg/types"
@@ -36,8 +38,17 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 			return
 		}
 
-		// Check if reqToken is the service token
-		if token, ok := isAuthBearer(c); ok && len(token) == tokenLength {
+		// Check if any request token is the service token. Exposed services may use
+		// their own "token" query parameter, so keep checking the auth cookie too.
+		tokens := getServiceTokenCandidates(c)
+		hasServiceTokenCandidate := false
+		for _, token := range tokens {
+			if len(token) == tokenLength {
+				hasServiceTokenCandidate = true
+				break
+			}
+		}
+		if hasServiceTokenCandidate {
 			serviceList, err := back.ListServicesByName(c.Param("serviceName"), "")
 			if err != nil {
 				// Check if error is caused because the service is not found
@@ -50,17 +61,78 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 			}
 
 			for _, serviceIter := range serviceList {
-				if token == serviceIter.Token {
-					c.Set(isServiceTokenKey, true)
-					c.Next()
-					return
+				for _, token := range tokens {
+					if len(token) != tokenLength {
+						continue
+					}
+					if token == serviceIter.Token {
+						c.Set(isServiceTokenKey, true)
+						setServiceTokenCookie(c, serviceIter.Name, token)
+						c.Next()
+						return
+					}
 				}
 			}
-			c.AbortWithStatus(http.StatusUnauthorized)
-			return
+			if hasServiceTokenCandidate {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
 		}
 
 		c.Next()
 		return
 	}
+}
+
+func getServiceTokenCandidates(c *gin.Context) []string {
+	tokens := []string{}
+
+	if token, ok := isAuthBearer(c); ok {
+		tokens = append(tokens, token)
+	}
+
+	if token := strings.TrimSpace(c.Query("token")); token != "" {
+		tokens = append(tokens, token)
+	}
+
+	if token := serviceTokenFromForwardedURI(c.GetHeader("X-Forwarded-Uri")); token != "" {
+		tokens = append(tokens, token)
+	}
+
+	if token, err := c.Cookie(getServiceTokenCookieName(c.Param("serviceName"))); err == nil && strings.TrimSpace(token) != "" {
+		tokens = append(tokens, strings.TrimSpace(token))
+	}
+
+	return tokens
+}
+
+func serviceTokenFromForwardedURI(rawURI string) string {
+	if strings.TrimSpace(rawURI) == "" {
+		return ""
+	}
+
+	uri, err := url.Parse(rawURI)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(uri.Query().Get("token"))
+}
+
+func setServiceTokenCookie(c *gin.Context, serviceName string, token string) {
+	path := "/system/services/" + serviceName + "/exposed"
+	secure := strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") || c.Request.TLS != nil
+
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     getServiceTokenCookieName(serviceName),
+		Value:    token,
+		Path:     path,
+		MaxAge:   0,
+		Secure:   secure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func getServiceTokenCookieName(serviceName string) string {
+	return "oscar_service_" + strings.ReplaceAll(serviceName, "-", "_") + "_auth"
 }

--- a/pkg/utils/auth/service_token.go
+++ b/pkg/utils/auth/service_token.go
@@ -38,18 +38,8 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 			return
 		}
 
-		// Check if any request token is the service token. Exposed services may use
-		// their own "token" query parameter, so keep checking the auth cookie too.
-		tokens := getServiceTokenCandidates(c)
-		hasServiceTokenCandidate := false
-		for _, token := range tokens {
-			if len(token) == tokenLength {
-				hasServiceTokenCandidate = true
-				break
-			}
-		}
-		if hasServiceTokenCandidate {
-			serviceList, err := back.ListServicesByName(c.Param("serviceName"), "")
+		if tokens := getServiceTokenCandidates(c); len(tokens) > 0 {
+			serviceList, err := back.ListServicesByName(c.Param("serviceName"))
 			if err != nil {
 				// Check if error is caused because the service is not found
 				if errors.IsNotFound(err) || errors.IsGone(err) {
@@ -60,23 +50,20 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 				return
 			}
 
-			for _, serviceIter := range serviceList {
-				for _, token := range tokens {
-					if len(token) != tokenLength {
-						continue
-					}
-					if token == serviceIter.Token {
-						c.Set(isServiceTokenKey, true)
-						setServiceTokenCookie(c, serviceIter.Name, token)
-						c.Next()
-						return
-					}
+			// only one service should be returned
+			// the restriction for unique service names is enforced in the service creation and update handlers
+			service := serviceList[0]
+			for _, token := range tokens {
+				if token == service.Token {
+					c.Set(isServiceTokenKey, true)
+					setServiceTokenCookie(c, service.Name, token)
+					c.Next()
+					return
 				}
 			}
-			if hasServiceTokenCandidate {
-				c.AbortWithStatus(http.StatusUnauthorized)
-				return
-			}
+
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
 		}
 
 		c.Next()
@@ -87,19 +74,23 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 func getServiceTokenCandidates(c *gin.Context) []string {
 	tokens := []string{}
 
+	// Prioritise the token in the authorization header over other sources of service tokens
 	if token, ok := isAuthBearer(c); ok {
+		if len(strings.TrimSpace(token)) == tokenLength {
+			tokens = append(tokens, token)
+		}
+		return tokens
+	}
+
+	if token := strings.TrimSpace(c.Query("token")); len(token) == tokenLength {
 		tokens = append(tokens, token)
 	}
 
-	if token := strings.TrimSpace(c.Query("token")); token != "" {
+	if token := serviceTokenFromForwardedURI(c.GetHeader("X-Forwarded-Uri")); len(token) == tokenLength {
 		tokens = append(tokens, token)
 	}
 
-	if token := serviceTokenFromForwardedURI(c.GetHeader("X-Forwarded-Uri")); token != "" {
-		tokens = append(tokens, token)
-	}
-
-	if token, err := c.Cookie(getServiceTokenCookieName(c.Param("serviceName"))); err == nil && strings.TrimSpace(token) != "" {
+	if token, err := c.Cookie(getServiceTokenCookieName(c.Param("serviceName"))); err == nil && len(strings.TrimSpace(token)) == tokenLength {
 		tokens = append(tokens, strings.TrimSpace(token))
 	}
 

--- a/pkg/utils/auth/service_token.go
+++ b/pkg/utils/auth/service_token.go
@@ -113,7 +113,7 @@ func setServiceTokenCookie(c *gin.Context, serviceName string, token string) {
 	path := "/system/services/" + serviceName + "/exposed"
 	secure := strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") || c.Request.TLS != nil
 
-	http.SetCookie(c.Writer, &http.Cookie{
+	http.SetCookie(c.Writer, &http.Cookie{ // #nosec G124
 		Name:     getServiceTokenCookieName(serviceName),
 		Value:    token,
 		Path:     path,

--- a/pkg/utils/auth/service_token_test.go
+++ b/pkg/utils/auth/service_token_test.go
@@ -76,16 +76,19 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 
 	// Decision graph paths for GetServiceTokenMiddleware:
 	// 1) basic auth -> pass through
-	// 2) no bearer token -> pass through
-	// 3) bearer token with invalid length -> pass through
-	// 4) valid bearer + backend not found -> 404
-	// 5) valid bearer + backend error -> 500
-	// 6) valid bearer + token match -> set context + pass through
-	// 7) valid bearer + no match -> 401
+	// 2) no service token -> pass through
+	// 3) service token with invalid length -> pass through
+	// 4) valid service token + backend not found -> 404
+	// 5) valid service token + backend error -> 500
+	// 6) valid service token + token match -> set context + pass through
+	// 7) valid service token + no match -> 401
 	tests := []struct {
 		name                string
 		basicAuth           bool
 		authHeader          string
+		targetPath          string
+		forwardedURI        string
+		cookieToken         string
 		backendServices     []*types.Service
 		backendErr          error
 		wantLookup          bool
@@ -116,6 +119,63 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 			wantStatus:          http.StatusOK,
 			wantNextHandler:     true,
 			wantServiceTokenCtx: false,
+		},
+		{
+			name:       "sets service token context from query token",
+			targetPath: "/system/services/svc/auth?token=" + validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
+		},
+		{
+			name:         "sets service token context from forwarded uri token",
+			forwardedURI: "/system/services/svc/exposed/?token=" + validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
+		},
+		{
+			name:        "sets service token context from service cookie",
+			cookieToken: validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
+		},
+		{
+			name:        "sets service token context from cookie when query token belongs to exposed app",
+			targetPath:  "/system/services/svc/auth?token=app-session-token",
+			cookieToken: validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
+		},
+		{
+			name:         "sets service token context from cookie when forwarded uri token belongs to exposed app",
+			forwardedURI: "/system/services/svc/exposed/api/ws?token=app-session-token",
+			cookieToken:  validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
 		},
 		{
 			name:                "returns not found when backend returns not found",
@@ -183,12 +243,22 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 				},
 			)
 
-			req, err := http.NewRequest(http.MethodGet, "/system/services/svc/auth", nil)
+			targetPath := tt.targetPath
+			if targetPath == "" {
+				targetPath = "/system/services/svc/auth"
+			}
+			req, err := http.NewRequest(http.MethodGet, targetPath, nil)
 			if err != nil {
 				t.Fatalf("unexpected error creating request: %v", err)
 			}
 			if tt.authHeader != "" {
 				req.Header.Set("Authorization", tt.authHeader)
+			}
+			if tt.forwardedURI != "" {
+				req.Header.Set("X-Forwarded-Uri", tt.forwardedURI)
+			}
+			if tt.cookieToken != "" {
+				req.AddCookie(&http.Cookie{Name: getServiceTokenCookieName("svc"), Value: tt.cookieToken})
 			}
 			if tt.basicAuth {
 				req.SetBasicAuth("user", "password")

--- a/pkg/utils/auth/service_token_test.go
+++ b/pkg/utils/auth/service_token_test.go
@@ -121,6 +121,18 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 			wantServiceTokenCtx: false,
 		},
 		{
+			name:         "denies request with bearer token of invalid length and valid query token present, bearer token is prioritised",
+			forwardedURI: "/system/services/svc/exposed/api/ws?token=" + validToken,
+			authHeader:   "Bearer user-token",
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          false,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: false,
+		},
+		{
 			name:       "sets service token context from query token",
 			targetPath: "/system/services/svc/auth?token=" + validToken,
 			backendServices: []*types.Service{
@@ -216,6 +228,30 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 			wantStatus:          http.StatusUnauthorized,
 			wantNextHandler:     false,
 			wantServiceTokenCtx: false,
+		},
+		{
+			name:         "both bearer token and query token present, bearer token is prioritised",
+			forwardedURI: "/system/services/svc/exposed/api/ws?token=app-session-token",
+			authHeader:   "Bearer " + validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
+		},
+		{
+			name:         "both bearer token and valid query token present, bearer token is prioritised",
+			forwardedURI: "/system/services/svc/exposed/api/ws?token=" + validToken,
+			authHeader:   "Bearer " + validToken,
+			backendServices: []*types.Service{
+				{Name: "svc", Token: validToken},
+			},
+			wantLookup:          true,
+			wantStatus:          http.StatusOK,
+			wantNextHandler:     true,
+			wantServiceTokenCtx: true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR adds a new `expose.auth_type: forward` mode for exposed OSCAR services when OSCAR is configured to use Gateway API / Traefik HTTPRoutes.

With this mode, `set_auth: true` no longer creates a Traefik BasicAuth middleware for the exposed service. Instead, OSCAR creates a Traefik ForwardAuth middleware that delegates authorization to the OSCAR manager through:

```text
/system/services/<service-name>/auth
```

The existing Basic Auth behavior remains the default through `auth_type: basic`, so this change is opt-in for services that explicitly request ForwardAuth.

## Problem solved

Some exposed services are full browser applications, not simple HTTP endpoints. For those applications, Basic Auth is a poor user experience because the browser shows a native credentials prompt before the application can load. This was especially visible with the Hermes dashboard agent: users could reach the exposed service URL only after manually satisfying Basic Auth, even when OSCAR already had the service token needed to authorize that service.

The desired flow is closer to the OSCAR Jupyter notebook experience:

1. OSCAR Dashboard generates an exposed-service URL containing the service token, for example:

   ```text
   /system/services/hermes-dashboard/exposed/?token=<service-token>
   ```

2. Traefik protects the exposed route through ForwardAuth.
3. OSCAR validates the token against the requested service.
4. OSCAR returns a scoped, HTTP-only authentication cookie for that exposed service.
5. The browser can then load the HTML, assets, API calls, and WebSocket connections without another Basic Auth prompt.

This keeps the exposed service authenticated while avoiding credential prompts and avoiding service-specific authentication code inside the exposed application.

## Important edge case

The first implementation path exposed a subtle issue with browser applications that also use a `token` query parameter internally. Hermes uses its own session token in WebSocket URLs such as:

```text
/api/events?token=<hermes-session-token>
```

If OSCAR treated every `token` query parameter as an OSCAR service token and rejected immediately on mismatch, ForwardAuth would deny those WebSocket requests even though the browser already had a valid OSCAR service cookie. This caused the Hermes chat to load but show an events feed disconnected warning.

This PR fixes that by collecting all possible OSCAR service-token candidates from:

- `Authorization: Bearer ...`
- direct `?token=...`
- `X-Forwarded-Uri` query `?token=...`
- the scoped OSCAR exposed-service auth cookie

OSCAR now accepts the request when any valid candidate matches the service token. This allows application-level query tokens to coexist with the OSCAR ForwardAuth cookie.

## Implementation details

- Adds `Expose.AuthType` with supported values:
  - `basic` as the default and backward-compatible mode
  - `forward` for Gateway API / Traefik ForwardAuth
- Validates that `auth_type: forward` is only used with `EXPOSED_SERVICES_ROUTE_KIND=httproute`.
- Skips BasicAuth secret creation when ForwardAuth is selected.
- Creates a Traefik ForwardAuth middleware pointing to OSCAR service authorization.
- Configures `addAuthCookiesToResponse` so Traefik forwards OSCAR's scoped cookie back to the browser.
- Extends service-token middleware to bootstrap authentication from the exposed-service URL and then rely on the service-scoped cookie for subsequent requests.
- Documents `auth_type` in the exposed services and FDL documentation.

## Security notes

This does not remove authentication from exposed services. Services still need `set_auth: true`, and `auth_type: forward` delegates the check to OSCAR instead of using browser-native Basic Auth.

The cookie is scoped to:

```text
/system/services/<service-name>/exposed
```

It is `HttpOnly`, `SameSite=Lax`, and is marked `Secure` when the original request is HTTPS.

## Validation

- `go test ./...`
- local kind deployment through `make deploy`
- verified generated Traefik middleware for a Hermes dashboard service uses ForwardAuth instead of BasicAuth
- verified first access with `?token=<service-token>` returns `200 OK` and sets the scoped OSCAR cookie
- verified subsequent API requests are authorized by the cookie
- verified Hermes dashboard WebSocket handshake to `/api/events?token=<hermes-session-token>` succeeds with `101 Switching Protocols` when the OSCAR cookie is present
