### PR TITLE
Feat sensitive service information hiding

### DIFF
--- a/pkg/handlers/list.go
+++ b/pkg/handlers/list.go
@@ -64,6 +64,7 @@ func MakeListHandler(back types.ServerlessBackend, kubeClientset kubernetes.Inte
 				switch service.Visibility {
 				case types.PUBLIC:
 					isAllowedServiceForUser = true
+					service.HideSensitiveInfoIfNotOwner(uid)
 				case types.PRIVATE:
 					if service.Owner == uid {
 						isAllowedServiceForUser = true
@@ -71,6 +72,7 @@ func MakeListHandler(back types.ServerlessBackend, kubeClientset kubernetes.Inte
 				case types.RESTRICTED:
 					if service.Owner == uid || slices.Contains(service.AllowedUsers, uid) {
 						isAllowedServiceForUser = true
+						service.HideSensitiveInfoIfNotOwner(uid)
 					}
 				}
 				// If the service is allowed for the user,

--- a/pkg/handlers/read.go
+++ b/pkg/handlers/read.go
@@ -88,6 +88,7 @@ func MakeReadHandler(back types.ServerlessBackend, kubeClientset kubernetes.Inte
 
 			switch service.Visibility {
 			case types.PUBLIC:
+				service.HideSensitiveInfoIfNotOwner(uid)
 				c.JSON(http.StatusOK, service)
 				return
 			case types.PRIVATE:
@@ -97,6 +98,7 @@ func MakeReadHandler(back types.ServerlessBackend, kubeClientset kubernetes.Inte
 				}
 			case types.RESTRICTED:
 				if service.Owner == uid || slices.Contains(service.AllowedUsers, uid) {
+					service.HideSensitiveInfoIfNotOwner(uid)
 					c.JSON(http.StatusOK, service)
 					return
 				}

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -380,6 +380,22 @@ func (s *Service) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// HideSensitiveInfoIfNotOwner hides sensitive information in the service if the user is not the owner.
+func (s *Service) HideSensitiveInfoIfNotOwner(uid string) {
+	if s.Owner == uid {
+		return
+	}
+	s.Token = "hidden"
+	s.Environment.Secrets = nil
+	s.Environment.Vars = nil
+	s.AllowedUsers = nil
+	if s.Labels != nil {
+		s.Labels = map[string]string{
+			"owner_name": s.Labels["owner_name"],
+		}
+	}
+}
+
 // Validate checks that the service definition is valid and returns an error if not.
 func (s Service) Validate() error {
 

--- a/pkg/types/service_test.go
+++ b/pkg/types/service_test.go
@@ -690,3 +690,104 @@ func TestServiceUsesManagedVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceHideSensitiveInfoIfNotOwner(t *testing.T) {
+	tests := []struct {
+		name                 string
+		owner                string
+		uid                  string
+		expectedToken        string
+		expectedVars         map[string]string
+		expectedSecrets      map[string]string
+		expectedAllowedUsers []string
+		expectedLabels       map[string]string
+	}{
+		{
+			name:          "same owner preserves all fields",
+			owner:         "user1",
+			uid:           "user1",
+			expectedToken: "testtoken",
+			expectedVars: map[string]string{
+				"TEST_VAR": "testvalue",
+			},
+			expectedSecrets: map[string]string{
+				"TEST_SECRET": "testsecret",
+			},
+			expectedAllowedUsers: []string{"userA", "userB"},
+			expectedLabels: map[string]string{
+				"testlabel":  "testlabelvalue",
+				"owner_name": "owner1",
+			},
+		},
+		{
+			name:                 "not owner hides sensitive fields and preserves owner_name label",
+			owner:                "user1",
+			uid:                  "user2",
+			expectedToken:        "hidden",
+			expectedVars:         nil,
+			expectedSecrets:      nil,
+			expectedAllowedUsers: nil,
+			expectedLabels: map[string]string{
+				"owner_name": "owner1",
+			},
+		},
+		{
+			name:                 "not owner with nil labels does not panic",
+			owner:                "user1",
+			uid:                  "user2",
+			expectedToken:        "hidden",
+			expectedVars:         nil,
+			expectedSecrets:      nil,
+			expectedAllowedUsers: nil,
+			expectedLabels:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := Service{
+				Name:  "svc",
+				Owner: tt.owner,
+				Token: "testtoken",
+				Environment: struct {
+					Vars    map[string]string `json:"variables"`
+					Secrets map[string]string `json:"secrets"`
+				}{
+					Vars:    map[string]string{"TEST_VAR": "testvalue"},
+					Secrets: map[string]string{"TEST_SECRET": "testsecret"},
+				},
+				AllowedUsers: []string{"userA", "userB"},
+				Labels: map[string]string{
+					"testlabel":  "testlabelvalue",
+					"owner_name": "owner1",
+				},
+			}
+			if tt.name == "not owner with nil labels does not panic" {
+				svc.Labels = nil
+			}
+
+			svc.HideSensitiveInfoIfNotOwner(tt.uid)
+
+			if svc.Token != tt.expectedToken {
+				t.Fatalf("expected token %q, got %q", tt.expectedToken, svc.Token)
+			}
+			if len(svc.Environment.Vars) != len(tt.expectedVars) {
+				t.Fatalf("expected vars %v, got %v", tt.expectedVars, svc.Environment.Vars)
+			}
+			if len(svc.Environment.Secrets) != len(tt.expectedSecrets) {
+				t.Fatalf("expected secrets %v, got %v", tt.expectedSecrets, svc.Environment.Secrets)
+			}
+			if len(svc.AllowedUsers) != len(tt.expectedAllowedUsers) {
+				t.Fatalf("expected allowed users %v, got %v", tt.expectedAllowedUsers, svc.AllowedUsers)
+			}
+			if len(svc.Labels) != len(tt.expectedLabels) {
+				t.Fatalf("expected labels %v, got %v", tt.expectedLabels, svc.Labels)
+			}
+			for key, want := range tt.expectedLabels {
+				if svc.Labels[key] != want {
+					t.Fatalf("expected label %q to be %q, got %q", key, want, svc.Labels[key])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Sensitive information hiding

* Added the `HideSensitiveInfoIfNotOwner` method to the `Service` struct in `pkg/types/service.go`, which hides fields like `Token`, `Environment.Vars`, `Environment.Secrets`, `AllowedUsers`, and `Labels` if the user is not the service owner.

### Testing

* Added `TestServiceHideSensitiveInfoIfNotOwner` in `pkg/types/service_test.go` to verify that sensitive fields are hidden for non-owners and preserved for owners.