### PR TITLE
Update dns exposed services implementation

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -50,6 +50,7 @@ OIDC_ISSUERS_DEFAULT="https://keycloak.grycap.net/realms/grycap"
 OIDC_GROUPS_DEFAULT="/oscar-staff, /oscar-test"
 GATEWAY_CONTROLLER="traefik"
 GATEWAY_CONTROLLER_SET="false"
+USE_DNS_WILDCARDS="true"
 
 usage(){
     cat <<EOF
@@ -62,6 +63,7 @@ Options:
   --kueue        Enable Kueue support for CPU and memory quotas (default: disabled).
   --kserve       Install KServe using deploy/kind-oscar-kserve.sh (default: disabled).
   --minio-quotas Deploy MinIO with 1 replica and 4 PVCs to support bucket quotas.
+  --wildcards    Enable DNS wildcard support for Traefik (default for Traefik).
   --ingress      Use NGINX Ingress as gateway controller.
   --traefik      Use Traefik as gateway controller (default).
   -h, --help     Show this help message and exit.
@@ -402,6 +404,7 @@ spec:
     commonName: localhost
     dnsNames:
         - localhost
+        - "*.localhost"
     ipAddresses:
         - 127.0.0.1
     issuerRef:
@@ -738,6 +741,10 @@ while [ "$#" -gt 0 ]; do
             ENABLE_MINIO_QUOTAS="true"
             shift
             ;;
+        --wildcards)
+            USE_DNS_WILDCARDS="true"
+            shift
+            ;;
         --ingress)
             GATEWAY_CONTROLLER="ingress"
             GATEWAY_CONTROLLER_SET="true"
@@ -794,6 +801,16 @@ else
             fi
             GATEWAY_CONTROLLER="$gateway_controller_choice"
         fi
+        if [ "$GATEWAY_CONTROLLER" == "traefik" ]; then
+            echo -e "\n[*] Traefik also supports DNS wildcard subdomains"
+            read -p "Do you want to enable wildcard DNS? [y/n] (default: y) " use_dns_wildcards </dev/tty
+            use_dns_wildcards=$(echo "$use_dns_wildcards" | tr '[:upper:]' '[:lower:]')
+            if [ "$use_dns_wildcards" == "n" ]; then
+                USE_DNS_WILDCARDS="false"
+            else
+                USE_DNS_WILDCARDS="true"
+            fi
+        fi
     fi
     if [ "$ENABLE_OIDC" != "true" ]; then
         echo -e "\n[*] OIDC defaults to be applied if enabled:"
@@ -844,6 +861,7 @@ else
     OSCAR_EXPOSURE_HELM_ARGS="--set httproute.create=false --set ingress.create=true "
     KIND_HTTP_CONTAINER_PORT=80
     KIND_HTTPS_CONTAINER_PORT=443
+    USE_DNS_WILDCARDS="false"
 fi
 
 HTTP_PORT_FALLBACKS=(8080 8081 8082 8880 9080 10080)
@@ -1104,6 +1122,7 @@ if [ "$ENABLE_METRICS" == "true" ]; then
         LOKI_EXPOSED_NAMESPACE="traefik" \
         LOKI_EXPOSED_APP_LABEL="traefik" \
         EXPOSED_SERVICES_ROUTE_KIND="httproute" \
+        INGRESS_HOST="localhost" \
         HTTPROUTE_GATEWAY_NAME="traefik-gateway" \
         HTTPROUTE_GATEWAY_NAMESPACE="traefik"; then
         echo -e "$RED[!]$END_COLOR Failed to configure OSCAR metrics endpoints"
@@ -1133,6 +1152,14 @@ if [ $(echo $ENABLE_KSERVE | tr '[:upper:]' '[:lower:]') == "true" ]; then
     fi
     if ! bash "$SCRIPT_DIR/scripts/kind-oscar-kserve.sh"; then
         echo -e "$RED[!]$END_COLOR KServe installation failed"
+        exit 1
+    fi
+fi
+
+if $USE_DNS_WILDCARDS ; then
+    echo -e "\n[*] Patching CoreDNS to resolve 'localhost' to the host machine ..."
+    if ! bash "$SCRIPT_DIR/scripts/kind-oscar-wildcard-dns.sh"; then
+        echo -e "$RED[!]$END_COLOR CoreDNS patching failed"
         exit 1
     fi
 fi

--- a/deploy/scripts/kind-oscar-wildcard-dns.sh
+++ b/deploy/scripts/kind-oscar-wildcard-dns.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Patches the CoreDNS Corefile in the current kubectl context to resolve any
+# "*.<INGRESS_HOST>" name to 127.0.0.1. This allows exposed OSCAR services
+# using host-based routing (e.g. "myservice.<INGRESS_HOST>") to be reached
+# without relying on the client's own DNS/hosts configuration.
+#
+# The domain can be customized via the INGRESS_HOST env var or as the first
+# script argument (defaults to "localhost").
+set -euo pipefail
+
+NAMESPACE="kube-system"
+CONFIGMAP="coredns"
+DEPLOYMENT="coredns"
+INGRESS_HOST="${1:-${INGRESS_HOST:-localhost}}"
+
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl not found in PATH" >&2
+    exit 1
+fi
+
+# Escape literal dots in the host so it can be embedded in the match regex.
+ESCAPED_INGRESS_HOST=$(printf '%s' "$INGRESS_HOST" | sed 's/\./\\./g')
+
+echo "[*] Fetching current CoreDNS Corefile from configmap/$CONFIGMAP -n $NAMESPACE ..."
+CURRENT_COREFILE=$(kubectl get configmap "$CONFIGMAP" -n "$NAMESPACE" -o jsonpath='{.data.Corefile}')
+
+if [ -z "$CURRENT_COREFILE" ]; then
+    echo "Error: could not read Corefile from configmap/$CONFIGMAP -n $NAMESPACE" >&2
+    exit 1
+fi
+
+if echo "$CURRENT_COREFILE" | grep -q "template IN A ${INGRESS_HOST} "; then
+    echo "[*] Wildcard *.${INGRESS_HOST} template already present in CoreDNS Corefile. Nothing to do."
+else
+    echo "[*] Patching Corefile to resolve *.${INGRESS_HOST} to 127.0.0.1 ..."
+    PATCH_FILEPATH=$(mktemp -t oscar-coredns-patch.XXXXXX)
+
+    PATCH_BLOCK=$(cat <<EOF
+    hosts {
+        127.0.0.1 ${INGRESS_HOST}
+        fallthrough
+    }
+    template IN A ${INGRESS_HOST} {
+        match ^([^.]+)\.${ESCAPED_INGRESS_HOST}\.\$
+        answer "{{ .Name }} 60 IN A 127.0.0.1"
+        fallthrough
+    }
+EOF
+    )
+
+    # Insert the hosts + template block right before the closing brace of the
+    # server block (the last "}" line of the Corefile). This is done with
+    # plain sed/printf (instead of awk -v) because awk's -v assignment runs
+    # its own escape-sequence processing on the value and would silently
+    # strip the backslashes needed by the match regex above.
+    LAST_LINE=$(printf '%s\n' "$CURRENT_COREFILE" | tail -n 1)
+    if [[ ! "$LAST_LINE" =~ ^\}[[:space:]]*$ ]]; then
+        echo "Error: unexpected Corefile format (last line is not a closing brace)" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$CURRENT_COREFILE" | sed '$d' > "$PATCH_FILEPATH"
+    printf '%s\n' "$PATCH_BLOCK" >> "$PATCH_FILEPATH"
+    printf '%s\n' "$LAST_LINE" >> "$PATCH_FILEPATH"
+
+    kubectl create configmap "$CONFIGMAP" -n "$NAMESPACE" \
+        --from-file=Corefile="$PATCH_FILEPATH" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    rm -f "$PATCH_FILEPATH"
+
+    echo "[*] Restarting CoreDNS to apply the new configuration ..."
+    kubectl -n "$NAMESPACE" rollout restart deployment/"$DEPLOYMENT"
+    kubectl -n "$NAMESPACE" rollout status deployment/"$DEPLOYMENT" --timeout=120s
+
+    echo "[OK] CoreDNS patched: *.${INGRESS_HOST} now resolves to 127.0.0.1"
+fi
+
+kubectl set env deployment/oscar -n oscar INGRESS_HOST="$INGRESS_HOST"

--- a/deploy/scripts/kind-oscar-wildcard-dns.sh
+++ b/deploy/scripts/kind-oscar-wildcard-dns.sh
@@ -77,3 +77,4 @@ EOF
 fi
 
 kubectl set env deployment/oscar -n oscar INGRESS_HOST="$INGRESS_HOST"
+kubectl set env deployment/oscar -n oscar EXPOSED_SERVICES_USE_SUBDOMAIN_ROUTE="true"

--- a/docs/exposed-services.md
+++ b/docs/exposed-services.md
@@ -34,13 +34,13 @@ expose:
   api_port: 5000
 ```
 
-Once the service is deployed, you can check if it was created correctly by making an HTTP request to the exposed endpoint. With the default Ingress mode, the endpoint is:
+Once the service is deployed, you can check if it was created correctly by making an HTTP request to the exposed endpoint. By default, the endpoint is:
 
 ``` bash
 https://{oscar_endpoint}/system/services/{service_name}/exposed/{path_resource} 
 ```
 
-When `EXPOSED_SERVICES_ROUTE_KIND=httproute`, each service is exposed at the root of its own subdomain:
+When `EXPOSED_SERVICES_ROUTE_KIND=httproute` and `EXPOSED_SERVICES_USE_SUBDOMAIN_ROUTE=true`, each service is exposed at the root of its own subdomain:
 
 ``` bash
 https://{service_name}.{INGRESS_HOST}/{path_resource}
@@ -48,9 +48,9 @@ https://{service_name}.{INGRESS_HOST}/{path_resource}
 
 This requires `INGRESS_HOST` to be configured and wildcard DNS and TLS for `*.{INGRESS_HOST}` to point to and be accepted by the cluster Gateway.
 
-For exposed services, OSCAR sets `OSCAR_SERVICE_BASE_PATH` in the container environment. Its value is `/system/services/{service_name}/exposed` in Ingress mode and `/` when services are exposed through DNS in HTTPRoute mode. The full list of OSCAR-managed environment variables is documented in [FDL](fdl.md#envvarsmap).
+For exposed services, OSCAR sets `OSCAR_SERVICE_BASE_PATH` in the container environment. Its value is `/system/services/{service_name}/exposed` in default mode and `/` when services are exposed through DNS in HTTPRoute mode. The full list of OSCAR-managed environment variables is documented in [FDL](fdl.md#envvarsmap).
 
-Notice that if you get a `502 Bad Gateway` error, it is most likely because the specified port on the service does not match the API port.
+Notice that the use of DNS subdomains is only available with HTTPRoute; Ingress is not supported. Also, if you get a `502 Bad Gateway` error, it is most likely because the specified port on the service does not match the API port.
 
 Additional options can be defined in the "expose" section of the FDL (some previously mentioned), such as:
 

--- a/docs/fdl.md
+++ b/docs/fdl.md
@@ -269,7 +269,7 @@ OSCAR also injects a small set of reserved environment variables in every servic
 |----------|-------------|
 | `OSCAR_SERVICE_NAME` | Service name. |
 | `OSCAR_SERVICE_TOKEN` | Generated OSCAR service token. |
-| `OSCAR_SERVICE_BASE_PATH` | Base exposed path: `/system/services/{service_name}/exposed` in Ingress mode or `/` when using DNS in HTTPRoute mode. It is an empty string for non-exposed services. |
+| `OSCAR_SERVICE_BASE_PATH` | Base exposed path: `/system/services/{service_name}/exposed` in default mode or `/` when using DNS in HTTPRoute mode (Ingress don't support DNS subdomains). It is an empty string for non-exposed services. |
 
 These variables are managed by OSCAR and are available in addition to the user-defined entries declared in `environment.variables`.
 

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -271,8 +271,7 @@ func createRoute(service types.Service, namespace string, kubeClientset kubernet
 
 func upsertRoute(service types.Service, namespace string, kubeClientset kubernetes.Interface, cfg *types.Config) error {
 	ingressExists := existsIngress(service.Name, namespace, kubeClientset)
-	httpRouteExists := existsHTTPRoute(service.Name, namespace) ||
-		existsHTTPRouteByName(getDNSHTTPRouteName(service.Name), namespace)
+	httpRouteExists := existsHTTPRoute(service.Name, namespace)
 
 	if getRouteKind(cfg) == routeKindHTTPRoute {
 		if ingressExists {
@@ -294,11 +293,6 @@ func upsertRoute(service types.Service, namespace string, kubeClientset kubernet
 
 	if httpRouteExists {
 		if err := deleteHTTPRoute(getHTTPRouteName(service.Name), namespace); err != nil {
-			return err
-		}
-	}
-	if existsHTTPRouteByName(getDNSHTTPRouteName(service.Name), namespace) {
-		if err := deleteHTTPRoute(getDNSHTTPRouteName(service.Name), namespace); err != nil {
 			return err
 		}
 	}
@@ -344,11 +338,6 @@ func deleteRouteResources(serviceName string, namespace string, kubeClientset ku
 
 	if existsHTTPRoute(serviceName, namespace) {
 		if err := deleteHTTPRoute(getHTTPRouteName(serviceName), namespace); err != nil {
-			return err
-		}
-	}
-	if existsHTTPRouteByName(getDNSHTTPRouteName(serviceName), namespace) {
-		if err := deleteHTTPRoute(getDNSHTTPRouteName(serviceName), namespace); err != nil {
 			return err
 		}
 	}
@@ -398,8 +387,8 @@ func validateHTTPRouteConfig(service types.Service, cfg *types.Config) error {
 	if strings.TrimSpace(cfg.HTTPRouteGatewayName) == "" {
 		return fmt.Errorf("HTTPROUTE_GATEWAY_NAME must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute")
 	}
-	if strings.TrimSpace(cfg.IngressHost) == "" {
-		return fmt.Errorf("INGRESS_HOST must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute")
+	if strings.TrimSpace(cfg.IngressHost) == "" && cfg.ExposedServicesUseDNSRoute {
+		return fmt.Errorf("INGRESS_HOST must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute and EXPOSED_SERVICES_USE_DNS_ROUTE=true")
 	}
 
 	return validateExposeAuthConfig(service, cfg)
@@ -913,14 +902,6 @@ func reconcileHTTPRoute(service types.Service, namespace string, kubeClientset k
 		return err
 	}
 
-	// Remove the additional DNS route created by older versions. The canonical
-	// HTTPRoute above now serves the DNS hostname directly.
-	err = gatewayClientset.Resource(httpRouteGVR).Namespace(namespace).Delete(
-		context.TODO(), getDNSHTTPRouteName(service.Name), metav1.DeleteOptions{},
-	)
-	if err = ignoreNotFound(err); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -964,12 +945,18 @@ func upsertHTTPRoute(gatewayClientset dynamic.Interface, httpRoute *unstructured
 
 func getHTTPRouteSpec(service types.Service, namespace string, cfg *types.Config) *unstructured.Unstructured {
 	host := strings.TrimPrefix(strings.TrimSpace(cfg.IngressHost), "*.")
+	apiPath := "/"
+	useDNSRoute := service.UsesDNSRoute(cfg)
+
+	if !useDNSRoute {
+		apiPath = getAPIPath(service.Name)
+	}
 	rule := map[string]any{
 		"matches": []any{
 			map[string]any{
 				"path": map[string]any{
 					"type":  "PathPrefix",
-					"value": "/",
+					"value": apiPath,
 				},
 			},
 		},
@@ -991,6 +978,20 @@ func getHTTPRouteSpec(service types.Service, namespace string, cfg *types.Config
 			},
 		},
 	}
+
+	if !useDNSRoute && !service.Expose.RewriteTarget {
+		filters = append(filters, map[string]any{
+			"type": "URLRewrite",
+			"urlRewrite": map[string]any{
+				"path": map[string]any{
+					"type":               "ReplacePrefixMatch",
+					"replacePrefixMatch": "/",
+				},
+			},
+		},
+		)
+	}
+
 	rule["filters"] = filters
 
 	if service.Expose.SetAuth {
@@ -1009,7 +1010,11 @@ func getHTTPRouteSpec(service types.Service, namespace string, cfg *types.Config
 		"rules": []any{rule},
 	}
 
-	spec["hostnames"] = []any{service.Name + "." + host}
+	if useDNSRoute {
+		spec["hostnames"] = []any{service.Name + "." + host}
+	} else if host != "" {
+		spec["hostnames"] = []any{host}
+	}
 
 	parentRef := map[string]any{
 		"group": "gateway.networking.k8s.io",
@@ -1479,11 +1484,6 @@ func getIngressName(name_container string) string {
 
 func getHTTPRouteName(name_container string) string {
 	return name_container + "-route"
-}
-
-func getDNSHTTPRouteName(name_container string) string {
-	// Kept only to remove the additional route created by early DNS-route versions.
-	return name_container + "-dns-route"
 }
 
 func getTraefikCORSMiddlewareName(name_container string) string {

--- a/pkg/backends/resources/expose.go
+++ b/pkg/backends/resources/expose.go
@@ -387,8 +387,8 @@ func validateHTTPRouteConfig(service types.Service, cfg *types.Config) error {
 	if strings.TrimSpace(cfg.HTTPRouteGatewayName) == "" {
 		return fmt.Errorf("HTTPROUTE_GATEWAY_NAME must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute")
 	}
-	if strings.TrimSpace(cfg.IngressHost) == "" && cfg.ExposedServicesUseDNSRoute {
-		return fmt.Errorf("INGRESS_HOST must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute and EXPOSED_SERVICES_USE_DNS_ROUTE=true")
+	if strings.TrimSpace(cfg.IngressHost) == "" && cfg.ExposedServicesUseSubdomainRoute {
+		return fmt.Errorf("INGRESS_HOST must be defined when EXPOSED_SERVICES_ROUTE_KIND=httproute and EXPOSED_SERVICES_USE_SUBDOMAIN_ROUTE=true")
 	}
 
 	return validateExposeAuthConfig(service, cfg)

--- a/pkg/backends/resources/expose_test.go
+++ b/pkg/backends/resources/expose_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/grycap/oscar/v4/pkg/types"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -258,9 +257,6 @@ func TestCreateExposeHTTPRouteWithAuth(t *testing.T) {
 	if !existsHTTPRoute(svc.Name, svc.Namespace) {
 		t.Fatalf("expected httproute to exist")
 	}
-	if existsHTTPRouteByName(getDNSHTTPRouteName(svc.Name), svc.Namespace) {
-		t.Fatalf("expected no additional legacy DNS httproute")
-	}
 
 	if existsIngress(svc.Name, svc.Namespace, client) {
 		t.Fatalf("expected no ingress to be created when route kind is httproute")
@@ -301,9 +297,6 @@ func TestCreateExposeHTTPRouteWithoutAuth(t *testing.T) {
 
 	if !existsHTTPRoute(svc.Name, svc.Namespace) {
 		t.Fatalf("expected httproute to exist")
-	}
-	if existsHTTPRouteByName(getDNSHTTPRouteName(svc.Name), svc.Namespace) {
-		t.Fatalf("expected no additional legacy DNS httproute")
 	}
 
 	if !existsTraefikCORSMiddleware(svc.Name, svc.Namespace) {
@@ -965,36 +958,6 @@ func TestUpdateHTTPRouteSetsResourceVersion(t *testing.T) {
 
 	if err := updateHTTPRoute(svc, namespace, fake.NewSimpleClientset(), cfg); err != nil {
 		t.Fatalf("updateHTTPRoute returned error: %v", err)
-	}
-}
-
-func TestUpdateHTTPRouteMigratesAdditionalDNSRoute(t *testing.T) {
-	cfg := newTestConfig()
-	cfg.ExposedServicesRouteKind = routeKindHTTPRoute
-	cfg.HTTPRouteGatewayName = "public-gateway"
-	cfg.IngressHost = "example.org"
-
-	svc := newExposeService("httproute-migration", 0, false)
-	namespace := cfg.ServicesNamespace
-
-	oldDNSRoute := getHTTPRouteSpec(svc, namespace, cfg)
-	oldDNSRoute.SetName(getDNSHTTPRouteName(svc.Name))
-	gatewayClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), oldDNSRoute)
-	useGatewayClient(t, gatewayClient)
-
-	if err := updateHTTPRoute(svc, namespace, fake.NewSimpleClientset(), cfg); err != nil {
-		t.Fatalf("updateHTTPRoute returned error: %v", err)
-	}
-
-	if _, err := gatewayClient.Resource(httpRouteGVR).Namespace(namespace).Get(
-		context.TODO(), getHTTPRouteName(svc.Name), metav1.GetOptions{},
-	); err != nil {
-		t.Fatalf("expected canonical DNS httproute to be created: %v", err)
-	}
-	if _, err := gatewayClient.Resource(httpRouteGVR).Namespace(namespace).Get(
-		context.TODO(), getDNSHTTPRouteName(svc.Name), metav1.GetOptions{},
-	); !apierrors.IsNotFound(err) {
-		t.Fatalf("expected additional DNS httproute to be removed, got: %v", err)
 	}
 }
 

--- a/pkg/backends/resources/expose_test.go
+++ b/pkg/backends/resources/expose_test.go
@@ -546,7 +546,8 @@ func TestGetProbePath(t *testing.T) {
 				},
 			},
 			cfg: &types.Config{
-				ExposedServicesRouteKind: types.HTTPROUTE,
+				ExposedServicesRouteKind:         types.HTTPROUTE,
+				ExposedServicesUseSubdomainRoute: true,
 			},
 			want: "/",
 		},
@@ -561,7 +562,8 @@ func TestGetProbePath(t *testing.T) {
 				},
 			},
 			cfg: &types.Config{
-				ExposedServicesRouteKind: types.HTTPROUTE,
+				ExposedServicesRouteKind:         types.HTTPROUTE,
+				ExposedServicesUseSubdomainRoute: false,
 			},
 			want: "/system/services/svc/exposed/",
 		},
@@ -591,9 +593,10 @@ func TestRouteKindSelection(t *testing.T) {
 	}
 }
 
-func TestGetHTTPRouteSpec(t *testing.T) {
+func TestGetHTTPRouteSpecUseSubdomainRoutes(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.ExposedServicesRouteKind = types.HTTPROUTE
+	cfg.ExposedServicesUseSubdomainRoute = true
 	cfg.IngressHost = "example.org"
 	cfg.HTTPRouteGatewayName = "public-gateway"
 	cfg.HTTPRouteGatewayNamespace = "gateway-system"
@@ -698,9 +701,85 @@ func TestGetHTTPRouteSpec(t *testing.T) {
 	}
 }
 
+func TestGetHTTPRouteSpecUseSubpathRoutes(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.ExposedServicesRouteKind = types.HTTPROUTE
+	cfg.ExposedServicesUseSubdomainRoute = false
+	cfg.IngressHost = "example.org"
+	cfg.HTTPRouteGatewayName = "public-gateway"
+	cfg.HTTPRouteGatewayNamespace = "gateway-system"
+
+	svc := newExposeService("http-route-service", 0, false)
+	httpRoute := getHTTPRouteSpec(svc, cfg.ServicesNamespace, cfg)
+
+	if httpRoute.GetName() != getHTTPRouteName(svc.Name) {
+		t.Fatalf("expected httproute name %s, got %s", getHTTPRouteName(svc.Name), httpRoute.GetName())
+	}
+
+	hostnames, found, err := unstructured.NestedSlice(httpRoute.Object, "spec", "hostnames")
+	if err != nil || !found || len(hostnames) != 1 || hostnames[0] != cfg.IngressHost {
+		t.Fatalf("expected hostnames [%s], got %v", cfg.IngressHost, hostnames)
+	}
+
+	rules, found, err := unstructured.NestedSlice(httpRoute.Object, "spec", "rules")
+	if err != nil || !found {
+		t.Fatalf("expected rules in httproute spec")
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected one rule, got %d", len(rules))
+	}
+
+	rule, ok := rules[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected rule to be a map")
+	}
+
+	matches, ok := rule["matches"].([]any)
+	if !ok || len(matches) != 1 {
+		t.Fatalf("expected one path match")
+	}
+	match := matches[0].(map[string]any)
+	path := match["path"].(map[string]any)
+	if path["value"] != getAPIPath(svc.Name) {
+		t.Fatalf("expected path %s, got %v", getAPIPath(svc.Name), path["value"])
+	}
+
+	backendRefs, ok := rule["backendRefs"].([]any)
+	if !ok || len(backendRefs) != 1 {
+		t.Fatalf("expected one backendRef")
+	}
+	backendRef, ok := backendRefs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected backendRef to be a map")
+	}
+	if backendRef["name"] != getServiceName(svc.Name) {
+		t.Fatalf("expected backend service %s, got %v", getServiceName(svc.Name), backendRef["name"])
+	}
+
+	filters, ok := rule["filters"].([]any)
+	if !ok || len(filters) != 2 {
+		t.Fatalf("expected CORS and URLRewrite filters, got %v", rule["filters"])
+	}
+
+	corsFilter, ok := filters[0].(map[string]any)
+	if !ok || corsFilter["type"] != "ExtensionRef" {
+		t.Fatalf("expected first filter type ExtensionRef, got %v", corsFilter["type"])
+	}
+	corsExtensionRef, ok := corsFilter["extensionRef"].(map[string]any)
+	if !ok || corsExtensionRef["group"] != "traefik.io" || corsExtensionRef["kind"] != "Middleware" || corsExtensionRef["name"] != getTraefikCORSMiddlewareName(svc.Name) {
+		t.Fatalf("expected traefik CORS middleware reference, got %v", corsExtensionRef)
+	}
+
+	rewriteFilter, ok := filters[1].(map[string]any)
+	if !ok || rewriteFilter["type"] != "URLRewrite" {
+		t.Fatalf("expected second filter type URLRewrite, got %v", rewriteFilter["type"])
+	}
+}
+
 func TestGetHTTPRouteSpecNormalizesWildcardHost(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.ExposedServicesRouteKind = types.HTTPROUTE
+	cfg.ExposedServicesUseSubdomainRoute = true
 	cfg.IngressHost = "*.example.org"
 	cfg.HTTPRouteGatewayName = "public-gateway"
 
@@ -745,6 +824,7 @@ func TestValidateHTTPRouteConfig(t *testing.T) {
 	svc := newExposeService("validation", 0, false)
 	cfg := newTestConfig()
 	cfg.ExposedServicesRouteKind = types.HTTPROUTE
+	cfg.ExposedServicesUseSubdomainRoute = true
 
 	if err := validateHTTPRouteConfig(svc, cfg); err == nil {
 		t.Fatalf("expected error when HTTPROUTE_GATEWAY_NAME is empty")
@@ -752,7 +832,7 @@ func TestValidateHTTPRouteConfig(t *testing.T) {
 
 	cfg.HTTPRouteGatewayName = "public-gateway"
 	if err := validateHTTPRouteConfig(svc, cfg); err == nil {
-		t.Fatalf("expected error when INGRESS_HOST is empty")
+		t.Fatalf("expected error when INGRESS_HOST is empty and subdomain route is enabled")
 	}
 	cfg.IngressHost = "example.org"
 	svc.Expose.SetAuth = true
@@ -780,6 +860,7 @@ func TestValidateHTTPRouteConfig(t *testing.T) {
 func TestGetHTTPRouteSpecWithAuth(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.ExposedServicesRouteKind = types.HTTPROUTE
+	cfg.ExposedServicesUseSubdomainRoute = true
 	cfg.HTTPRouteGatewayName = "public-gateway"
 	cfg.IngressHost = "example.org"
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -235,6 +235,8 @@ type Config struct {
 	//
 	IngressHost string `json:"-"`
 
+	ExposedServicesUseDNSRoute bool `json:"-"`
+
 	// ExposedServicesRouteKind determines which Kubernetes resource is used to expose services (ingress|httproute)
 	ExposedServicesRouteKind string `json:"-"`
 
@@ -362,6 +364,7 @@ var configVars = []configVar{
 	{"OIDCClientSecret", "OIDC_CLIENT_SECRET", false, stringType, ""},
 	{"UsersAdmin", "USERS_ADMIN", false, stringSliceType, ""},
 	{"IngressHost", "INGRESS_HOST", false, stringType, ""},
+	{"ExposedServicesUseDNSRoute", "EXPOSED_SERVICES_USE_DNS_ROUTE", false, boolType, "false"},
 	{"ExposedServicesRouteKind", "EXPOSED_SERVICES_ROUTE_KIND", false, routeKindType, "ingress"},
 	{"HTTPRouteGatewayName", "HTTPROUTE_GATEWAY_NAME", false, stringType, "traefik-gateway"},
 	{"HTTPRouteGatewayNamespace", "HTTPROUTE_GATEWAY_NAMESPACE", false, stringType, "traefik"},

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -235,7 +235,7 @@ type Config struct {
 	//
 	IngressHost string `json:"-"`
 
-	ExposedServicesUseDNSRoute bool `json:"-"`
+	ExposedServicesUseSubdomainRoute bool `json:"-"`
 
 	// ExposedServicesRouteKind determines which Kubernetes resource is used to expose services (ingress|httproute)
 	ExposedServicesRouteKind string `json:"-"`
@@ -364,7 +364,7 @@ var configVars = []configVar{
 	{"OIDCClientSecret", "OIDC_CLIENT_SECRET", false, stringType, ""},
 	{"UsersAdmin", "USERS_ADMIN", false, stringSliceType, ""},
 	{"IngressHost", "INGRESS_HOST", false, stringType, ""},
-	{"ExposedServicesUseDNSRoute", "EXPOSED_SERVICES_USE_DNS_ROUTE", false, boolType, "false"},
+	{"ExposedServicesUseSubdomainRoute", "EXPOSED_SERVICES_USE_SUBDOMAIN_ROUTE", false, boolType, "false"},
 	{"ExposedServicesRouteKind", "EXPOSED_SERVICES_ROUTE_KIND", false, routeKindType, "ingress"},
 	{"HTTPRouteGatewayName", "HTTPROUTE_GATEWAY_NAME", false, stringType, "traefik-gateway"},
 	{"HTTPRouteGatewayNamespace", "HTTPROUTE_GATEWAY_NAMESPACE", false, stringType, "traefik"},

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -831,6 +831,7 @@ func (service *Service) UsesDNSRoute(cfg *Config) bool {
 	return service != nil &&
 		cfg != nil &&
 		strings.EqualFold(strings.TrimSpace(cfg.ExposedServicesRouteKind), HTTPROUTE) &&
+		cfg.ExposedServicesUseDNSRoute &&
 		(len(service.Expose.NodePort) == 0 || service.Expose.NodePort[0] == 0)
 }
 

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -831,7 +831,7 @@ func (service *Service) UsesDNSRoute(cfg *Config) bool {
 	return service != nil &&
 		cfg != nil &&
 		strings.EqualFold(strings.TrimSpace(cfg.ExposedServicesRouteKind), HTTPROUTE) &&
-		cfg.ExposedServicesUseDNSRoute &&
+		cfg.ExposedServicesUseSubdomainRoute &&
 		(len(service.Expose.NodePort) == 0 || service.Expose.NodePort[0] == 0)
 }
 

--- a/pkg/types/service_test.go
+++ b/pkg/types/service_test.go
@@ -481,7 +481,8 @@ func TestGetExposedBasePath(t *testing.T) {
 }
 
 func TestUsesDNSRoute(t *testing.T) {
-	httpRouteConfig := &Config{ExposedServicesRouteKind: HTTPROUTE}
+	httpRouteConfig := &Config{ExposedServicesRouteKind: HTTPROUTE, ExposedServicesUseDNSRoute: true}
+	httpRouteConfigNoDNS := &Config{ExposedServicesRouteKind: HTTPROUTE, ExposedServicesUseDNSRoute: false}
 	ingressConfig := &Config{ExposedServicesRouteKind: Ingress}
 
 	tests := []struct {
@@ -493,9 +494,10 @@ func TestUsesDNSRoute(t *testing.T) {
 		{name: "nil service", cfg: httpRouteConfig},
 		{name: "nil config", service: &Service{}},
 		{name: "ingress", service: &Service{}, cfg: ingressConfig},
-		{name: "HTTPRoute without NodePort", service: &Service{}, cfg: httpRouteConfig, want: true},
-		{name: "HTTPRoute with dynamic NodePort", service: &Service{Expose: Expose{NodePort: []int32{0}}}, cfg: httpRouteConfig, want: true},
-		{name: "HTTPRoute with static NodePort", service: &Service{Expose: Expose{NodePort: []int32{30080}}}, cfg: httpRouteConfig},
+		{name: "HTTPRoute without NodePort with DNS use enabled", service: &Service{}, cfg: httpRouteConfig, want: true},
+		{name: "HTTPRoute with DNS use disabled", service: &Service{}, cfg: httpRouteConfigNoDNS, want: false},
+		{name: "HTTPRoute with dynamic NodePort with DNS", service: &Service{Expose: Expose{NodePort: []int32{0}}}, cfg: httpRouteConfig, want: true},
+		{name: "HTTPRoute with static NodePort with DNS", service: &Service{Expose: Expose{NodePort: []int32{30080}}}, cfg: httpRouteConfig, want: false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/types/service_test.go
+++ b/pkg/types/service_test.go
@@ -584,9 +584,10 @@ func TestToPodSpecWithExposeMetadataEnvVars(t *testing.T) {
 		t.Fatalf("expected %s to be %q, got %q", OscarServiceBasePathEnvVar, "/system/services/testname/exposed", envVars[OscarServiceBasePathEnvVar])
 	}
 
-	httpRouteConfig := testConfig
-	httpRouteConfig.ExposedServicesRouteKind = HTTPROUTE
-	podSpec, err = svc.ToPodSpec(&httpRouteConfig)
+	httpRouteSubdomainConfig := testConfig
+	httpRouteSubdomainConfig.ExposedServicesRouteKind = HTTPROUTE
+	httpRouteSubdomainConfig.ExposedServicesUseSubdomainRoute = true
+	podSpec, err = svc.ToPodSpec(&httpRouteSubdomainConfig)
 	if err != nil {
 		t.Fatalf("unexpected error for HTTPRoute config: %v", err)
 	}
@@ -596,13 +597,25 @@ func TestToPodSpecWithExposeMetadataEnvVars(t *testing.T) {
 	}
 
 	svc.Expose.NodePort = []int32{30080}
-	podSpec, err = svc.ToPodSpec(&httpRouteConfig)
+	podSpec, err = svc.ToPodSpec(&httpRouteSubdomainConfig)
 	if err != nil {
 		t.Fatalf("unexpected error for NodePort config: %v", err)
 	}
 	envVars = envVarsToMap(podSpec.Containers[0].Env)
 	if envVars[OscarServiceBasePathEnvVar] != "/system/services/testname/exposed" {
 		t.Fatalf("expected NodePort %s to keep the legacy path, got %q", OscarServiceBasePathEnvVar, envVars[OscarServiceBasePathEnvVar])
+	}
+
+	httpRouteNoSubdomainConfig := testConfig
+	httpRouteNoSubdomainConfig.ExposedServicesRouteKind = HTTPROUTE
+	httpRouteNoSubdomainConfig.ExposedServicesUseSubdomainRoute = false
+	podSpec, err = svc.ToPodSpec(&httpRouteNoSubdomainConfig)
+	if err != nil {
+		t.Fatalf("unexpected error for HTTPRoute config: %v", err)
+	}
+	envVars = envVarsToMap(podSpec.Containers[0].Env)
+	if envVars[OscarServiceBasePathEnvVar] != "/system/services/testname/exposed" {
+		t.Fatalf("expected HTTPRoute %s to be %q, got %q", OscarServiceBasePathEnvVar, "/system/services/testname/exposed", envVars[OscarServiceBasePathEnvVar])
 	}
 }
 

--- a/pkg/types/service_test.go
+++ b/pkg/types/service_test.go
@@ -481,8 +481,8 @@ func TestGetExposedBasePath(t *testing.T) {
 }
 
 func TestUsesDNSRoute(t *testing.T) {
-	httpRouteConfig := &Config{ExposedServicesRouteKind: HTTPROUTE, ExposedServicesUseDNSRoute: true}
-	httpRouteConfigNoDNS := &Config{ExposedServicesRouteKind: HTTPROUTE, ExposedServicesUseDNSRoute: false}
+	httpRouteConfig := &Config{ExposedServicesRouteKind: HTTPROUTE, ExposedServicesUseSubdomainRoute: true}
+	httpRouteConfigNoDNS := &Config{ExposedServicesRouteKind: HTTPROUTE, ExposedServicesUseSubdomainRoute: false}
 	ingressConfig := &Config{ExposedServicesRouteKind: Ingress}
 
 	tests := []struct {
@@ -494,10 +494,10 @@ func TestUsesDNSRoute(t *testing.T) {
 		{name: "nil service", cfg: httpRouteConfig},
 		{name: "nil config", service: &Service{}},
 		{name: "ingress", service: &Service{}, cfg: ingressConfig},
-		{name: "HTTPRoute without NodePort with DNS use enabled", service: &Service{}, cfg: httpRouteConfig, want: true},
-		{name: "HTTPRoute with DNS use disabled", service: &Service{}, cfg: httpRouteConfigNoDNS, want: false},
-		{name: "HTTPRoute with dynamic NodePort with DNS", service: &Service{Expose: Expose{NodePort: []int32{0}}}, cfg: httpRouteConfig, want: true},
-		{name: "HTTPRoute with static NodePort with DNS", service: &Service{Expose: Expose{NodePort: []int32{30080}}}, cfg: httpRouteConfig, want: false},
+		{name: "HTTPRoute without NodePort with DNS subdomain use enabled", service: &Service{}, cfg: httpRouteConfig, want: true},
+		{name: "HTTPRoute with DNS subdomain use disabled", service: &Service{}, cfg: httpRouteConfigNoDNS, want: false},
+		{name: "HTTPRoute with dynamic NodePort with DNS subdomain", service: &Service{Expose: Expose{NodePort: []int32{0}}}, cfg: httpRouteConfig, want: true},
+		{name: "HTTPRoute with static NodePort with DNS subdomain", service: &Service{Expose: Expose{NodePort: []int32{30080}}}, cfg: httpRouteConfig, want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Removal of unused legacy DNS HTTPRoute support:**

* Removed all logic and code related to creating, deleting, and migrating the legacy additional DNS HTTPRoute (e.g., `getDNSHTTPRouteName`, `existsHTTPRouteByName`, and related test cases). This simplifies resource management and avoids unnecessary extra routes. 

**Configuration improvements for DNS-based routing:**

* Added a new configuration option `EXPOSED_SERVICES_USE_SUBDOMINE_ROUTE` to control whether DNS-based HTTPRoutes are used, and updated the `Config` struct accordingly. 
* Validation now only requires `INGRESS_HOST` if DNS-based routing is enabled, making configuration more flexible.

**HTTPRoute creation logic updates:**

* The HTTPRoute spec now uses the DNS-based hostname and path only when DNS routing is enabled, and applies a `URLRewrite` filter as appropriate. 

**Local development improvements:**

* Added a new script `deploy/scripts/kind-oscar-wildcard-dns.sh` to patch CoreDNS for wildcard DNS resolution in local Kubernetes clusters, making local development and testing easier.

**Test and code cleanup:**

* Removed unused imports and test cases related to the legacy DNS HTTPRoute logic, ensuring tests accurately reflect the current codebase. 

These changes together modernize and simplify the HTTPRoute exposure logic, provide better configuration for DNS-based routing, and improve the developer experience for local testing.
