### PR TITLE
feat: add DNS subdomain routing and cookie handling for KServe

### DIFF
--- a/pkg/utils/kserve.go
+++ b/pkg/utils/kserve.go
@@ -608,6 +608,10 @@ func buildKserveName(serviceName string) string {
 	return serviceName
 }
 
+func getServiceAuthCookieName(serviceName string) string {
+	return "oscar_service_" + strings.ReplaceAll(serviceName, "-", "_") + "_auth"
+}
+
 func getHTTPRouteName(serviceName string) string {
 	return serviceName + "-route"
 }
@@ -672,8 +676,10 @@ func buildTraefikOIDCMiddlewareSpec(service *types.Service, owner *KserveService
 		},
 		"spec": map[string]any{
 			"forwardAuth": map[string]any{
-				"address":            authEndpointAddress,
-				"trustForwardHeader": true,
+				"address":                  authEndpointAddress,
+				"trustForwardHeader":       true,
+				"addAuthCookiesToResponse": []any{getServiceAuthCookieName(service.Name)},
+				"authResponseHeaders":      []any{"Authorization"},
 			},
 		},
 	}}
@@ -766,6 +772,8 @@ func buildHTTPRouteSpec(service *types.Service, owner *KserveServiceOwner, cfg *
 	serviceName := service.Name
 	httpRouteName := serviceName + httpRouteSuffix
 	namespace := owner.Namespace
+	apiPath := "/"
+	host := fmt.Sprintf("%s.%s", serviceName, strings.TrimSpace(cfg.IngressHost))
 
 	filters := []any{
 		map[string]any{
@@ -788,23 +796,29 @@ func buildHTTPRouteSpec(service *types.Service, owner *KserveServiceOwner, cfg *
 			},
 		})
 	}
-	// TO DO: vLLM framework support root path change
-	filters = append(filters, map[string]any{
-		"type": "URLRewrite",
-		"urlRewrite": map[string]any{
-			"path": map[string]any{
-				"type":               "ReplacePrefixMatch",
-				"replacePrefixMatch": "/",
+
+	// If ExposedServicesUseSubdomainRoute is false (custom domain routing is disabled),
+	// we need to rewrite the path to remove the prefix and use the IngressHost as the hostname.
+	if !cfg.ExposedServicesUseSubdomainRoute {
+		apiPath = getAPIPath(serviceName)
+		host = strings.TrimSpace(cfg.IngressHost)
+		filters = append(filters, map[string]any{
+			"type": "URLRewrite",
+			"urlRewrite": map[string]any{
+				"path": map[string]any{
+					"type":               "ReplacePrefixMatch",
+					"replacePrefixMatch": "/",
+				},
 			},
-		},
-	})
+		})
+	}
 
 	rule := map[string]any{
 		"matches": []any{
 			map[string]any{
 				"path": map[string]any{
 					"type":  "PathPrefix",
-					"value": getAPIPath(serviceName),
+					"value": apiPath,
 				},
 			},
 		},
@@ -824,7 +838,7 @@ func buildHTTPRouteSpec(service *types.Service, owner *KserveServiceOwner, cfg *
 		"rules": []any{rule},
 	}
 
-	if host := strings.TrimSpace(cfg.IngressHost); host != "" {
+	if host != "" {
 		spec["hostnames"] = []any{host}
 	}
 


### PR DESCRIPTION
This pull request introduces improvements to the routing and authentication logic for KServe services, focusing on more flexible handling of subdomain and root-path routing, as well as enhancing authentication cookie management. The changes primarily affect how HTTP routes and authentication cookies are generated and configured, especially in relation to the use of custom domains and subdomain routing.

**Routing logic enhancements:**

* Updated `buildHTTPRouteSpec` to support both subdomain-based and root-path routing. When `ExposedServicesUseSubdomainRoute` is false, the route rewrites the path and sets the hostname to the main ingress host, allowing services to be exposed under a common domain with path prefixes. [[1]](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bR775-R776) [[2]](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bL791-R804) [[3]](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bR814-R821) [[4]](diffhunk://#diff-790684955a312823bf674e21643288c69cf6131559fdb356b379bf474990f23bL827-R841)

**Authentication improvements:**

* Added a new function `getServiceAuthCookieName` to generate unique authentication cookie names per service, replacing dashes with underscores for compatibility.
* Modified `buildTraefikOIDCMiddlewareSpec` to include the generated service-specific auth cookie in the `addAuthCookiesToResponse` list and ensure the `Authorization` header is forwarded in the response.