### PR TITLE
Add service name existence check

### DIFF
--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -299,6 +299,15 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 			}
 		}
 
+		// Check if a service with the same name already exists in the cluster
+		if exists, err := serviceWithSameNameExists(service.Name, back); err != nil {
+			c.String(http.StatusInternalServerError, fmt.Sprintf("Error checking for existing service: %v", err))
+			return
+		} else if exists {
+			c.String(http.StatusBadRequest, "A service with the provided name already exists")
+			return
+		}
+
 		// Create service
 		if err := back.CreateService(service); err != nil {
 			// Check if error is caused because the service name provided already exists
@@ -975,4 +984,17 @@ func registerMinIOWebhook(name string, token string, minIO *types.MinIOProvider,
 	}
 
 	return minIOAdminClient.RestartServer()
+}
+
+func serviceWithSameNameExists(name string, back types.ServerlessBackend) (bool, error) {
+	services, err := back.ListServicesByName(name)
+	if err != nil {
+		// Check if error is caused because the service is not found
+		if k8sErrors.IsNotFound(err) || k8sErrors.IsGone(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	return len(services) > 0, nil
 }

--- a/pkg/handlers/create_test.go
+++ b/pkg/handlers/create_test.go
@@ -38,9 +38,11 @@ import (
 	"github.com/grycap/oscar/v4/pkg/utils"
 	"github.com/grycap/oscar/v4/pkg/utils/auth"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -807,6 +809,65 @@ func TestGetProviderInfo(t *testing.T) {
 	provID, provName = getProviderInfo("rucio")
 	if provName != types.RucioName || provID != types.DefaultProvider {
 		t.Fatalf("expected default provider id, got %s %s", provName, provID)
+	}
+}
+
+func TestServiceWithSameNameExists(t *testing.T) {
+	tests := []struct {
+		name          string
+		services      []*types.Service
+		backendErr    error
+		expectedExist bool
+		expectErr     bool
+	}{
+		{
+			name:          "service exists",
+			services:      []*types.Service{{Name: "svc"}},
+			expectedExist: true,
+			expectErr:     false,
+		},
+		{
+			name:          "service does not exist",
+			services:      []*types.Service{{Name: "other"}},
+			expectedExist: false,
+			expectErr:     false,
+		},
+		{
+			name:          "not found error treated as not existing",
+			backendErr:    k8serr.NewNotFound(schema.GroupResource{Group: "serving.knative.dev", Resource: "services"}, "svc"),
+			expectedExist: false,
+			expectErr:     false,
+		},
+		{
+			name:          "gone error treated as not existing",
+			backendErr:    k8serr.NewGone("resource gone"),
+			expectedExist: false,
+			expectErr:     false,
+		},
+		{
+			name:          "generic backend error is returned",
+			backendErr:    fmt.Errorf("boom"),
+			expectedExist: false,
+			expectErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			back := backends.MakeFakeBackend()
+			back.Services = tt.services
+			if tt.backendErr != nil {
+				back.AddError("ListServicesByName", tt.backendErr)
+			}
+
+			exists, err := serviceWithSameNameExists("svc", back)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("unexpected error state, got err=%v expectErr=%v", err, tt.expectErr)
+			}
+			if exists != tt.expectedExist {
+				t.Fatalf("unexpected exists result, got=%v expected=%v", exists, tt.expectedExist)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

This pull request introduces a new validation step to prevent the creation of services with duplicate names and adds comprehensive unit tests for this logic. The main changes include implementing a helper function to check for existing services by name, integrating this check into the service creation handler, and ensuring robust test coverage for various scenarios.

### Service creation validation

* Added a check in `MakeCreateHandler` to ensure that a service with the same name does not already exist before creating a new service. If a duplicate is found, the handler returns a `400 Bad Request` error.
* Implemented the `serviceWithSameNameExists` helper function, which queries the backend for services with the given name and handles specific errors (`NotFound`, `Gone`) gracefully.

### Testing and dependencies

* Added the `TestServiceWithSameNameExists` unit test, covering scenarios such as service existence, not-found errors, gone errors, and generic backend errors.
* Updated imports in `create_test.go` to include necessary Kubernetes error and schema packages for testing.