### PR TITLE
Extend ForwardAuth with OIDC browser sessions

### DIFF
--- a/docs/exposed-services.md
+++ b/docs/exposed-services.md
@@ -52,7 +52,12 @@ Additional options can be defined in the "expose" section of the FDL (some previ
 - `NodePort`: The access method from the domain name to the public ip `<cluster_ip>:<NodePort>`.
 - `default_command`: Selects between executing the container's default command and executing the script inside the container. (default: false, it executes the script)
 - `set_auth`: The credentials are composed of the service name as the user and the service token as the password. Turn off this field if the container provides its own authentication method. It does not work with `NodePort` (default: false, it has no authentication).
-- `auth_type`: Authentication middleware used when `set_auth` is enabled. `basic` keeps the existing Basic Auth behavior. `forward` uses Traefik ForwardAuth to delegate checks to OSCAR service authorization and can bootstrap browser sessions from `?token=<service-token>` on Gateway API/Traefik exposed services.
+- `auth_type`: Authentication middleware used when `set_auth` is enabled. `basic` keeps the existing Basic Auth behavior. `forward` uses Traefik ForwardAuth to delegate checks to OSCAR service authorization. It accepts the existing service token and OIDC bearer tokens, applies service-level permissions to OIDC users, and creates a service-scoped `HttpOnly` browser cookie. The Dashboard can bootstrap that cookie through `/system/services/{service_name}/auth` using either a bearer header on `GET` or a top-level form `POST` containing `token` and an optional service-scoped `redirect`; the POST flow avoids cross-origin credential restrictions and redirects to the clean exposed URL after authorization. A direct `?token=<service-token-or-OIDC-JWT>` bootstrap is also supported for compatibility, but bearer tokens SHOULD be sent in a header or form body to avoid exposing them in URLs and access logs.
+
+For an OIDC-authenticated ForwardAuth request, OSCAR passes the verified identity
+to the exposed application through `X-OSCAR-User-Sub`,
+`X-OSCAR-User-Name`, and `X-OSCAR-User-Groups`. Applications MUST only trust
+these headers when their route is protected by OSCAR ForwardAuth.
 - `health_path`: The path where the service readiness and liveness status are checked. Only if the root path `/` returns status 4XX or 5XX.
 
 

--- a/docs/fdl.md
+++ b/docs/fdl.md
@@ -182,7 +182,7 @@ storage_providers:
 | `cpu_threshold` </br> *integer* | Percent of use of CPU before creating other pod (default: 80 max:100). Optional.  |
 | `nodePort` </br> *integer* | Change the access method from the domain name to the public ip. Optional.   |
 | `set_auth` </br> *bool* | Create credentials for the service, composed of the service name as the user and the service token as the password. (default: false). Optional.  |
-| `auth_type` </br> *string* | Authentication middleware used when `set_auth` is enabled. Supported values are `basic` (default) and `forward`. `forward` is only supported for Gateway API/Traefik exposed services and delegates checks to OSCAR service authorization. Optional. |
+| `auth_type` </br> *string* | Authentication middleware used when `set_auth` is enabled. Supported values are `basic` (default) and `forward`. `forward` is only supported for Gateway API/Traefik exposed services, delegates checks to OSCAR service authorization, and supports service-token and OIDC-bearer browser sessions. Optional. |
 | `rewrite_target` </br> *bool* | It is an expose boolean in the FDL that controls how OSCAR configures the NGINX Ingress/HTTProute rewrite for exposed services. If rewrite_target: false, ingress rewrites to /$1. If rewrite_target: true, ingress rewrites to /system/services/<service>/exposed/$1 (default: false). Optional.  |
 | `default_command` </br> *bool* | Select between executing the container's default command and executing the script inside the container. (default: false). Optional.  |
 | `health_path` </br> *string* | Change the service readiness and liveness check path/endpoint. (default: "/"). Optional.  |

--- a/main.go
+++ b/main.go
@@ -113,6 +113,9 @@ func main() {
 	r.GET("/system/services/:serviceName/auth",
 		append(auth.BuildServiceAuthMiddlewareChain(cfg, kubeClientset, back), handlers.MakeServiceAuthHandler())...,
 	)
+	r.POST("/system/services/:serviceName/auth",
+		append(auth.BuildServiceAuthMiddlewareChain(cfg, kubeClientset, back), handlers.MakeServiceAuthBootstrapHandler())...,
+	)
 
 	// Swagger UI endpoint (disabled in production)
 	// r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -1269,6 +1269,11 @@ func getTraefikAuthMiddlewareSpec(service types.Service, namespace string, cfg *
 				"address":                  getServiceAuthEndpoint(service, cfg),
 				"trustForwardHeader":       true,
 				"addAuthCookiesToResponse": []any{getServiceAuthCookieName(service.Name)},
+				"authResponseHeaders": []any{
+					auth.OscarUserSubHeader,
+					auth.OscarUserNameHeader,
+					auth.OscarUserGroupsHeader,
+				},
 			},
 		}
 	}

--- a/pkg/backends/resources/expose_test.go
+++ b/pkg/backends/resources/expose_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/grycap/oscar/v4/pkg/utils/auth"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -918,6 +920,15 @@ func TestGetTraefikAuthMiddlewareSpecForward(t *testing.T) {
 
 	if cookies[0] != getServiceAuthCookieName(svc.Name) {
 		t.Fatalf("expected auth cookie %s, got %s", getServiceAuthCookieName(svc.Name), cookies[0])
+	}
+
+	headers, found, err := unstructured.NestedStringSlice(middleware.Object, "spec", "forwardAuth", "authResponseHeaders")
+	if err != nil || !found {
+		t.Fatalf("expected forwardAuth.authResponseHeaders in middleware")
+	}
+	expectedHeaders := []string{auth.OscarUserSubHeader, auth.OscarUserNameHeader, auth.OscarUserGroupsHeader}
+	if !slices.Equal(headers, expectedHeaders) {
+		t.Fatalf("expected auth response headers %v, got %v", expectedHeaders, headers)
 	}
 }
 

--- a/pkg/handlers/service_auth.go
+++ b/pkg/handlers/service_auth.go
@@ -18,16 +18,20 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
+	"path"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v4/pkg/utils/auth"
 )
 
 // MakeServiceAuthHandler godoc
-// @Summary Authenticate service
-// @Description Validate access to a specific service using Basic auth or Bearer token (service token or OIDC token), plus service-level permissions.
+// @Summary Authorize access to an exposed service
+// @Description Validate a service token or OIDC bearer credential, apply service-level permissions, and return ForwardAuth identity headers.
 // @Tags services
 // @Param serviceName path string true "Service name"
-// @Success 200 "OK"
+// @Success 200 "Authorized"
 // @Failure 401 "Unauthorized"
 // @Failure 403 "Forbidden"
 // @Failure 404 "Not Found"
@@ -37,7 +41,84 @@ import (
 // @Router /system/services/{serviceName}/auth [get]
 func MakeServiceAuthHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		setForwardAuthResponse(c)
 		c.Status(http.StatusOK)
-		return
 	}
+}
+
+// MakeServiceAuthBootstrapHandler godoc
+// @Summary Start an exposed-service browser session
+// @Description Validate and authorize an OIDC access token submitted by a browser, set a service-scoped authentication cookie, and redirect to the exposed service.
+// @Tags services
+// @Accept application/x-www-form-urlencoded
+// @Param serviceName path string true "Service name"
+// @Param token formData string true "OIDC access token"
+// @Param redirect formData string false "Path below the selected service's exposed route"
+// @Success 303 "Authenticated; redirecting to the exposed service"
+// @Failure 400 "Invalid redirect path"
+// @Failure 401 "Unauthorized"
+// @Failure 403 "Forbidden"
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Security BearerAuth
+// @Router /system/services/{serviceName}/auth [post]
+func MakeServiceAuthBootstrapHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		setForwardAuthResponse(c)
+		target, ok := serviceAuthRedirect(c.Param("serviceName"), c.PostForm("redirect"))
+		if !ok {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		c.Redirect(http.StatusSeeOther, target)
+	}
+}
+
+func setForwardAuthResponse(c *gin.Context) {
+	auth.SetForwardAuthCookie(c)
+	// Always return these headers so Traefik replaces any client-supplied
+	// values, including for service-token authentication where no end-user
+	// identity is available.
+	c.Header(auth.OscarUserSubHeader, safeForwardAuthHeader(c.GetString("uidOrigin")))
+	c.Header(auth.OscarUserNameHeader, safeForwardAuthHeader(c.GetString("userName")))
+	groups, _ := c.Get(auth.UserGroupsContextKey)
+	if values, ok := groups.([]string); ok {
+		c.Header(auth.OscarUserGroupsHeader, safeForwardAuthHeader(strings.Join(values, ",")))
+	} else {
+		c.Header(auth.OscarUserGroupsHeader, "")
+	}
+}
+
+func serviceAuthRedirect(serviceName, requested string) (string, bool) {
+	basePath := "/system/services/" + serviceName + "/exposed"
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return basePath + "/", true
+	}
+
+	target, err := url.ParseRequestURI(requested)
+	if err != nil || target.IsAbs() || target.Host != "" || target.Path == "" || strings.Contains(target.Path, "\\") {
+		return "", false
+	}
+
+	hadTrailingSlash := strings.HasSuffix(target.Path, "/")
+	cleanPath := path.Clean(target.Path)
+	if cleanPath != basePath && !strings.HasPrefix(cleanPath, basePath+"/") {
+		return "", false
+	}
+	// Reject ambiguous traversal instead of silently redirecting to a normalized target.
+	if cleanPath != strings.TrimSuffix(target.Path, "/") {
+		return "", false
+	}
+
+	target.Path = cleanPath
+	target.RawPath = ""
+	if hadTrailingSlash {
+		target.Path += "/"
+	}
+	return target.String(), true
+}
+
+func safeForwardAuthHeader(value string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(value)
 }

--- a/pkg/handlers/service_auth_test.go
+++ b/pkg/handlers/service_auth_test.go
@@ -19,9 +19,12 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/grycap/oscar/v4/pkg/utils/auth"
 )
 
 func TestMakeServiceAuthHandler(t *testing.T) {
@@ -58,5 +61,75 @@ func TestMakeServiceAuthHandler(t *testing.T) {
 				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
 			}
 		})
+	}
+}
+
+func TestMakeServiceAuthHandlerRedirectsPOSTToExposedService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/system/services/:serviceName/auth", MakeServiceAuthBootstrapHandler())
+
+	tests := []struct {
+		name       string
+		redirect   string
+		wantStatus int
+		wantTarget string
+	}{
+		{name: "defaults to exposed root", wantStatus: http.StatusSeeOther, wantTarget: "/system/services/example/exposed/"},
+		{name: "accepts service child", redirect: "/system/services/example/exposed/notebook?tab=1", wantStatus: http.StatusSeeOther, wantTarget: "/system/services/example/exposed/notebook?tab=1"},
+		{name: "preserves child trailing slash", redirect: "/system/services/example/exposed/notebook/", wantStatus: http.StatusSeeOther, wantTarget: "/system/services/example/exposed/notebook/"},
+		{name: "rejects another service", redirect: "/system/services/other/exposed/", wantStatus: http.StatusBadRequest},
+		{name: "rejects absolute URL", redirect: "https://attacker.example/", wantStatus: http.StatusBadRequest},
+		{name: "rejects plain traversal", redirect: "/system/services/example/exposed/../../config", wantStatus: http.StatusBadRequest},
+		{name: "rejects encoded traversal", redirect: "/system/services/example/exposed/%2e%2e/%2e%2e/config", wantStatus: http.StatusBadRequest},
+		{name: "rejects backslash traversal", redirect: `/system/services/example/exposed/..\\..\\config`, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			form := url.Values{}
+			if tt.redirect != "" {
+				form.Set("redirect", tt.redirect)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/system/services/example/auth", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.Code, tt.wantStatus)
+			}
+			if got := resp.Header().Get("Location"); got != tt.wantTarget {
+				t.Fatalf("location = %q, want %q", got, tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestMakeServiceAuthHandlerForwardsOIDCIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/system/services/:serviceName/auth",
+		func(c *gin.Context) {
+			c.Set("uidOrigin", "student-sub")
+			c.Set("userName", "Student\nName")
+			c.Set(auth.UserGroupsContextKey, []string{"oscar-students", "pilot"})
+			c.Next()
+		},
+		MakeServiceAuthHandler(),
+	)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/system/services/example/auth", nil)
+	router.ServeHTTP(resp, req)
+
+	if got := resp.Header().Get(auth.OscarUserSubHeader); got != "student-sub" {
+		t.Fatalf("sub header = %q, want student-sub", got)
+	}
+	if got := resp.Header().Get(auth.OscarUserNameHeader); got != "StudentName" {
+		t.Fatalf("name header = %q, want StudentName", got)
+	}
+	if got := resp.Header().Get(auth.OscarUserGroupsHeader); got != "oscar-students,pilot" {
+		t.Fatalf("groups header = %q, want oscar-students,pilot", got)
 	}
 }

--- a/pkg/resourcemanager/delegate.go
+++ b/pkg/resourcemanager/delegate.go
@@ -229,7 +229,7 @@ func reorganizeIfNearby(alternatives []Alternative, distances []float64, thresho
 	}
 
 	// Randomly shuffle nearby items
-	rand.Shuffle(len(nearby), func(i, j int) {
+	rand.Shuffle(len(nearby), func(i, j int) { // #nosec G404 -- non-security-sensitive tie breaking
 		nearby[i], nearby[j] = nearby[j], nearby[i]
 	})
 

--- a/pkg/utils/auth/auth.go
+++ b/pkg/utils/auth/auth.go
@@ -39,7 +39,7 @@ func GetAuthMiddleware(cfg *types.Config, kubeClientset kubernetes.Interface) gi
 	return CustomAuth(cfg, kubeClientset)
 }
 
-func BuildServiceAuthMiddlewareChain(cfg *types.Config, kubeClientset kubernetes.Interface, back types.ServerlessBackend) []gin.HandlerFunc {
+func BuildServiceAuthMiddlewareChain(cfg *types.Config, _ kubernetes.Interface, back types.ServerlessBackend) []gin.HandlerFunc {
 	var authHandler gin.HandlerFunc
 	fmt.Printf("OIDC authentication enabled: %v\n", cfg.OIDCEnable)
 	if !cfg.OIDCEnable {
@@ -48,7 +48,15 @@ func BuildServiceAuthMiddlewareChain(cfg *types.Config, kubeClientset kubernetes
 			cfg.Username: cfg.Password,
 		})
 	} else {
-		authHandler = CustomAuth(cfg, kubeClientset)
+		oidcIdentityHandler := getOIDCIdentityMiddleware(cfg, nil)
+		basicAuthHandler := gin.BasicAuth(gin.Accounts{cfg.Username: cfg.Password})
+		authHandler = func(c *gin.Context) {
+			if _, ok := isAuthBearer(c); ok {
+				oidcIdentityHandler(c)
+			} else {
+				basicAuthHandler(c)
+			}
+		}
 	}
 
 	var wrapperHandler gin.HandlerFunc = func(c *gin.Context) {
@@ -62,7 +70,12 @@ func BuildServiceAuthMiddlewareChain(cfg *types.Config, kubeClientset kubernetes
 		authHandler(c)
 	}
 
-	return []gin.HandlerFunc{GetServiceTokenMiddleware(back), wrapperHandler, GetServicePermissionsMiddleware(back)}
+	return []gin.HandlerFunc{
+		GetServiceTokenMiddleware(back),
+		GetForwardAuthBootstrapMiddleware(),
+		wrapperHandler,
+		GetServicePermissionsMiddleware(back),
+	}
 }
 
 // CustomAuth returns a custom auth handler (gin middleware)

--- a/pkg/utils/auth/bearer.go
+++ b/pkg/utils/auth/bearer.go
@@ -1,0 +1,47 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// isAuthBearer extracts a credential transported with the HTTP Bearer scheme.
+// It does not determine whether the credential is a service token or an OIDC token.
+func isAuthBearer(c *gin.Context) (string, bool) {
+	authHeader := c.GetHeader("Authorization")
+	splitToken := strings.Split(authHeader, "Bearer ")
+	if len(splitToken) == 2 {
+		return strings.TrimSpace(splitToken[1]), true
+	}
+	return "", false
+}
+
+func tokenFromForwardedURI(rawURI string) string {
+	if strings.TrimSpace(rawURI) == "" {
+		return ""
+	}
+
+	uri, err := url.Parse(rawURI)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(uri.Query().Get("token"))
+}

--- a/pkg/utils/auth/forward_auth.go
+++ b/pkg/utils/auth/forward_auth.go
@@ -1,0 +1,97 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const forwardAuthTokenContextKey = "forwardAuthOIDCToken"
+const minOIDCAccessTokenLength = 65
+const maxOIDCAccessTokenLength = 16 * 1024
+
+const (
+	OscarUserSubHeader    = "X-OSCAR-User-Sub"
+	OscarUserNameHeader   = "X-OSCAR-User-Name"
+	OscarUserGroupsHeader = "X-OSCAR-User-Groups"
+)
+
+// GetForwardAuthBootstrapMiddleware obtains an OIDC access token from a browser
+// bootstrap request or service-scoped cookie. The regular OIDC and service
+// permission middleware still validate and authorize it on every request.
+func GetForwardAuthBootstrapMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := forwardAuthOIDCToken(c)
+		if token == "" {
+			c.Next()
+			return
+		}
+
+		if _, ok := isAuthBearer(c); !ok {
+			c.Request.Header.Set("Authorization", "Bearer "+token)
+		}
+		c.Set(forwardAuthTokenContextKey, token)
+		c.Next()
+	}
+}
+
+// SetForwardAuthCookie persists a detected OIDC access token. Call it only
+// after OIDC authentication and service permissions have succeeded.
+func SetForwardAuthCookie(c *gin.Context) {
+	value, exists := c.Get(forwardAuthTokenContextKey)
+	if !exists {
+		return
+	}
+	token, ok := value.(string)
+	if !ok || !looksLikeJWT(token) {
+		return
+	}
+	setServiceAuthCookie(c, c.Param("serviceName"), token)
+}
+
+func forwardAuthOIDCToken(c *gin.Context) string {
+	if token, ok := isAuthBearer(c); ok && looksLikeJWT(token) {
+		return token
+	}
+
+	if token := strings.TrimSpace(c.PostForm("token")); looksLikeJWT(token) {
+		return token
+	}
+
+	if token := strings.TrimSpace(c.Query("token")); looksLikeJWT(token) {
+		return token
+	}
+
+	if token := tokenFromForwardedURI(c.GetHeader("X-Forwarded-Uri")); looksLikeJWT(token) {
+		return token
+	}
+
+	if token := serviceAuthCookie(c, c.Param("serviceName")); looksLikeJWT(token) {
+		return token
+	}
+
+	return ""
+}
+
+// looksLikeJWT performs structural classification only. Cryptographic and
+// claim validation is deliberately left to the OIDC middleware.
+func looksLikeJWT(token string) bool {
+	token = strings.TrimSpace(token)
+	return len(token) >= minOIDCAccessTokenLength && len(token) <= maxOIDCAccessTokenLength && strings.Count(token, ".") == 2
+}

--- a/pkg/utils/auth/forward_auth.go
+++ b/pkg/utils/auth/forward_auth.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const forwardAuthTokenContextKey = "forwardAuthOIDCToken"
+const forwardAuthTokenContextKey = "forwardAuthOIDCToken" // #nosec G101 -- Gin context key, not a hardcoded credential
 const minOIDCAccessTokenLength = 65
 const maxOIDCAccessTokenLength = 16 * 1024
 

--- a/pkg/utils/auth/forward_auth_test.go
+++ b/pkg/utils/auth/forward_auth_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetForwardAuthBootstrapMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	jwtToken := strings.Repeat("a", 32) + "." + strings.Repeat("b", 32) + "." + strings.Repeat("c", 32)
+	tests := []struct {
+		name          string
+		authHeader    string
+		targetPath    string
+		forwardedURI  string
+		cookieToken   string
+		formToken     string
+		wantBearer    string
+		wantSetCookie bool
+	}{
+		{name: "accepts bearer header", authHeader: "Bearer " + jwtToken, wantBearer: jwtToken, wantSetCookie: true},
+		{name: "accepts query bearer", targetPath: "/system/services/svc/auth?token=" + jwtToken, wantBearer: jwtToken, wantSetCookie: true},
+		{name: "accepts form bearer", formToken: jwtToken, wantBearer: jwtToken, wantSetCookie: true},
+		{name: "accepts forwarded URI bearer", forwardedURI: "/system/services/svc/exposed/?token=" + jwtToken, wantBearer: jwtToken, wantSetCookie: true},
+		{name: "accepts service auth cookie bearer", cookieToken: jwtToken, wantBearer: jwtToken, wantSetCookie: true},
+		{name: "ignores non-JWT application token", targetPath: "/system/services/svc/auth?token=application-session-token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			gotBearer := ""
+			router.Any("/system/services/:serviceName/auth",
+				GetForwardAuthBootstrapMiddleware(),
+				func(c *gin.Context) {
+					gotBearer, _ = isAuthBearer(c)
+					SetForwardAuthCookie(c)
+					c.Status(http.StatusOK)
+				},
+			)
+
+			targetPath := tt.targetPath
+			if targetPath == "" {
+				targetPath = "/system/services/svc/auth"
+			}
+			method := http.MethodGet
+			body := strings.NewReader("")
+			if tt.formToken != "" {
+				method = http.MethodPost
+				body = strings.NewReader(url.Values{"token": []string{tt.formToken}}.Encode())
+			}
+			req := httptest.NewRequest(method, targetPath, body)
+			if tt.formToken != "" {
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			if tt.forwardedURI != "" {
+				req.Header.Set("X-Forwarded-Uri", tt.forwardedURI)
+			}
+			if tt.cookieToken != "" {
+				req.AddCookie(&http.Cookie{Name: getServiceAuthCookieName("svc"), Value: tt.cookieToken})
+			}
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			if gotBearer != tt.wantBearer {
+				t.Fatalf("bearer = %q, want %q", gotBearer, tt.wantBearer)
+			}
+			setCookie := resp.Header().Get("Set-Cookie")
+			if tt.wantSetCookie && !strings.Contains(setCookie, getServiceAuthCookieName("svc")+"=") {
+				t.Fatalf("expected service auth cookie, got %q", setCookie)
+			}
+			if !tt.wantSetCookie && setCookie != "" {
+				t.Fatalf("unexpected service auth cookie %q", setCookie)
+			}
+		})
+	}
+}
+
+func TestForwardAuthCookieIsNotSetBeforeAuthorization(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	jwtToken := strings.Repeat("a", 32) + "." + strings.Repeat("b", 32) + "." + strings.Repeat("c", 32)
+
+	router := gin.New()
+	router.GET("/system/services/:serviceName/auth",
+		GetForwardAuthBootstrapMiddleware(),
+		func(c *gin.Context) {
+			c.AbortWithStatus(http.StatusForbidden)
+		},
+		func(c *gin.Context) {
+			SetForwardAuthCookie(c)
+			c.Status(http.StatusOK)
+		},
+	)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/system/services/svc/auth?token="+jwtToken, nil)
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusForbidden)
+	}
+	if cookie := resp.Header().Get("Set-Cookie"); cookie != "" {
+		t.Fatalf("unexpected auth cookie on denied request: %q", cookie)
+	}
+}

--- a/pkg/utils/auth/oidc.go
+++ b/pkg/utils/auth/oidc.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 
 	"net/http"
 	"strings"
@@ -40,7 +41,8 @@ const (
 	EGIIssuer          = "/realms/egi"
 	AI4EOSCIssuer      = "/realms/ai4eosc"
 
-	SecretKeyLength = 10
+	SecretKeyLength      = 10
+	UserGroupsContextKey = "userGroups"
 )
 
 var oidcLogger = log.New(os.Stdout, "[OIDC-AUTH] ", log.Flags())
@@ -48,11 +50,12 @@ var ClusterOidcManagers = make(map[string]*oidcManager)
 
 // oidcManager struct to represent a OIDC manager, including a cache of tokens
 type oidcManager struct {
-	provider   *oidc.Provider
-	config     *oidc.Config
-	subject    string
-	groups     []string
-	tokenCache map[string]*userInfo
+	provider        *oidc.Provider
+	config          *oidc.Config
+	subject         string
+	groups          []string
+	tokenCache      map[string]*userInfo
+	tokenCacheMutex sync.RWMutex
 }
 
 // userInfo custom struct to store essential fields from UserInfo
@@ -108,54 +111,75 @@ func NewOIDCManager(issuer string, subject string, groups []string) (*oidcManage
 	}, nil
 }
 
-// getIODCMiddleware returns the Gin's handler middleware to validate OIDC-based auth
-func getOIDCMiddleware(kubeClientset kubernetes.Interface, minIOAdminClient *utils.MinIOAdminClient, cfg *types.Config, oidcConfig *oidc.Config) gin.HandlerFunc {
+type oidcIdentityHandler func(*gin.Context) (*userInfo, bool)
 
+func newOIDCIdentityHandler(cfg *types.Config, oidcConfig *oidc.Config) oidcIdentityHandler {
+	managers := make(map[string]*oidcManager, len(cfg.OIDCValidIssuers))
 	for _, iss := range cfg.OIDCValidIssuers {
-		issuerManager, err := NewOIDCManager(iss, cfg.OIDCSubject, cfg.OIDCGroups)
-		if oidcConfig != nil {
-			issuerManager.config = oidcConfig
-		}
+		manager, err := NewOIDCManager(iss, cfg.OIDCSubject, cfg.OIDCGroups)
 		if err != nil {
-			return func(c *gin.Context) {
+			return func(c *gin.Context) (*userInfo, bool) {
 				c.AbortWithStatus(http.StatusUnauthorized)
-				return
+				return nil, false
 			}
 		}
+		if oidcConfig != nil {
+			manager.config = oidcConfig
+		}
 
-		ClusterOidcManagers[iss] = issuerManager
-
+		managers[iss] = manager
+		ClusterOidcManagers[iss] = manager
 	}
 
-	mc := NewMultitenancyConfig(kubeClientset, cfg.OIDCSubject)
-
-	return func(c *gin.Context) {
-		// Get token from headers
-		authHeader := c.GetHeader("Authorization")
-		if !strings.HasPrefix(authHeader, "Bearer ") {
+	return func(c *gin.Context) (*userInfo, bool) {
+		rawToken, ok := isAuthBearer(c)
+		if !ok {
 			c.AbortWithStatus(http.StatusUnauthorized)
-			return
+			return nil, false
 		}
-		rawToken := strings.TrimPrefix(authHeader, "Bearer ")
 		iss, err := GetIssuerFromToken(rawToken)
 		if err != nil {
 			c.String(http.StatusBadRequest, fmt.Sprintf("%v", err))
-			return
+			return nil, false
 		}
-		oidcManager := ClusterOidcManagers[iss]
-		if oidcManager == nil {
+		manager := managers[iss]
+		if manager == nil {
 			c.String(http.StatusUnauthorized, fmt.Sprintf("'%s' is not listed as an authorized issuer", iss))
-			return
-		}
-		// Check the token
-		if !oidcManager.IsAuthorised(rawToken) {
-			c.AbortWithStatus(http.StatusUnauthorized)
-			return
+			return nil, false
 		}
 
-		ui, err := oidcManager.GetUserInfo(rawToken)
-		if err != nil {
-			c.String(http.StatusInternalServerError, fmt.Sprintf("%v", err))
+		ui, ok := manager.authorizedUserInfo(rawToken)
+		if !ok {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return nil, false
+		}
+		return ui, true
+	}
+}
+
+// getOIDCIdentityMiddleware validates OIDC identity and groups without
+// provisioning any per-user infrastructure. It is used by ForwardAuth.
+func getOIDCIdentityMiddleware(cfg *types.Config, oidcConfig *oidc.Config) gin.HandlerFunc {
+	authenticate := newOIDCIdentityHandler(cfg, oidcConfig)
+	return func(c *gin.Context) {
+		ui, ok := authenticate(c)
+		if !ok {
+			return
+		}
+		setOIDCIdentityContext(c, ui)
+		c.Next()
+	}
+}
+
+// getOIDCMiddleware validates OIDC identity and provisions the infrastructure
+// needed by regular OSCAR API operations.
+func getOIDCMiddleware(kubeClientset kubernetes.Interface, minIOAdminClient *utils.MinIOAdminClient, cfg *types.Config, oidcConfig *oidc.Config) gin.HandlerFunc {
+	authenticate := newOIDCIdentityHandler(cfg, oidcConfig)
+	mc := NewMultitenancyConfig(kubeClientset, cfg.OIDCSubject)
+
+	return func(c *gin.Context) {
+		ui, ok := authenticate(c)
+		if !ok {
 			return
 		}
 		uid := ui.Subject
@@ -200,19 +224,33 @@ func getOIDCMiddleware(kubeClientset kubernetes.Interface, minIOAdminClient *uti
 
 		utils.EnsureVolumeLimits(FormatUID(uid), namespace, kubeClientset, cfg)
 
-		c.Set("uidOrigin", uid)
-		c.Set("userName", ui.Name)
+		setOIDCIdentityContext(c, ui)
 		c.Set("multitenancyConfig", mc)
 		c.Next()
 	}
 }
 
+func setOIDCIdentityContext(c *gin.Context, ui *userInfo) {
+	c.Set("uidOrigin", ui.Subject)
+	c.Set("userName", ui.Name)
+	c.Set(UserGroupsContextKey, ui.Groups)
+}
+
 // clearExpired delete expired tokens from the cache
 func (om *oidcManager) clearExpired() {
+	om.tokenCacheMutex.RLock()
+	tokens := make([]string, 0, len(om.tokenCache))
 	for rawToken := range om.tokenCache {
+		tokens = append(tokens, rawToken)
+	}
+	om.tokenCacheMutex.RUnlock()
+
+	for _, rawToken := range tokens {
 		_, err := om.provider.Verifier(om.config).Verify(context.TODO(), rawToken)
 		if err != nil {
+			om.tokenCacheMutex.Lock()
 			delete(om.tokenCache, rawToken)
+			om.tokenCacheMutex.Unlock()
 		}
 	}
 }
@@ -324,22 +362,31 @@ func (om *oidcManager) GetUID(rawToken string) (string, error) {
 
 // IsAuthorised checks if a token is authorised to access the API
 func (om *oidcManager) IsAuthorised(rawToken string) bool {
+	_, ok := om.authorizedUserInfo(rawToken)
+	return ok
+}
+
+func (om *oidcManager) authorizedUserInfo(rawToken string) (*userInfo, bool) {
 	// Check if the token is valid
 	_, err := om.provider.Verifier(om.config).Verify(context.TODO(), rawToken)
 	if err != nil {
-		return false
+		return nil, false
 	}
 
 	// Check if token is in cache
+	om.tokenCacheMutex.RLock()
 	ui, found := om.tokenCache[rawToken]
+	om.tokenCacheMutex.RUnlock()
 	if !found {
 		// Get userInfo from the issuer
 		ui, err = om.GetUserInfo(rawToken)
 		if err != nil {
-			return false
+			return nil, false
 		}
 		// Store userInfo in cache
+		om.tokenCacheMutex.Lock()
 		om.tokenCache[rawToken] = ui
+		om.tokenCacheMutex.Unlock()
 
 		// Call clearExpired to delete expired tokens
 		om.clearExpired()
@@ -349,12 +396,12 @@ func (om *oidcManager) IsAuthorised(rawToken string) bool {
 	for _, tokenGroup := range ui.Groups {
 		for _, authGroup := range om.groups {
 			if tokenGroup == authGroup {
-				return true
+				return ui, true
 			}
 		}
 	}
 
-	return false
+	return nil, false
 }
 
 func (om *oidcManager) UserInOneGroup(ui *userInfo, cfg *types.Config) bool {

--- a/pkg/utils/auth/oidc_test.go
+++ b/pkg/utils/auth/oidc_test.go
@@ -255,7 +255,7 @@ func TestGetOIDCMiddleware(t *testing.T) {
 			Namespace: "oscar-svc",
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "test-pv",
+			VolumeName:  "test-pv",
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -354,6 +354,64 @@ func TestGetOIDCMiddleware(t *testing.T) {
 				t.Errorf("expected status to be %v, got %v", s.code, c.Writer.Status())
 			}
 		})
+	}
+}
+
+func TestGetOIDCIdentityMiddlewareDoesNotProvision(t *testing.T) {
+	testsupport.SkipIfCannotListen(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, request *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/.well-known/openid-configuration":
+			rw.Write([]byte(`{"issuer":"http://` + request.Host + `","userinfo_endpoint":"http://` + request.Host + `/userinfo"}`))
+		case "/userinfo":
+			rw.Write([]byte(`{"sub":"student-sub","name":"Student Zero","group_membership":["/oscar-students"]}`))
+		default:
+			t.Errorf("lightweight identity middleware made unexpected provisioning request to %s", request.URL.Path)
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &types.Config{
+		OIDCEnable:       true,
+		OIDCValidIssuers: []string{server.URL},
+		OIDCGroups:       []string{"/oscar-students"},
+	}
+	oidcConfig := &oidc.Config{InsecureSkipSignatureCheck: true, SkipClientIDCheck: true}
+
+	var subject, name string
+	var groups []string
+	router := gin.New()
+	router.Use(getOIDCIdentityMiddleware(cfg, oidcConfig))
+	router.GET("/", func(c *gin.Context) {
+		subject = c.GetString("uidOrigin")
+		name = c.GetString("userName")
+		value, _ := c.Get(UserGroupsContextKey)
+		groups, _ = value.([]string)
+		c.Status(http.StatusOK)
+	})
+
+	claims := jwt.MapClaims{
+		"iss": server.URL,
+		"sub": "student-sub",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("Authorization", "Bearer "+GetToken(claims))
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if subject != "student-sub" || name != "Student Zero" {
+		t.Fatalf("unexpected identity: subject=%q name=%q", subject, name)
+	}
+	if !reflect.DeepEqual(groups, []string{"/oscar-students"}) {
+		t.Fatalf("groups = %v", groups)
 	}
 }
 

--- a/pkg/utils/auth/service_auth_cookie.go
+++ b/pkg/utils/auth/service_auth_cookie.go
@@ -1,0 +1,53 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The service-scoped authentication cookie can carry either a service token or
+// an OIDC access token. The corresponding middleware determines and validates its type.
+func setServiceAuthCookie(c *gin.Context, serviceName, credential string) {
+	path := "/system/services/" + serviceName + "/exposed"
+	secure := strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") || c.Request.TLS != nil
+
+	http.SetCookie(c.Writer, &http.Cookie{ // #nosec G124
+		Name:     getServiceAuthCookieName(serviceName),
+		Value:    credential,
+		Path:     path,
+		MaxAge:   0,
+		Secure:   secure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func serviceAuthCookie(c *gin.Context, serviceName string) string {
+	credential, err := c.Cookie(getServiceAuthCookieName(serviceName))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(credential)
+}
+
+func getServiceAuthCookieName(serviceName string) string {
+	return "oscar_service_" + strings.ReplaceAll(serviceName, "-", "_") + "_auth"
+}

--- a/pkg/utils/auth/service_permissions.go
+++ b/pkg/utils/auth/service_permissions.go
@@ -19,7 +19,6 @@ package auth
 import (
 	"net/http"
 	"slices"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/grycap/oscar/v4/pkg/types"
@@ -96,15 +95,6 @@ func hasPermission(service *types.Service, uid string) bool {
 		return false
 	}
 	return false
-}
-
-func isAuthBearer(c *gin.Context) (string, bool) {
-	authHeader := c.GetHeader("Authorization")
-	splitToken := strings.Split(authHeader, "Bearer ")
-	if len(splitToken) == 2 {
-		return strings.TrimSpace(splitToken[1]), true
-	}
-	return "", false
 }
 
 func isBasicAuth(c *gin.Context) bool {

--- a/pkg/utils/auth/service_token.go
+++ b/pkg/utils/auth/service_token.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -26,11 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-const tokenLength = 64
+const serviceTokenLength = 64
 const isServiceTokenKey = "isServiceToken"
 
-// GetServiceTokenMiddleware returns a gin middleware that checks if the request is authenticated with a service token
-// APPLY ONLY before auth.GetAuthMiddleware, since it relies on the fact that if a service token is provided, the user authentication will not be performed
+// GetServiceTokenMiddleware checks credentials issued specifically for an OSCAR service.
+// Apply it only before GetAuthMiddleware, because a valid service token bypasses user authentication.
 func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if isBasicAuth(c) {
@@ -41,7 +40,6 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 		if tokens := getServiceTokenCandidates(c); len(tokens) > 0 {
 			serviceList, err := back.ListServicesByName(c.Param("serviceName"))
 			if err != nil {
-				// Check if error is caused because the service is not found
 				if errors.IsNotFound(err) || errors.IsGone(err) {
 					c.AbortWithStatus(http.StatusNotFound)
 				} else {
@@ -50,13 +48,12 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 				return
 			}
 
-			// only one service should be returned
-			// the restriction for unique service names is enforced in the service creation and update handlers
+			// Service names are unique, so the lookup returns the single target service.
 			service := serviceList[0]
 			for _, token := range tokens {
 				if token == service.Token {
 					c.Set(isServiceTokenKey, true)
-					setServiceTokenCookie(c, service.Name, token)
+					setServiceAuthCookie(c, service.Name, token)
 					c.Next()
 					return
 				}
@@ -67,63 +64,31 @@ func GetServiceTokenMiddleware(back types.ServerlessBackend) gin.HandlerFunc {
 		}
 
 		c.Next()
-		return
 	}
 }
 
 func getServiceTokenCandidates(c *gin.Context) []string {
 	tokens := []string{}
 
-	// Prioritise the token in the authorization header over other sources of service tokens
+	// An Authorization credential takes precedence over tokens from other sources.
 	if token, ok := isAuthBearer(c); ok {
-		if len(strings.TrimSpace(token)) == tokenLength {
+		if len(strings.TrimSpace(token)) == serviceTokenLength {
 			tokens = append(tokens, token)
 		}
 		return tokens
 	}
 
-	if token := strings.TrimSpace(c.Query("token")); len(token) == tokenLength {
+	if token := strings.TrimSpace(c.Query("token")); len(token) == serviceTokenLength {
 		tokens = append(tokens, token)
 	}
 
-	if token := serviceTokenFromForwardedURI(c.GetHeader("X-Forwarded-Uri")); len(token) == tokenLength {
+	if token := tokenFromForwardedURI(c.GetHeader("X-Forwarded-Uri")); len(token) == serviceTokenLength {
 		tokens = append(tokens, token)
 	}
 
-	if token, err := c.Cookie(getServiceTokenCookieName(c.Param("serviceName"))); err == nil && len(strings.TrimSpace(token)) == tokenLength {
-		tokens = append(tokens, strings.TrimSpace(token))
+	if token := serviceAuthCookie(c, c.Param("serviceName")); len(token) == serviceTokenLength {
+		tokens = append(tokens, token)
 	}
 
 	return tokens
-}
-
-func serviceTokenFromForwardedURI(rawURI string) string {
-	if strings.TrimSpace(rawURI) == "" {
-		return ""
-	}
-
-	uri, err := url.Parse(rawURI)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(uri.Query().Get("token"))
-}
-
-func setServiceTokenCookie(c *gin.Context, serviceName string, token string) {
-	path := "/system/services/" + serviceName + "/exposed"
-	secure := strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") || c.Request.TLS != nil
-
-	http.SetCookie(c.Writer, &http.Cookie{ // #nosec G124
-		Name:     getServiceTokenCookieName(serviceName),
-		Value:    token,
-		Path:     path,
-		MaxAge:   0,
-		Secure:   secure,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
-func getServiceTokenCookieName(serviceName string) string {
-	return "oscar_service_" + strings.ReplaceAll(serviceName, "-", "_") + "_auth"
 }

--- a/pkg/utils/auth/service_token_test.go
+++ b/pkg/utils/auth/service_token_test.go
@@ -72,7 +72,7 @@ func (m *serviceTokenMockBackend) GetKubeClientset() kubernetes.Interface {
 func TestGetServiceTokenMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	validToken := strings.Repeat("a", tokenLength)
+	validToken := strings.Repeat("a", serviceTokenLength)
 
 	// Decision graph paths for GetServiceTokenMiddleware:
 	// 1) basic auth -> pass through
@@ -222,7 +222,7 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 			name:       "returns unauthorized when token does not match",
 			authHeader: "Bearer " + validToken,
 			backendServices: []*types.Service{
-				{Name: "svc", Token: strings.Repeat("b", tokenLength)},
+				{Name: "svc", Token: strings.Repeat("b", serviceTokenLength)},
 			},
 			wantLookup:          true,
 			wantStatus:          http.StatusUnauthorized,
@@ -294,7 +294,7 @@ func TestGetServiceTokenMiddleware(t *testing.T) {
 				req.Header.Set("X-Forwarded-Uri", tt.forwardedURI)
 			}
 			if tt.cookieToken != "" {
-				req.AddCookie(&http.Cookie{Name: getServiceTokenCookieName("svc"), Value: tt.cookieToken})
+				req.AddCookie(&http.Cookie{Name: getServiceAuthCookieName("svc"), Value: tt.cookieToken})
 			}
 			if tt.basicAuth {
 				req.SetBasicAuth("user", "password")


### PR DESCRIPTION
## Summary

This PR extends OSCAR's exposed-service ForwardAuth flow with OIDC-aware browser sessions and verified end-user identity.

It:

- accepts OSCAR service tokens and OIDC bearer tokens in the service authorization endpoint;
- authorizes OIDC users with the existing service-level visibility rules;
- bootstraps a service-scoped, `HttpOnly` cookie for browser navigation;
- forwards the verified subject, name, and groups as `X-OSCAR-User-*` headers;
- keeps ForwardAuth OIDC validation lightweight, without provisioning user infrastructure;
- separates service-token, bearer-token, ForwardAuth, and cookie responsibilities into focused files.

## Evolution from #581

This work builds on [#581](https://github.com/grycap/oscar/pull/581), which introduced the opt-in `expose.auth_type: forward` mode for Gateway API / Traefik services.

PR #581 established the original flow:

1. Traefik delegates exposed-route authorization to `/system/services/{serviceName}/auth`.
2. OSCAR validates a service token supplied through a bearer header, query parameter, forwarded URI, or scoped cookie.
3. OSCAR returns a service-scoped cookie so browser applications and WebSockets can continue without a Basic Auth prompt.
4. Existing `auth_type: basic` behavior remains the default.

This PR evolves that implementation from service-token-only access into an authenticated OSCAR-user flow:

- an OIDC access token is now distinguished from an OSCAR service token and validated with the configured issuer and group rules;
- restricted-service permissions are applied to the authenticated OSCAR user;
- the Dashboard can submit the current OIDC token with a top-level form POST, avoiding cross-origin credential restrictions;
- OSCAR returns verified identity headers to the exposed application;
- the original query-token and service-token cookie behavior remains supported for backward compatibility;
- bearer-token and ForwardAuth logic no longer lives in `service_token.go`, reflecting that the credentials have different semantics.

## Browser authorization flow

`GET /system/services/{serviceName}/auth` is the ForwardAuth authorization check.

`POST /system/services/{serviceName}/auth` is the browser-session bootstrap endpoint. It accepts an OIDC token in a form body, sets the scoped authentication cookie, and responds with `303 See Other` to the exposed service.

Redirect targets are restricted to the selected service's exposed route. Absolute URLs, another service's route, backslash paths, and plain or encoded traversal attempts are rejected.

## Lightweight OIDC validation

The regular OSCAR OIDC middleware provisions resources needed by API users, including MinIO users, Kubernetes namespaces, quotas, and Kueue resources.

ForwardAuth requests only need to authenticate and authorize access to an already deployed web application. They now use a lightweight identity middleware that verifies the token, issuer, groups, and user information without performing that provisioning. Regular OSCAR API authentication retains the existing provisioning behavior.

OIDC user information is cached behind a mutex so concurrent ForwardAuth requests can safely reuse it.

## Security and compatibility

- Existing Basic Auth behavior is unchanged.
- Existing OSCAR service-token ForwardAuth behavior from #581 is retained.
- Cookies remain scoped to `/system/services/{serviceName}/exposed`, `HttpOnly`, `SameSite=Lax`, and `Secure` for HTTPS requests.
- Traefik replaces client-supplied `X-OSCAR-User-*` values with the verified headers returned by OSCAR.
- Applications should only trust those headers when protected by OSCAR ForwardAuth.
- Tokens in headers or form bodies are preferred over query parameters to avoid URL and access-log exposure.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./pkg/utils/auth`
- `go vet ./pkg/handlers ./pkg/utils/auth`
- `git diff --check`
- generated a temporary Swagger specification and verified distinct GET and POST operations

`mkdocs build --strict` could not run locally because the installed environment does not include the configured Material for MkDocs theme.