### PR TITLE
feat: add KServe example for Qwen2.5-0.5B-Instruct 

### DIFF
--- a/examples/kserve-llmisvc-qwen2-5/Dockerfile.model
+++ b/examples/kserve-llmisvc-qwen2-5/Dockerfile.model
@@ -1,0 +1,21 @@
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS builder
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN apk add --no-cache ca-certificates git git-lfs
+RUN git lfs install --system
+RUN git clone --depth 1 https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct /models
+RUN cd /models && git lfs pull && rm -rf .git
+
+FROM --platform=$BUILDPLATFORM busybox
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+# Create a non-root user and group, and set permissions for the /models directory
+# Necesary to avoid permission issues when KServe tries to access the model files
+# Default KServe modelcard uid is 1010
+RUN addgroup -g 1010 storage \
+	&& adduser -D -u 1010 -G storage storage \
+	&& mkdir -p /models \
+	&& chown -R 1010:1010 /models \
+	&& chmod 755 /models
+COPY --from=builder --chown=1010:1010 /models/ /models/
+USER 1010:1010

--- a/examples/kserve-llmisvc-qwen2-5/Dockerfile.vllm
+++ b/examples/kserve-llmisvc-qwen2-5/Dockerfile.vllm
@@ -1,0 +1,5 @@
+FROM --platform=$BUILDPLATFORM vllm/vllm-openai-cpu:v0.22.1
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+USER root
+RUN useradd -u 1010 -m storage

--- a/examples/kserve-llmisvc-qwen2-5/README.md
+++ b/examples/kserve-llmisvc-qwen2-5/README.md
@@ -1,0 +1,76 @@
+# KServe LLM: Qwen2.5-0.5B-Instruct (vLLM CPU)
+
+This example deploys an LLM service on OSCAR using KServe,
+vLLM on CPU, and an OCI modelcar image that contains the
+`Qwen/Qwen2.5-0.5B-Instruct` model.
+
+## Example files
+
+| File | Description |
+|---|---|
+| `fdl.yaml` | OSCAR service definition with a KServe `llm_inference` block. |
+| `Dockerfile.vllm` | vLLM CPU runtime wrapper with user `uid=1010` for KServe modelcar compatibility. |
+| `Dockerfile.model` | Modelcar image that downloads the model from Hugging Face. |
+
+## Requirements
+
+- OSCAR cluster with KServe enabled.
+- `oscar-cli` configured against your cluster.
+
+## 1. Deploy the service
+
+```bash
+oscar-cli apply fdl.yaml
+```
+
+Verify that the service was created:
+
+```bash
+oscar-cli service list
+```
+
+The service name in this example is `qwen2-5-05b-instruct`.
+
+## 2. Test the OpenAI-compatible endpoint
+
+Once the service is ready, the model will be exposed on `https://<YOUR_CLUSTER>/system/services/<SERVICE_NAME>/models` and you can send a chat request:
+
+```bash
+curl -X POST "https://<YOUR_CLUSTER>/system/services/qwen2-5-05b-instruct/models/v1/chat/completions" \
+	-H "Content-Type: application/json" \
+	-H "Authorization: Bearer <TOKEN>" \
+	--data '{
+		"model": "qwen2-5-05b-instruct",
+		"messages": [
+			{
+				"role": "user",
+				"content": "Write a short explanation about KServe"
+			}
+		]
+	}'
+```
+
+> Note: If there is only one model, it will have the same name as the OSCAR service.
+
+## Build the images
+
+### vLLM CPU runtime
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/grycap/kserve-vllm-openai-cpu:v0.22.1 -f Dockerfile.vllm . --push
+```
+
+### OCI modelcar (Qwen2.5 model)
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/grycap/kserve-qwen2-5-05b-instruct:latest -f Dockerfile.model . --push
+```
+
+If you use a local registry (for example `localhost:5001`), update the tags in
+the commands above and in `fdl.yaml` (`runtime_image` and `storage_uri`).
+
+## Notes
+
+- The first startup can take several minutes (model download and pod rollout).
+- The current example defines modest resources (`cpu: 2`, `memory: 6Gi`); adjust them for your cluster.
+- `fdl.yaml` uses `--dtype=auto` and `--enforce-eager` for more stable CPU execution.

--- a/examples/kserve-llmisvc-qwen2-5/README.md
+++ b/examples/kserve-llmisvc-qwen2-5/README.md
@@ -9,8 +9,8 @@ vLLM on CPU, and an OCI modelcar image that contains the
 | File | Description |
 |---|---|
 | `fdl.yaml` | OSCAR service definition with a KServe `llm_inference` block. |
-| `Dockerfile.vllm` | vLLM CPU runtime wrapper with user `uid=1010` for KServe modelcar compatibility. |
-| `Dockerfile.model` | Modelcar image that downloads the model from Hugging Face. |
+| `docker/Dockerfile.vllm` | vLLM CPU runtime wrapper with user `uid=1010` for KServe modelcar compatibility. |
+| `docker/Dockerfile.model` | Modelcar image that downloads the model from Hugging Face. |
 
 ## Requirements
 
@@ -33,24 +33,41 @@ The service name in this example is `qwen2-5-05b-instruct`.
 
 ## 2. Test the OpenAI-compatible endpoint
 
-Once the service is ready, the model will be exposed on `https://<YOUR_CLUSTER>/system/services/<SERVICE_NAME>/models` and you can send a chat request:
+Once the service is ready, the model will be exposed on `https://<YOUR_CLUSTER>/system/services/<SERVICE_NAME>/models` and you can test your service in different ways:
 
-```bash
-curl -X POST "https://<YOUR_CLUSTER>/system/services/qwen2-5-05b-instruct/models/v1/chat/completions" \
-	-H "Content-Type: application/json" \
-	-H "Authorization: Bearer <TOKEN>" \
-	--data '{
-		"model": "qwen2-5-05b-instruct",
-		"messages": [
-			{
-				"role": "user",
-				"content": "Write a short explanation about KServe"
-			}
-		]
-	}'
-```
+### Direct request with `curl`
 
-> Note: If there is only one model, it will have the same name as the OSCAR service.
+1. Open a terminal and try:
+
+    ```bash
+    curl -X POST "https://<YOUR_CLUSTER>/system/services/qwen2-5-05b-instruct/models/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer <TOKEN>" \
+        --data '{
+            "model": "qwen2-5-05b-instruct",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Write a short explanation about KServe"
+                }
+            ]
+        }'
+    ```
+    > Replace `<TOKEN>` with your service token or four personal OIDC token.  
+    
+    > Note: If there is only one model, it will have the same name as the OSCAR service.
+
+### Through Open WebUI
+
+1. Install [Docker](https://www.docker.com)
+2. Run Open WebUI:
+    ```bash
+    docker run -d -p 3000:8080 -e WEBUI_AUTH=False -v open-webui:/app/backend/data --name open-webui ghcr.io/open-webui/open-webui:main
+    ```
+3. Go to [http://localhost:3000/](http://localhost:3000/)
+4. Add a connection to the service:  
+    `Top right corner → Admin Panel → Settings → Connections → OpenAI API`
+5. Try it
 
 ## Build the images
 
@@ -74,3 +91,11 @@ the commands above and in `fdl.yaml` (`runtime_image` and `storage_uri`).
 - The first startup can take several minutes (model download and pod rollout).
 - The current example defines modest resources (`cpu: 2`, `memory: 6Gi`); adjust them for your cluster.
 - `fdl.yaml` uses `--dtype=auto` and `--enforce-eager` for more stable CPU execution.
+
+## Additional Resources
+
+- [vLLM Documentation](https://docs.vllm.ai/en/latest/)
+- [OSCAR Documentation](https://docs.oscar.grycap.net/)
+- [KServe](https://kserve.github.io/website/)
+- [API](https://docs.oscar.grycap.net/latest/api/)
+- [OSCAR CLI](https://github.com/grycap/oscar-cli)

--- a/examples/kserve-llmisvc-qwen2-5/fdl.yaml
+++ b/examples/kserve-llmisvc-qwen2-5/fdl.yaml
@@ -1,0 +1,18 @@
+functions:
+  oscar:
+  - oscar-kserve-y2m:
+      name: qwen2-5-05b-instruct
+      image: ubuntu
+      kserve:
+        type: llm_inference
+        llm_inference:
+          runtime_image: ghcr.io/grycap/kserve-vllm-openai-cpu:v0.22.1
+        storage_uri: "oci://ghcr.io/grycap/kserve-qwen2-5-05b-instruct:latest"
+        cpu: '2.0'
+        memory: 6Gi
+        args:
+          - --dtype=auto
+          - --enforce-eager
+        env:
+          VLLM_CPU_KVCACHE_SPACE: "1"
+      log_level: CRITICAL


### PR DESCRIPTION
**New Qwen2.5-0.5B-Instruct KServe Example:**

*Example configuration and documentation:*
- Added a comprehensive `README.md` explaining the deployment steps, requirements, image building, and endpoint usage for the Qwen2.5-0.5B-Instruct model with vLLM on CPU.
- Introduced `fdl.yaml` with an OSCAR service definition, specifying the KServe `llm_inference` block, resource requests, runtime image, model storage URI, and environment variables for optimal CPU execution.

*Container image setup:*
- Added `Dockerfile.model` to build an OCI-compliant model image that downloads the Qwen2.5-0.5B-Instruct model from Hugging Face, sets up permissions for KServe compatibility, and uses a non-root user.
- Added `Dockerfile.vllm` to create a vLLM CPU runtime image, ensuring the correct user is present for KServe modelcar compatibility.