### PR TITLE
fix: move api_version entry in KServe configuration to inference and set KSERVE_HOST var

### DIFF
--- a/examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml
+++ b/examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml
@@ -10,9 +10,9 @@ functions:
         type: inference
         inference:
           model_format: onnx
+          api_version: "v2"
         storage_uri: "oci://ghcr.io/grycap/kserve-yolo8n-onnx"
         min_scale: 1
-        api_version: "v2"
         cpu: '1.0'
         memory: 2Gi
       log_level: CRITICAL

--- a/examples/kserve-llmisvc-qwen2-5/fdl.yaml
+++ b/examples/kserve-llmisvc-qwen2-5/fdl.yaml
@@ -2,7 +2,6 @@ functions:
   oscar:
   - oscar-kserve-y2m:
       name: qwen2-5-05b-instruct
-      image: ubuntu
       kserve:
         type: llm_inference
         llm_inference:

--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -316,6 +316,13 @@ func MakeCreateHandler(cfg *types.Config, back types.ServerlessBackend) gin.Hand
 			return
 		}
 
+		// Set the KSERVE_HOST environment variable for KServe servicescd
+		if service.IsKserve() {
+			if service.Environment.Vars == nil {
+				service.Environment.Vars = make(map[string]string)
+			}
+			service.Environment.Vars["KSERVE_HOST"] = fmt.Sprintf("%s.%s.svc.cluster.local", utils.GetKserveSvcName(service.Name, service.Kserve.Type), service.Namespace)
+		}
 		// Create service
 		if err := back.CreateService(service); err != nil {
 			// Check if error is caused because the service name provided already exists

--- a/pkg/resourcemanager/delegate.go
+++ b/pkg/resourcemanager/delegate.go
@@ -229,7 +229,7 @@ func reorganizeIfNearby(alternatives []Alternative, distances []float64, thresho
 	}
 
 	// Randomly shuffle nearby items
-	rand.Shuffle(len(nearby), func(i, j int) {
+	rand.Shuffle(len(nearby), func(i, j int) { // #nosec G404 -- non-security-sensitive tie breaking
 		nearby[i], nearby[j] = nearby[j], nearby[i]
 	})
 


### PR DESCRIPTION
This pull request introduces an improvement to the KServe integration and makes a small configuration adjustment. The main update ensures that all KServe-based services have the `KSERVE_HOST` environment variable automatically set during creation, which will help with service discovery and configuration. Additionally, there is a minor change to the ordering of the `api_version` field in a YAML example.

KServe integration improvements:

* [`pkg/handlers/create.go`](diffhunk://#diff-c98f5b49af1736d6639c469125668db9cb1c073e6468952b6af6ff0b4c32f3faR319-R325): Automatically sets the `KSERVE_HOST` environment variable for KServe services during creation, ensuring that the service has the correct internal address for communication.

Configuration and example adjustments:

* [`examples/kserve-isvc-yolo/oscar-svc-yolo8n.yaml`](diffhunk://#diff-3902016e693df76c6610bed246ddec463a2348ccdbfff28d6b9def715105450cR13-L15): Moved the `api_version: "v2"` field within the `inference` block for better clarity and consistency.