### PR TITLE
fix: update MinIO endpoint to use host.docker.internal 

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -1119,9 +1119,9 @@ kubectl apply -f https://raw.githubusercontent.com/grycap/oscar/master/deploy/ya
 echo -e "\n[*] Deploying OSCAR ..."
 helm repo add --force-update grycap https://grycap.github.io/helm-charts/
 if [ $(echo $use_knative | tr '[:upper:]' '[:lower:]') == "y" ]; then 
-    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.endpoint=http://minio.minio:9000 --set minIO.TLSVerify=false --set minIO.accessKey=minio --set minIO.secretKey="$MINIO_PASSWORD" --set serverlessBackend=knative --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
+    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.endpoint=http://host.docker.internal:$HOST_MINIO_API_PORT --set minIO.TLSVerify=false --set minIO.accessKey=minio --set minIO.secretKey="$MINIO_PASSWORD" --set serverlessBackend=knative --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
 else
-    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.endpoint=http://minio.minio:9000 --set minIO.TLSVerify=false --set minIO.accessKey=minio --set minIO.secretKey="$MINIO_PASSWORD" --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
+    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.endpoint=http://host.docker.internal:$HOST_MINIO_API_PORT --set minIO.TLSVerify=false --set minIO.accessKey=minio --set minIO.secretKey="$MINIO_PASSWORD" --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
 fi
 
 if [ -n "$OSCAR_POST_DEPLOYMENT_IMAGE" ]; then


### PR DESCRIPTION
**Deployment configuration update:**

* Updated the `deploy/kind-deploy.sh` script so that the `minIO.endpoint` Helm chart value now points to `http://host.docker.internal:$HOST_MINIO_API_PORT` instead of `http://minio.minio:9000`, both for Knative and non-Knative deployments. This allows the OSCAR deployment to connect to a MinIO instance running on the host rather than inside the cluster.

Related to: https://github.com/grycap/oscar-dashboard-devel/pull/170