### PR TITLE
Add GPU quota support in ClusterQueue configuration and resource handling

### DIFF
--- a/pkg/handlers/quotas.go
+++ b/pkg/handlers/quotas.go
@@ -212,6 +212,7 @@ func fetchQuota(ctx context.Context, cfg *types.Config, qb types.QuotaBackend, u
 
 		var maxCPU int64
 		var maxMem int64
+		var maxGPU int64
 		if len(cq.Spec.ResourceGroups) > 0 && len(cq.Spec.ResourceGroups[0].Flavors) > 0 {
 			for _, res := range cq.Spec.ResourceGroups[0].Flavors[0].Resources {
 				switch res.Name {
@@ -219,12 +220,15 @@ func fetchQuota(ctx context.Context, cfg *types.Config, qb types.QuotaBackend, u
 					maxCPU = res.NominalQuota.MilliValue()
 				case corev1.ResourceMemory:
 					maxMem = res.NominalQuota.Value()
+				case corev1.ResourceName("nvidia.com/gpu"):
+					maxGPU = res.NominalQuota.Value()
 				}
 			}
 		}
 
 		var usedCPU int64
 		var usedMem int64
+		var usedGPU int64
 		if len(cq.Status.FlavorsUsage) > 0 {
 			for _, res := range cq.Status.FlavorsUsage[0].Resources {
 				switch res.Name {
@@ -232,12 +236,15 @@ func fetchQuota(ctx context.Context, cfg *types.Config, qb types.QuotaBackend, u
 					usedCPU = res.Total.MilliValue()
 				case corev1.ResourceMemory:
 					usedMem = res.Total.Value()
+				case corev1.ResourceName("nvidia.com/gpu"):
+					usedGPU = res.Total.Value()
 				}
 			}
 		}
 
 		resp.Resources["cpu"] = types.QuotaValues{Max: maxCPU, Used: usedCPU}
 		resp.Resources["memory"] = types.QuotaValues{Max: maxMem, Used: usedMem}
+		resp.Resources["gpu"] = types.QuotaValues{Max: maxGPU, Used: usedGPU}
 	}
 
 	if cfg.VolumeEnable {
@@ -331,6 +338,14 @@ func updateKueueQuota(ctx context.Context, qb types.QuotaBackend, user string, r
 				q, err := resource.ParseQuantity(req.Memory)
 				if err != nil {
 					return fmt.Errorf("invalid memory quantity: %w", err)
+				}
+				flavor.Resources[i].NominalQuota = q
+			}
+		case corev1.ResourceName("nvidia.com/gpu"):
+			if req.GPU != "" {
+				q, err := resource.ParseQuantity(req.GPU)
+				if err != nil {
+					return fmt.Errorf("invalid gpu quantity: %w", err)
 				}
 				flavor.Resources[i].NominalQuota = q
 			}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -167,6 +167,9 @@ type Config struct {
 	// KueueDefaultMemory default per-user ClusterQueue memory quota
 	KueueDefaultMemory string `json:"-"`
 
+	// KueueDefaultGPU default per-user ClusterQueue GPU quota
+	KueueDefaultGPU string `json:"-"`
+
 	// KueueDefaultFlavor default ResourceFlavor name used for ClusterQueues
 	KueueDefaultFlavor string `json:"-"`
 
@@ -331,6 +334,7 @@ var configVars = []configVar{
 	{"KueueEnable", "KUEUE_ENABLE", false, boolType, "true"},
 	{"KueueDefaultCPU", "KUEUE_DEFAULT_CPU", false, stringType, "2"},
 	{"KueueDefaultMemory", "KUEUE_DEFAULT_MEMORY", false, stringType, "2Gi"},
+	{"KueueDefaultGPU", "KUEUE_DEFAULT_GPU", false, stringType, "0"},
 	{"KueueDefaultFlavor", "KUEUE_DEFAULT_FLAVOR", false, stringType, "oscar-default-flavor"},
 
 	{"VolumeEnable", "VOLUME_ENABLE", false, boolType, "true"},

--- a/pkg/types/quotas.go
+++ b/pkg/types/quotas.go
@@ -64,6 +64,7 @@ type VolumeQuotaValues struct {
 type QuotaUpdateRequest struct {
 	CPU     string             `json:"cpu"`
 	Memory  string             `json:"memory"`
+	GPU     string             `json:"gpu,omitempty"`
 	Volumes *VolumeQuotaUpdate `json:"volumes,omitempty"`
 	MinIO   *MinIOQuotaUpdate  `json:"minio,omitempty"`
 }

--- a/pkg/utils/kueue.go
+++ b/pkg/utils/kueue.go
@@ -141,6 +141,14 @@ func ensureClusterQueue(ctx context.Context, kueueClient *kueueclientset.Clients
 		return fmt.Errorf("invalid Kueue default memory quota %q: %w", cfg.KueueDefaultMemory, err)
 	}
 
+	gpuQuota := resource.MustParse("0")
+	if cfg.GPUAvailable {
+		gpuQuota, err = resource.ParseQuantity(cfg.KueueDefaultGPU)
+		if err != nil {
+			return fmt.Errorf("invalid Kueue default GPU quota %q: %w", cfg.KueueDefaultGPU, err)
+		}
+	}
+
 	cq := &kueuev1.ClusterQueue{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cqName,
@@ -156,7 +164,7 @@ func ensureClusterQueue(ctx context.Context, kueueClient *kueueclientset.Clients
 			},
 			ResourceGroups: []kueuev1.ResourceGroup{
 				{
-					CoveredResources: []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
+					CoveredResources: []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, v1.ResourceName("nvidia.com/gpu")},
 					Flavors: []kueuev1.FlavorQuotas{
 						{
 							Name: kueuev1.ResourceFlavorReference(flavorName),
@@ -168,6 +176,10 @@ func ensureClusterQueue(ctx context.Context, kueueClient *kueueclientset.Clients
 								{
 									Name:         v1.ResourceMemory,
 									NominalQuota: memoryQuota,
+								},
+								{
+									Name:         v1.ResourceName("nvidia.com/gpu"),
+									NominalQuota: gpuQuota,
 								},
 							},
 						},

--- a/pkg/utils/kueue_test.go
+++ b/pkg/utils/kueue_test.go
@@ -754,6 +754,7 @@ func TestGetServiceResourceRequestsDecisionGraph(t *testing.T) {
 		wantCPU     string
 		wantMemory  string
 		wantGPU     bool
+		wantGPUQty  string
 		wantSGX     bool
 	}{
 		{
@@ -809,6 +810,7 @@ func TestGetServiceResourceRequestsDecisionGraph(t *testing.T) {
 			wantCPU:    "500m",
 			wantMemory: "1Gi",
 			wantGPU:    true,
+			wantGPUQty: "1",
 			wantSGX:    true,
 		},
 	}
@@ -850,6 +852,16 @@ func TestGetServiceResourceRequestsDecisionGraph(t *testing.T) {
 			if hasGPU != tt.wantGPU {
 				t.Fatalf("gpu request present = %v, want %v", hasGPU, tt.wantGPU)
 			}
+			if tt.wantGPU {
+				gpuReq := requests["nvidia.com/gpu"]
+				expectedGPU, err := resource.ParseQuantity(tt.wantGPUQty)
+				if err != nil {
+					t.Fatalf("invalid expected GPU quantity %q: %v", tt.wantGPUQty, err)
+				}
+				if !gpuReq.Equal(expectedGPU) {
+					t.Fatalf("gpu request quantity = %s, want %s", gpuReq.String(), expectedGPU.String())
+				}
+			}
 
 			_, hasSGX := requests["sgx.intel.com/enclave"]
 			if hasSGX != tt.wantSGX {
@@ -871,6 +883,7 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 		wantCPU     string
 		wantMemory  string
 		wantGPU     bool
+		wantGPUQty  string
 	}{
 		{
 			name: "not a kserve service",
@@ -951,6 +964,7 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			wantCPU:    "1",
 			wantMemory: "2Gi",
 			wantGPU:    true,
+			wantGPUQty: "1",
 		},
 		{
 			name: "kserve invalid cpu",
@@ -1031,6 +1045,16 @@ func TestGetKserveResourceRequestsDecisionGraph(t *testing.T) {
 			_, hasGPU := requests["nvidia.com/gpu"]
 			if hasGPU != tt.wantGPU {
 				t.Fatalf("KServe GPU request present = %v, want %v", hasGPU, tt.wantGPU)
+			}
+			if tt.wantGPU {
+				gpuReq := requests["nvidia.com/gpu"]
+				expectedGPU, err := resource.ParseQuantity(tt.wantGPUQty)
+				if err != nil {
+					t.Fatalf("invalid expected KServe GPU quantity %q: %v", tt.wantGPUQty, err)
+				}
+				if !gpuReq.Equal(expectedGPU) {
+					t.Fatalf("KServe GPU request quantity = %s, want %s", gpuReq.String(), expectedGPU.String())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Proposed Changes

This pull request adds support for managing GPU quotas alongside CPU and memory quotas in the quota management system. It introduces GPU quota configuration, updates request/response handling, and extends tests to cover GPU scenarios.

**GPU Quota Support**

* Added GPU quota fields to the `Config` struct and environment variable configuration, allowing default GPU quotas to be set via `KUEUE_DEFAULT_GPU` 

**ClusterQueue and Resource Management**

* Modified ClusterQueue creation logic to include GPU resources and quotas when enabled, ensuring GPU resources are covered in resource groups and flavors 

**Testing Enhancements**

* Extended unit tests in `kueue_test.go` to validate GPU resource requests, including checks for correct GPU quantities in both service and KServe resource request scenarios 