### PR TITLE
fix: Delete associated secret when creating a service EnsureServiceVolume fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func main() {
 	metricsGroup.GET("", handlers.MakeMetricsSummaryHandler(back, metricsAgg))
 	metricsGroup.GET("/breakdown", handlers.MakeMetricsBreakdownHandler(back, metricsAgg))
 	metricsGroup.GET("/:serviceName", handlers.MakeMetricValueHandler(back, metricsAgg))
+
 	// Quotas
 	if cfg.KueueEnable || cfg.VolumeEnable {
 		system.GET("/quotas/user", handlers.MakeGetOwnQuotaHandler(*qb, cfg))

--- a/pkg/backends/knative.go
+++ b/pkg/backends/knative.go
@@ -142,12 +142,6 @@ func (kn *KnativeBackend) CreateService(service types.Service) error {
 		if delErr := deleteServiceConfigMap(service.Name, namespace, kn.kubeClientset); delErr != nil {
 			log.Println(delErr.Error())
 		}
-		if utils.SecretExists(service.Name, namespace, kn.kubeClientset) {
-			secretsErr := utils.DeleteSecret(service.Name, namespace, kn.kubeClientset)
-			if secretsErr != nil {
-				log.Printf("Error deleting associated secret: %v", secretsErr)
-			}
-		}
 		return err
 	}
 

--- a/pkg/backends/knative.go
+++ b/pkg/backends/knative.go
@@ -142,6 +142,12 @@ func (kn *KnativeBackend) CreateService(service types.Service) error {
 		if delErr := deleteServiceConfigMap(service.Name, namespace, kn.kubeClientset); delErr != nil {
 			log.Println(delErr.Error())
 		}
+		if utils.SecretExists(service.Name, namespace, kn.kubeClientset) {
+			secretsErr := utils.DeleteSecret(service.Name, namespace, kn.kubeClientset)
+			if secretsErr != nil {
+				log.Printf("Error deleting associated secret: %v", secretsErr)
+			}
+		}
 		return err
 	}
 

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -326,17 +326,13 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 					c.String(http.StatusConflict, "A service with the provided name already exists")
 				}
 			} else if k8sErrors.IsNotFound(err) && service.Volume != nil {
+				errDelete := back.DeleteService(service)
+				if errDelete != nil {
+					log.Printf("Error deleting service: %v\n", errDelete)
+				}
 				if service.CreatesManagedVolume() {
-					errDelete := back.DeleteService(service)
-					if errDelete != nil {
-						log.Printf("Error deleting service: %v\n", errDelete)
-					}
 					c.String(http.StatusBadRequest, "Referenced volume size is not defined: Please add the volume size in service definition")
 				} else {
-					errDelete := back.DeleteService(service)
-					if errDelete != nil {
-						log.Printf("Error deleting service: %v\n", errDelete)
-					}
 					c.String(http.StatusBadRequest, "Referenced volume does not exist in the caller namespace")
 				}
 			} else {

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -333,6 +333,10 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 					}
 					c.String(http.StatusBadRequest, "Referenced volume size is not defined: Please add the volume size in service definition")
 				} else {
+					errDelete := back.DeleteService(service)
+					if errDelete != nil {
+						log.Printf("Error deleting service: %v\n", errDelete)
+					}
 					c.String(http.StatusBadRequest, "Referenced volume does not exist in the caller namespace")
 				}
 			} else {


### PR DESCRIPTION
Resource cleanup improvements:

* In the `CreateService` method of `knative.go`, added logic to check for and delete any Kubernetes secret associated with the service being deleted, and log an error if the secret cannot be deleted after EnsureServiceVolume fails