### PR TITLE
fix: Prevent workload admission check for admin owner in Kueue

### DIFF
--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -236,7 +236,7 @@ func UpdateExpose(service types.Service, namespace string, kubeClientset kuberne
 	}
 
 	utils.UpdateWorkload(service, targetNamespace, cfg, getPodTemplateSpec)
-	if cfg.KueueEnable {
+	if cfg.KueueEnable && service.Owner != types.DefaultOwner {
 		err = utils.CheckWorkloadAdmited(service, namespace, cfg, kubeClientset, getDeploymentSpec)
 		if err != nil {
 			return fmt.Errorf("Invalid workload after update: Error checking workload admission: change the cpu/memory requests")
@@ -457,7 +457,7 @@ func createDeployment(service types.Service, namespace string, kubeClientset kub
 	if err != nil {
 		return err
 	}
-	if cfg.KueueEnable {
+	if cfg.KueueEnable && service.Owner != types.DefaultOwner {
 		err = utils.CheckWorkloadAdmited(service, namespace, cfg, kubeClientset, getDeploymentSpec)
 		if err != nil {
 			if err := utils.DeleteKueueLocalQueue(context.TODO(), cfg, service.Namespace, service.Name); err != nil {

--- a/pkg/resourcemanager/delegate.go
+++ b/pkg/resourcemanager/delegate.go
@@ -230,8 +230,8 @@ func reorganizeIfNearby(alternatives []Alternative, distances []float64, thresho
 
 	// Randomly shuffle nearby items
 	rand.Shuffle(len(nearby), func(i, j int) { // #nosec G404 -- non-security-sensitive tie breaking
-		nearby[i], nearby[j] = nearby[j], nearby[i]
-	})
+		nearby[i], nearby[j] = nearby[j], nearby[i] // #nosec G404 -- non-security-sensitive tie breaking
+	}) // #nosec G404 -- non-security-sensitive tie breaking
 
 	// Create a new reorganized alternative list
 	newAlternatives := []Alternative{}


### PR DESCRIPTION
Now, Kueue admission checks are only run when Kueue is enabled and the service owner is not the admin. 