### PR TITLE
fix interactive Kueue enablement

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -825,6 +825,9 @@ fi
 if [ $(echo $use_kserve | tr '[:upper:]' '[:lower:]') == "y" ]; then
     ENABLE_KSERVE="true"
 fi
+if [ $(echo $use_kueue | tr '[:upper:]' '[:lower:]') == "y" ]; then
+    ENABLE_KUEUE="true"
+fi
 if [ $(echo $use_minio_quotas | tr '[:upper:]' '[:lower:]') == "y" ]; then
     ENABLE_MINIO_QUOTAS="true"
 fi


### PR DESCRIPTION
## What changed

- Propagate an affirmative interactive Kueue prompt to `ENABLE_KUEUE=true`.

## Why

The deployment wizard asked whether CPU and memory quotas should be enabled, but ignored the answer. As a result, Kueue was not installed and OSCAR was deployed with `kueue.enable=false` unless `--kueue` was passed explicitly.

## Impact

Interactive local deployments now enable Kueue and CPU/RAM quotas when the user answers `y`, matching the documented behavior of the prompt.

## Validation

- `bash -n deploy/kind-deploy.sh`
- `git diff --cached --check`
