### PR TITLE
fix: handle errors and return early in OIDC middleware

### DIFF
--- a/pkg/utils/auth/oidc.go
+++ b/pkg/utils/auth/oidc.go
@@ -172,21 +172,25 @@ func getOIDCMiddleware(kubeClientset kubernetes.Interface, minIOAdminClient *uti
 			err = mc.CreateSecretForOIDC(uid, sk)
 			if err != nil {
 				c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating secret for user %s: %v", uid, err))
+				return
 			}
 			err = minIOAdminClient.CreateMinIOUser(uid, sk)
 			if err != nil {
 				c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating MinIO user for uid %s: %v", uid, err))
+				return
 			}
 		}
 
 		// Create Kueue ClusterQueue and LocalQueue for the user if they don't exist
 		if err := utils.CreateKueueUserQueuesIfDontExist(cfg, uid); err != nil {
 			c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating Kueue ClusterQueue for user %s: %v", uid, err))
+			return
 		}
 		namespace := utils.BuildUserNamespace(cfg, uid)
 		// Ensure Volume Quotas for the user
 		if _, err := utils.CreateMinIOQuotaConfigMapIfDontExist(c.Request.Context(), cfg, kubeClientset, namespace); err != nil {
 			c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating Kueue ClusterQueue for user %s: %v", uid, err))
+			return
 		}
 
 		utils.EnsureVolumeLimits(FormatUID(uid), namespace, kubeClientset, cfg)


### PR DESCRIPTION
- Error handling improvements:
  * Added `return` statements after sending error responses in the OIDC middleware to prevent further execution when an error occurs in secret creation, MinIO user creation, Kueue queue creation, or MinIO quota configuration. (`pkg/utils/auth/oidc.go`)