### PR TITLE
fix: improve error handling for managed volume PVC creation failure

### DIFF
--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -308,8 +308,16 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 				} else {
 					c.String(http.StatusConflict, "A service with the provided name already exists")
 				}
-			} else if k8sErrors.IsNotFound(err) && service.Volume != nil && !service.CreatesManagedVolume() {
-				c.String(http.StatusBadRequest, "Referenced volume does not exist in the caller namespace")
+			} else if k8sErrors.IsNotFound(err) && service.Volume != nil {
+				if service.CreatesManagedVolume() {
+					errDelete := back.DeleteService(service)
+					if errDelete != nil {
+						log.Printf("Error deleting service: %v\n", errDelete)
+					}
+					c.String(http.StatusBadRequest, "Referenced volume size is not defined: Please add the volume size in service definition")
+				} else {
+					c.String(http.StatusBadRequest, "Referenced volume does not exist in the caller namespace")
+				}
 			} else {
 				errDelete := back.DeleteService(service)
 				if errDelete != nil {


### PR DESCRIPTION
Fixes # https://github.com/grycap/issue-tracker/issues/414

The error handling in the service creation handler to properly distinguish between managed volume PVC creation failures (missing volume size) and referenced PVC not found errors. Previously, the code had dead code paths and incorrect error messages.