### PR TITLE
chore: update api_port to array format in expose service configurations for OSCAR v4.1.X

### DIFF
--- a/examples/expose_services/deep/deep_expose.yaml
+++ b/examples/expose_services/deep/deep_expose.yaml
@@ -13,7 +13,7 @@ functions:
       expose:
         min_scale: 1
         max_scale: 1
-        api_port: 5000
+        api_port: [5000]
         rewrite_target: true
         cpu_threshold: 90
         set_auth: true

--- a/examples/expose_services/jupyter/jupyter_expose.yaml
+++ b/examples/expose_services/jupyter/jupyter_expose.yaml
@@ -13,6 +13,6 @@ functions:
      expose:
       min_scale: 1
       max_scale: 1
-      api_port: 8888
+      api_port: [8888]
       cpu_threshold: 90
       rewrite_target: true

--- a/examples/expose_services/jupyter/jupyter_expose_mount.yaml
+++ b/examples/expose_services/jupyter/jupyter_expose_mount.yaml
@@ -17,6 +17,6 @@ functions:
      expose:
       min_scale: 1
       max_scale: 1
-      api_port: 8888
+      api_port: [8888]
       cpu_threshold: 90
       rewrite_target: true

--- a/examples/expose_services/nginx/nginx_expose.yaml
+++ b/examples/expose_services/nginx/nginx_expose.yaml
@@ -12,6 +12,6 @@ functions:
      expose:
       min_scale: 1
       max_scale: 10 
-      api_port: 80  
+      api_port: [80]  
       cpu_threshold: 50 
       default_command: false

--- a/examples/expose_services/openclaw/openclaw_expose.yaml
+++ b/examples/expose_services/openclaw/openclaw_expose.yaml
@@ -18,7 +18,7 @@ functions:
       expose:
         min_scale: 1
         max_scale: 1
-        api_port: 18789
+        api_port: [18789]
         cpu_threshold: 90
         rewrite_target: true
         set_auth: true

--- a/examples/expose_services/openclaw/openclaw_expose_workspace.yaml
+++ b/examples/expose_services/openclaw/openclaw_expose_workspace.yaml
@@ -23,7 +23,7 @@ functions:
       expose:
         min_scale: 1
         max_scale: 1
-        api_port: 18789
+        api_port: [18789]
         cpu_threshold: 90
         rewrite_target: true
         set_auth: true

--- a/examples/vllm-deepseek/vllm.yaml
+++ b/examples/vllm-deepseek/vllm.yaml
@@ -15,7 +15,7 @@ functions:
       expose:
         min_scale: 1
         max_scale: 1
-        api_port: 8000
+        api_port: [8000]
         cpu_threshold: 90
         rewrite_target: true
         health_path: "/health"

--- a/examples/vllm-llama/vllm_llama.yaml
+++ b/examples/vllm-llama/vllm_llama.yaml
@@ -15,7 +15,7 @@ functions:
       expose:
         min_scale: 1
         max_scale: 1
-        api_port: 8000
+        api_port: [8000]
         cpu_threshold: 90
         rewrite_target: true
         health_path: "/health"


### PR DESCRIPTION
**Configuration format updates v4.1.X:**

* Changed `api_port` from an integer to a single-element list in the following files:
  - `examples/expose_services/deep/deep_expose.yaml` (`api_port: 5000` → `api_port: [5000]`)
  - `examples/expose_services/jupyter/jupyter_expose.yaml` (`api_port: 8888` → `api_port: [8888]`)
  - `examples/expose_services/jupyter/jupyter_expose_mount.yaml` (`api_port: 8888` → `api_port: [8888]`)
  - `examples/expose_services/nginx/nginx_expose.yaml` (`api_port: 80` → `api_port: [80]`)
  - `examples/expose_services/openclaw/openclaw_expose.yaml` (`api_port: 18789` → `api_port: [18789]`)
  - `examples/expose_services/openclaw/openclaw_expose_workspace.yaml` (`api_port: 18789` → `api_port: [18789]`)
  - `examples/vllm-deepseek/vllm.yaml` (`api_port: 8000` → `api_port: [8000]`)
  - `examples/vllm-llama/vllm_llama.yaml` (`api_port: 8000` → `api_port: [8000]`)