### PR TITLE
OSCAR v4.1.2

### DIFF
--- a/pkg/utils/auth/oidc.go
+++ b/pkg/utils/auth/oidc.go
@@ -186,7 +186,12 @@ func getOIDCMiddleware(kubeClientset kubernetes.Interface, minIOAdminClient *uti
 			c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating Kueue ClusterQueue for user %s: %v", uid, err))
 			return
 		}
-		namespace := utils.BuildUserNamespace(cfg, uid)
+		namespace, err := utils.EnsureUserNamespace(c.Request.Context(), kubeClientset, cfg, uid)
+		if err != nil {
+			c.String(http.StatusInternalServerError, fmt.Sprintf("error ensuring namespace for user %s: %v", uid, err))
+			return
+		}
+
 		// Ensure Volume Quotas for the user
 		if _, err := utils.CreateMinIOQuotaConfigMapIfDontExist(c.Request.Context(), cfg, kubeClientset, namespace); err != nil {
 			c.String(http.StatusInternalServerError, fmt.Sprintf("Error creating Kueue ClusterQueue for user %s: %v", uid, err))

--- a/pkg/utils/auth/oidc_test.go
+++ b/pkg/utils/auth/oidc_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -31,6 +32,9 @@ import (
 	"github.com/grycap/oscar/v4/pkg/testsupport"
 	"github.com/grycap/oscar/v4/pkg/types"
 	"github.com/grycap/oscar/v4/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -243,6 +247,46 @@ func TestGetOIDCMiddleware(t *testing.T) {
 	}))
 
 	kubeClientset := fake.NewSimpleClientset()
+
+	// Create base PVC and PV needed by ensureSharedRuntimePVC
+	basePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      types.PVCName,
+			Namespace: "oscar-svc",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "test-pv",
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	basePVC.Status.Phase = corev1.ClaimBound
+
+	basePV := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				NFS: &corev1.NFSVolumeSource{
+					Server: "nfs.example.com",
+					Path:   "/exports",
+				},
+			},
+		},
+	}
+	kubeClientset.CoreV1().PersistentVolumeClaims("oscar-svc").Create(context.TODO(), basePVC, metav1.CreateOptions{})
+	kubeClientset.CoreV1().PersistentVolumes().Create(context.TODO(), basePV, metav1.CreateOptions{})
+
 	cfg := types.Config{
 		MinIOProvider: &types.MinIOProvider{
 			Endpoint: server.URL,


### PR DESCRIPTION
**OIDC Middleware Robustness:**
* Changed the OIDC middleware to use `utils.EnsureUserNamespace`, which checks for the existence of the user namespace and creates it if necessary, instead of just building the namespace name. This makes the namespace handling more reliable and handles errors gracefully.

**Unit Test Enhancements:**
* Updated `oidc_test.go` to import additional Kubernetes API packages required for creating PersistentVolume and PersistentVolumeClaim resources. [[1]](diffhunk://#diff-b8aca27911242c874047aa6bde8f0936e625cbe2c844b1beee9d8e3e8ac7bac0R19) [[2]](diffhunk://#diff-b8aca27911242c874047aa6bde8f0936e625cbe2c844b1beee9d8e3e8ac7bac0R35-R37)
* In the OIDC middleware test, added creation of a base PersistentVolumeClaim and PersistentVolume in the fake Kubernetes client, ensuring the test environment closely matches production requirements for shared runtime PVCs.

**Submodule Update:**
* Updated the `dashboard` submodule to a newer commit, likely pulling in upstream changes or fixes.
