### PR TITLE
feat: rename KServe Inference configuration to use RuntimeImage instead of Runtime

### DIFF
--- a/docs/fdl.md
+++ b/docs/fdl.md
@@ -209,8 +209,8 @@ storage_providers:
 
 | Field                        | Description                                 |
 |------------------------------| --------------------------------------------|
-| `model_format` </br> *string* | Model format expected by KServe for `inference` services. Required when `type` is `inference`. Typical values include: `onnx`, `sklearn`, `xgboost`, `pytorch`, `tensorflow`, `triton`, `huggingface`. |
-| `runtime` </br> *string* | Explicit KServe ServingRuntime name to use for `inference` services. Optional. |
+| `model_format` </br> *string* | Model format expected by KServe for `inference` services. Required when `type` is `inference`. Typical values include: `onnx`, `sklearn`, `xgboost`, `pytorch`, `tensorflow`, `triton`, `huggingface`. Every model format has its own runtime and the available runtimes may vary depending on the cluster configuration |
+| `runtime_image` </br> *string* | Explicit KServe ServingRuntime name to use for `inference` services. Use if the model format are not enough. Optional. |
 | `api_version` </br> *string* | Protocol version used by KServe predictors. Allowed values: `v1`, `v2`. Optional. (default: `v1`) |
 
 ## KServeLLMInferenceSettings

--- a/pkg/types/kserve.go
+++ b/pkg/types/kserve.go
@@ -137,7 +137,7 @@ func (k Kserve) ValidateUpdate(old Kserve) error {
 		if old.Inference == nil || k.Inference == nil {
 			return fmt.Errorf("inference configuration cannot be nil for KServe service")
 		}
-		if old.Inference.Runtime != k.Inference.Runtime {
+		if old.Inference.RuntimeImage != k.Inference.RuntimeImage {
 			return fmt.Errorf("cannot update runtime for KServe")
 		}
 		if old.Inference.ModelFormat != k.Inference.ModelFormat {
@@ -186,13 +186,15 @@ func (k Kserve) Equal(other Kserve) bool {
 }
 
 type KserveInference struct {
-	// ModelFormat the model format to use for KServe InferenceService
+	// ModelFormat the model format to use for KServe InferenceService.
+	// Every model format has its own runtime and the available runtimes may vary depending on the cluster configuration.
 	// ("onnx", "sklearn", "xgboost", "pytorch", "tensorflow", "triton", "huggingface").
 	ModelFormat string `json:"model_format,omitempty"`
-	// Runtime the KServe runtime to use
+	// RuntimeImage the KServe runtime to use. Its a custom runtime if
+	// the available runtimes in the model format are not enough
 	// Ref: https://kserve.github.io/website/docs/concepts/resources/servingruntime
 	// Optional.
-	Runtime string `json:"runtime,omitempty"`
+	RuntimeImage string `json:"runtime_image,omitempty"`
 	// Can be used to specify the protocol version for KServe (e.g., "v1", "v2").
 	// Optional. (default: "v1")
 	APIVersion string `json:"api_version,omitempty" default:"v1"`
@@ -234,7 +236,7 @@ func (k KserveInference) Validate() error {
 
 func (k KserveInference) Equal(other KserveInference) bool {
 	return k.ModelFormat == other.ModelFormat &&
-		k.Runtime == other.Runtime &&
+		k.RuntimeImage == other.RuntimeImage &&
 		k.APIVersion == other.APIVersion
 }
 

--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -372,8 +372,8 @@ func newKserveInferenceServiceSpec(service *types.Service, owner *KserveServiceO
 		"protocolVersion": service.Kserve.Inference.APIVersion,
 	}
 
-	if service.Kserve.Inference.Runtime != "" {
-		modelSpec["runtime"] = service.Kserve.Inference.Runtime
+	if service.Kserve.Inference.RuntimeImage != "" {
+		modelSpec["runtime"] = service.Kserve.Inference.RuntimeImage
 	}
 	// TO DO: consider if we want to inject root path for LLM services as well, and if so, how to handle the case when the framework is vllm that expects the prefix to be preserved for routing
 	//injectRootPath(service)
@@ -436,8 +436,8 @@ func updateKserveInferenceServiceSpec(service *types.Service, oldIsvc *unstructu
 		"storageUri":      service.Kserve.StorageUri,
 		"protocolVersion": service.Kserve.Inference.APIVersion,
 	}
-	if service.Kserve.Inference.Runtime != "" {
-		modelSpec["runtime"] = service.Kserve.Inference.Runtime
+	if service.Kserve.Inference.RuntimeImage != "" {
+		modelSpec["runtime"] = service.Kserve.Inference.RuntimeImage
 	}
 
 	modelSpec["resources"] = resources

--- a/pkg/utils/kserve_test.go
+++ b/pkg/utils/kserve_test.go
@@ -1018,8 +1018,8 @@ func TestCheckKserveUpdate(t *testing.T) {
 		{
 			name: "cannot change runtime",
 			mutate: func(oldSvc, newSvc *oscarType.Service) {
-				oldSvc.Kserve.Inference.Runtime = "kserve-runtime-a"
-				newSvc.Kserve.Inference.Runtime = "kserve-runtime-b"
+				oldSvc.Kserve.Inference.RuntimeImage = "kserve-runtime-a"
+				newSvc.Kserve.Inference.RuntimeImage = "kserve-runtime-b"
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
This pull request updates the handling of KServe inference runtimes by renaming the `runtime` field to `runtime_image` throughout the codebase and documentation. This change clarifies the field's purpose and usage, ensuring consistency and better alignment with KServe's terminology. The documentation and validation logic are also updated to reflect this change.

**API and Field Renaming:**

* Renamed the `runtime` field to `runtime_image` in the `KserveInference` struct, updating all references, comments, and JSON tags accordingly to clarify that this field is for specifying a custom KServe runtime image.
* Updated validation and equality checks to use `runtime_image` instead of `runtime`, ensuring correct behavior when comparing or updating KServe inference configurations. [[1]](diffhunk://#diff-4e04ef107488e1c85c44bb5c8641183acf8d2305b8e22dd994056f05c79319fcL140-R140) [[2]](diffhunk://#diff-4e04ef107488e1c85c44bb5c8641183acf8d2305b8e22dd994056f05c79319fcL237-R239)

**Documentation Updates:**

* Updated the `docs/fdl.md` documentation to replace references to the `runtime` field with `runtime_image`, providing clearer guidance on when and why to use this field. The documentation now also explains the relationship between model formats and runtimes.

**Spec Generation Logic:**

* Modified KServe inference service spec generation and update logic to use the new `runtime_image` field when setting the runtime in the model spec. [[1]](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bL375-R376) [[2]](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bL439-R440)

**Test Updates:**

* Updated tests to use `runtime_image` instead of `runtime` when verifying that runtime changes are correctly detected as errors.