### PR TITLE
docs: add per-invocation environment example

### DIFF
--- a/examples/pass-envvars/README.md
+++ b/examples/pass-envvars/README.md
@@ -1,0 +1,88 @@
+# Passing values per invocation
+
+This example shows how an OSCAR service can select a value at invocation time
+without updating its persistent environment configuration.
+
+The service defines `MESSAGE=configured-value`. The user script applies the
+following precedence, from highest to lowest:
+
+1. The `X-Message` HTTP header in a synchronous invocation.
+2. The `environment.MESSAGE` field in a JSON payload.
+3. The `MESSAGE` environment variable configured in the service.
+
+HTTP headers are exposed by the watchdog using CGI-style names. Therefore,
+`X-Message` is available to the script as `Http_X_Message`; it does not replace
+the original `MESSAGE` variable automatically.
+
+## Deployment
+
+Replace `oscar-cluster` in [`pass-envvars.yaml`](pass-envvars.yaml) with the
+identifier of your cluster in OSCAR CLI, then deploy the service:
+
+```sh
+oscar-cli apply pass-envvars.yaml
+```
+
+The example uses `ghcr.io/grycap/cowsay` because it includes `jq`, which the
+script uses to read the optional JSON payload.
+
+## Synchronous invocation
+
+Without an invocation-specific value, the script uses the service
+configuration:
+
+```sh
+curl -H "Authorization: Bearer <SERVICE_TOKEN>" \
+  -d '{}' \
+  https://<CLUSTER_ENDPOINT>/run/pass-envvars
+```
+
+To provide a value for one invocation, add the `X-Message` header:
+
+```sh
+curl -H "Authorization: Bearer <SERVICE_TOKEN>" \
+  -H "X-Message: synchronous-value" \
+  -d '{}' \
+  https://<CLUSTER_ENDPOINT>/run/pass-envvars
+```
+
+The relevant output is:
+
+```text
+Configured MESSAGE: configured-value
+Header Http_X_Message: synchronous-value
+Payload environment.MESSAGE: <unset>
+Effective MESSAGE: synchronous-value
+Selected source: HTTP header
+```
+
+Please consult the OSCAR-CLI documentation to review the support for this functionality.
+
+## Asynchronous invocation
+
+Arbitrary request headers are not propagated to the Kubernetes Job created for
+an asynchronous invocation. Pass invocation-specific values in the JSON
+payload instead:
+
+```json
+{
+  "environment": {
+    "MESSAGE": "asynchronous-value"
+  }
+}
+```
+
+Send this payload to `/job/pass-envvars` using the service token:
+
+```sh
+curl -H "Authorization: Bearer <SERVICE_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"environment":{"MESSAGE":"asynchronous-value"}}' \
+  https://<CLUSTER_ENDPOINT>/job/pass-envvars
+```
+
+The execution logs will report `Effective MESSAGE: asynchronous-value` and
+`Selected source: invocation payload`.
+
+Do not use either mechanism for secrets. Configure sensitive values as service
+secrets instead.

--- a/examples/pass-envvars/pass-envvars.yaml
+++ b/examples/pass-envvars/pass-envvars.yaml
@@ -1,0 +1,12 @@
+functions:
+  oscar:
+  - oscar-cluster:
+      name: pass-envvars
+      memory: 256Mi
+      cpu: "1.0"
+      image: ghcr.io/grycap/cowsay
+      script: script.sh
+      log_level: CRITICAL
+      environment:
+        variables:
+          MESSAGE: configured-value

--- a/examples/pass-envvars/script.sh
+++ b/examples/pass-envvars/script.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+configured_message=${MESSAGE:-}
+header_message=${Http_X_Message:-}
+payload_message=""
+
+if jq -e . "$INPUT_FILE_PATH" >/dev/null 2>&1; then
+    payload_message=$(jq -r '.environment.MESSAGE // empty' "$INPUT_FILE_PATH")
+fi
+
+effective_message=$configured_message
+source="service environment"
+
+if [ -n "$payload_message" ]; then
+    effective_message=$payload_message
+    source="invocation payload"
+fi
+
+if [ -n "$header_message" ]; then
+    effective_message=$header_message
+    source="HTTP header"
+fi
+
+printf 'Configured MESSAGE: %s\n' "$configured_message"
+printf 'Header Http_X_Message: %s\n' "${header_message:-<unset>}"
+printf 'Payload environment.MESSAGE: %s\n' "${payload_message:-<unset>}"
+printf 'Effective MESSAGE: %s\n' "$effective_message"
+printf 'Selected source: %s\n' "$source"


### PR DESCRIPTION
## Summary

- add an OSCAR example for selecting environment-like values per invocation
- document synchronous overrides through CGI-style HTTP header variables
- document asynchronous overrides through the JSON invocation payload
- demonstrate explicit precedence between headers, payload values, and service configuration

## Motivation

OSCAR service environment variables are persistent configuration. Users may need to select a different non-secret value for an individual invocation without updating the service. This example documents the supported request-level mechanisms and makes clear that custom headers do not automatically replace configured variables.

## Validation

- `sh -n examples/pass-envvars/script.sh`
- executed the script locally with configured and header values
- `git diff --cached --check`

No Go tests were run because this change only adds example and documentation files.
