### PR TITLE
fix: add ?namespace= query param for admin delete and fix inverted condition

### DIFF
--- a/pkg/handlers/delete.go
+++ b/pkg/handlers/delete.go
@@ -45,6 +45,7 @@ var deleteLogger = log.New(os.Stdout, "[DELETE-HANDLER] ", log.Flags())
 // @Tags services
 // @Produce json
 // @Param serviceName path string true "Service name"
+// @Param namespace query string false "Namespace (admin only - if omitted searches across all namespaces)"
 // @Success 204 {string} string "No Content"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 403 {string} string "Forbidden"

--- a/pkg/handlers/delete.go
+++ b/pkg/handlers/delete.go
@@ -58,6 +58,7 @@ func MakeDeleteHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 		// First get the Service
 		var service *types.Service
 		var uid string
+		var namespace string
 		var err error
 		serviceName := c.Param("serviceName")
 		authHeader := c.GetHeader("Authorization")
@@ -70,8 +71,12 @@ func MakeDeleteHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 				return
 			}
 		}
-
-		service, err = back.ReadService(utils.BuildUserNamespace(cfg, uid), serviceName)
+		if isOIDC {
+			namespace = utils.BuildUserNamespace(cfg, uid)
+		} else {
+			namespace = c.Query("namespace")
+		}
+		service, err = back.ReadService(namespace, serviceName)
 		if err != nil {
 			if errors.IsNotFound(err) || errors.IsGone(err) {
 				c.Status(http.StatusNotFound)


### PR DESCRIPTION
## Summary

Fixes the delete handler for admin users (Basic Auth) who were unable to delete services created by OIDC users.

## Changes

- Fixed inverted condition on namespace resolution ( → )
- Added optional  query parameter for admin users to specify the target namespace when multiple services share the same name across different user namespaces

## Behavior

| Auth | Namespace | Behavior |
|------|-----------|----------|
| Bearer (OIDC) |  | User restricted to their own namespace |
| Basic (Admin) |  | If provided, uses that namespace; if empty, searches across all namespaces via  |

Prevents the error: "the service '' does not have a registered ConfigMap"