### PR TITLE
Update metrics deployment

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -539,7 +539,7 @@ deployMetrics(){
     echo -e "\n[*] Deploying Prometheus ..."
     helm repo add --force-update prometheus-community https://prometheus-community.github.io/helm-charts
     helm repo update
-    helm upgrade --install prometheus prometheus-community/prometheus \
+    helm upgrade --install prometheus-operator prometheus-community/kube-prometheus-stack \
         --namespace monitoring \
         --set server.service.type=ClusterIP \
         --set server.persistentVolume.storageClass=nfs \
@@ -1098,7 +1098,14 @@ if [ "$ENABLE_METRICS" == "true" ]; then
     echo -e "\n[*] Configuring OSCAR to use Prometheus and Loki ..."
     if ! kubectl -n oscar set env deployment/oscar \
         PROMETHEUS_URL="http://prometheus-server.monitoring.svc.cluster.local" \
-        LOKI_URL="http://loki-gateway.monitoring.svc.cluster.local"; then
+        LOKI_URL="http://loki-gateway.monitoring.svc.cluster.local" \
+        LOKI_QUERY="{namespace=\"oscar\"}" \
+        LOKI_EXPOSED_QUERY="{app=\"traefik\"}" \
+        LOKI_EXPOSED_NAMESPACE="traefik" \
+        LOKI_EXPOSED_APP_LABEL="traefik" \
+        EXPOSED_SERVICES_ROUTE_KIND="httproute" \
+        HTTPROUTE_GATEWAY_NAME="traefik-gateway" \
+        HTTPROUTE_GATEWAY_NAMESPACE="traefik"; then
         echo -e "$RED[!]$END_COLOR Failed to configure OSCAR metrics endpoints"
     fi
 fi

--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -1097,7 +1097,7 @@ fi
 if [ "$ENABLE_METRICS" == "true" ]; then
     echo -e "\n[*] Configuring OSCAR to use Prometheus and Loki ..."
     if ! kubectl -n oscar set env deployment/oscar \
-        PROMETHEUS_URL="http://prometheus-server.monitoring.svc.cluster.local" \
+        PROMETHEUS_URL="http://prometheus-operator-kube-p-prometheus.monitoring.svc.cluster.local:9090" \
         LOKI_URL="http://loki-gateway.monitoring.svc.cluster.local" \
         LOKI_QUERY="{namespace=\"oscar\"}" \
         LOKI_EXPOSED_QUERY="{app=\"traefik\"}" \

--- a/deploy/metrics/alloy-values.kind.yaml
+++ b/deploy/metrics/alloy-values.kind.yaml
@@ -14,14 +14,8 @@ alloy:
 
         rule {
           source_labels = ["__meta_kubernetes_namespace"]
-          regex         = "oscar"
-          action        = "keep"
-        }
-
-        rule {
-          source_labels = ["__meta_kubernetes_pod_label_app"]
-          regex         = "oscar"
-          action        = "keep"
+          regex         = "^oscar$"
+          action        = "keep" 
         }
 
         rule {
@@ -45,14 +39,8 @@ alloy:
 
         rule {
           source_labels = ["__meta_kubernetes_namespace"]
-          regex         = "traefik"
-          action        = "keep"
-        }
-
-        rule {
-          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-          regex         = "traefik"
-          action        = "keep"
+          regex         = "^traefik$"
+          action        = "keep" 
         }
 
         rule {
@@ -71,72 +59,174 @@ alloy:
         }
       }
 
+      loki.process "oscar" {
+
+      stage.match {
+          selector = "{namespace=\"oscar\"}"
+          stage.drop {
+            expression = ".*GET.*/health.*"
+          }
+        }
+        forward_to = [loki.write.default.receiver]
+      }
+
+      loki.process "traefik" {
+  
+       stage.json {
+         expressions = {
+             ip_cliente       = "ClientHost",
+             status_http      = "DownstreamStatus",
+             duration_ns      = "Duration",
+             method           = "RequestMethod",
+             path             = "RequestPath",
+             host             = "RequestHost",
+             service_name  = "ServiceName",
+             timestamp_log    = "time",
+          }
+        }
+  
+         stage.labels {
+           values={
+           ip_cliente = "ip_cliente",
+           status_http= "status_http",
+           duration_ns = "duration_ns",
+           method= "method",
+           path = "path",
+           host = "host",
+           service_name = "service_name",
+           timestamp_log = "timestamp_log",
+         }
+        }
+  
+  
+      stage.match {
+          selector = "{namespace=\"traefik\"}"
+          stage.drop {
+            expression = "RequestMethod\":\"GET\",\"RequestPath\":\"/.well-known/acme-challenge/"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/lab/"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/static/"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/contents"
+          }
+  
+          stage.drop {
+            expression = "/favicon.ico"
+          }
+  
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/config/jupyterlabapputilsextensionannouncements"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/kernelspecs"
+          }
+  
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/events/subscribe"
+          }
+  
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/me"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/nbdime/api/isgit"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/nbdime/api/"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/git"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/nbconvert"
+          }
+  
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/lsp/status"
+          }
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/kernelspecs/"
+          }
+  
+          ///-----------------------------------------------
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/terminals"
+  
+          }
+  
+  
+          stage.drop {
+            expression = "/system/services/.*/exposed/api/sessions?"
+          }
+  
+          //stage.drop {
+          //  expression = "/system/services/.*/exposed/api/kernels/"
+          //}
+
+          stage.drop {
+            expression = "/system/services/.*/exposed/terminals/websocket/"
+          }
+  
+  
+          //---------------
+  
+  
+          stage.match {
+              selector = `{path=~"^/system/services/.+/exposed/api/kernels\\?.*"}`
+  
+              stage.regex {
+                source      = "path"
+                expression  = "^/system/services/(?P<service_name>[^/]+)/exposed/api/kernels"
+              }
+  
+             stage.labels {
+                values = {
+                    "namespace" = "service_name",
+                }
+            }
+          }
+  
+  
+  
+  
+  
+        }
+  
+  
+        forward_to = [loki.write.default.receiver]
+      }
+
       loki.source.kubernetes "pods" {
         targets    = discovery.relabel.pod_logs.output
         forward_to = [loki.process.oscar.receiver]
       }
-
+  
       loki.source.kubernetes "ingress" {
         targets    = discovery.relabel.ingress_logs.output
-        forward_to = [loki.process.ingress.receiver]
+        forward_to = [loki.process.traefik.receiver]
       }
-
-      loki.process "ingress" {
-        forward_to = [loki.write.default.receiver]
-
-        stage.match {
-          selector = "{namespace!=\"\"} |~ \"/system/services/[^/[:space:]]+/exposed($|[/?[:space:]])\""
-          action   = "keep"
-
-          stage.label_drop {
-            values = ["pod"]
-          }
-        }
-
-        stage.match {
-          selector = "{namespace!=\"\"} !~ \"/system/services/[^/[:space:]]+/exposed($|[/?[:space:]])\""
-          action   = "drop"
-        }
-      }
-
-      loki.process "oscar" {
-        forward_to = [loki.write.default.receiver]
-
-        stage.match {
-          selector = "{namespace!=\"\"} |= \"[GIN]\""
-          action   = "drop"
-        }
-
-        stage.match {
-          selector = "{namespace!=\"\"} |~ \"GIN-EXECUTIONS-LOGGER\" |~ \"/(job|run)/\""
-          action   = "keep"
-
-          stage.regex {
-            expression = ".*\\|\\s*[^|]+\\|\\s*[^|]+\\|\\s*(?P<ip>[0-9a-fA-F:.]+)(?::\\d+)?\\s*\\|.*"
-          }
-
-          stage.geoip {
-            source  = "ip"
-            db      = "/var/lib/alloy/geoip/GeoLite2-Country.mmdb"
-            db_type = "country"
-          }
-
-          stage.labels {
-            values = {
-              geoip_country_name = "",
-              geoip_country_code = "",
-            }
-          }
-
-          stage.label_drop {
-            values = ["pod", "geoip_country_name", "detected_level"]
-          }
-        }
-      }
+  
 
       loki.write "default" {
         endpoint {
-          url = "http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push"
+          url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
         }
       }
 


### PR DESCRIPTION
**Metrics stack upgrade and configuration:**
- Switched from deploying standalone Prometheus to the `kube-prometheus-stack` (Prometheus Operator) for a more complete monitoring solution. Updated service and storage settings accordingly. (`deploy/kind-deploy.sh`)
- Updated OSCAR's environment variables to use the new Prometheus Operator endpoint and added several new Loki and Traefik-related environment variables to support advanced log querying and routing. (`deploy/kind-deploy.sh`)

**Log relabeling and filtering improvements:**
- Tightened namespace and label matching for log relabeling by switching from loose to exact regex matches for `oscar` and `traefik` namespaces. (`deploy/metrics/alloy-values.kind.yaml`) [[1]](diffhunk://#diff-65a588fa6a98a9da323bcf8dad53a4d7c9e17ce8f58f6ec16c3c7e59d0599729L17-R17) [[2]](diffhunk://#diff-65a588fa6a98a9da323bcf8dad53a4d7c9e17ce8f58f6ec16c3c7e59d0599729L48-R42)

**Loki log processing and enrichment:**
- Refactored Loki pipeline to separate and enrich log processing for OSCAR and Traefik:
  - For OSCAR, dropped health check logs.
  - For Traefik, added JSON parsing, extracted and labeled key fields, and implemented an extensive set of drop rules to filter out noisy or irrelevant paths (e.g., health checks, static files, and specific API endpoints).
  - Added logic to extract service names from kernel API paths for better log attribution. (`deploy/metrics/alloy-values.kind.yaml`)

**Loki write endpoint update:**
- Changed the Loki write endpoint to point directly to the Loki service, ensuring logs are pushed to the correct destination. (`deploy/metrics/alloy-values.kind.yaml`)
