### PR TITLE
feat: enhance deployment status handling with initialization and crash loop states

### DIFF
--- a/pkg/handlers/deployment.go
+++ b/pkg/handlers/deployment.go
@@ -83,13 +83,13 @@ func MakeGetDeploymentStatusHandler(back types.ServerlessBackend, kubeClientset 
 			return
 		}
 
-		runtimeCtx, err := inspectDeploymentRuntime(back, kubeClientset, service, cfg)
+		status, err := inspectDeploymentRuntimeStatusOnly(back, kubeClientset, service, cfg)
 		if err != nil {
 			c.String(http.StatusInternalServerError, err.Error())
 			return
 		}
 
-		c.JSON(http.StatusOK, runtimeCtx.status)
+		c.JSON(http.StatusOK, status)
 	}
 }
 
@@ -216,9 +216,10 @@ func inspectExposedDeploymentRuntime(kubeClientset kubernetes.Interface, service
 		return deploymentRuntimeContext{}, err
 	}
 
+	items := podItems(pods)
 	return deploymentRuntimeContext{
-		status:  deploymentStatusFromDeployment(service, deployment),
-		logPods: podItems(pods),
+		status:  deploymentStatusFromDeployment(service, deployment, items),
+		logPods: items,
 	}, nil
 }
 
@@ -282,13 +283,14 @@ func inspectKserveDeploymentRuntime(kubeClientset kubernetes.Interface, service 
 		return deploymentRuntimeContext{}, err
 	}
 
+	items := podItems(pods)
 	return deploymentRuntimeContext{
-		status:  deploymentStatusFromDeployment(service, deployment),
-		logPods: podItems(pods),
+		status:  deploymentStatusFromDeployment(service, deployment, items),
+		logPods: items,
 	}, nil
 }
 
-func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.Deployment) types.ServiceDeploymentStatus {
+func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.Deployment, pods []corev1.Pod) types.ServiceDeploymentStatus {
 	var desired int32 = 1
 	if deployment.Spec.Replicas != nil {
 		desired = *deployment.Spec.Replicas
@@ -307,6 +309,9 @@ func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.D
 		affected = 0
 	}
 
+	crashLoop := hasCrashLoopBackOff(pods)
+	podInitializing := hasPodInitializing(pods)
+
 	state := types.DeploymentStatePending
 	switch {
 	case desired == 0:
@@ -315,6 +320,10 @@ func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.D
 		state = types.DeploymentStateReady
 	case available > 0:
 		state = types.DeploymentStateDegraded
+	case crashLoop:
+		state = types.DeploymentStateFailed
+	case podInitializing:
+		state = types.DeploymentStateInit
 	case hasDeploymentFailureCondition(deployment.Status.Conditions):
 		state = types.DeploymentStateFailed
 	default:
@@ -324,6 +333,18 @@ func deploymentStatusFromDeployment(service *types.Service, deployment *appsv1.D
 	reason, transitioned := latestDeploymentCondition(deployment.Status.Conditions)
 	if state == types.DeploymentStateStopped {
 		reason = "Deployment is stopped."
+	}
+	if state == types.DeploymentStatePending && crashLoop {
+		state = types.DeploymentStateFailed
+	}
+	if state == types.DeploymentStatePending && podInitializing {
+		state = types.DeploymentStateInit
+	}
+	if state == types.DeploymentStateInit {
+		reason = "Deployment is initializing."
+	}
+	if state == types.DeploymentStateFailed && crashLoop {
+		reason = firstCrashLoopBackOffReason(pods)
 	}
 	if reason == "" && state == types.DeploymentStateDegraded {
 		reason = fmt.Sprintf("%d of %d instances are affected.", affected, desired)
@@ -374,9 +395,14 @@ func deploymentStatusFromKnativeService(service *types.Service, knService *knv1.
 			state = types.DeploymentStatePending
 		}
 	}
+	if state == types.DeploymentStatePending && total == 0 {
+		state = types.DeploymentStateInit
+	}
 
 	if reason == "" {
 		switch state {
+		case types.DeploymentStateInit:
+			reason = "Runtime service is initializing."
 		case types.DeploymentStateReady:
 			reason = "Runtime service is ready."
 		case types.DeploymentStatePending:
@@ -535,6 +561,63 @@ func podFailureReason(pod corev1.Pod) (string, *metav1.Time) {
 		return string(pod.Status.Phase), pod.Status.StartTime
 	}
 	return "", pod.Status.StartTime
+}
+
+func hasPodInitializing(pods []corev1.Pod) bool {
+	for _, pod := range pods {
+		if pod.Status.Reason == "PodInitializing" {
+			return true
+		}
+		for _, status := range pod.Status.InitContainerStatuses {
+			if status.State.Waiting != nil && (status.State.Waiting.Reason == "PodInitializing" || strings.HasPrefix(status.State.Waiting.Reason, "Init:")) {
+				return true
+			}
+		}
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Waiting != nil {
+				switch status.State.Waiting.Reason {
+				case "PodInitializing", "ContainerCreating":
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hasCrashLoopBackOff(pods []corev1.Pod) bool {
+	for _, pod := range pods {
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Waiting != nil && status.State.Waiting.Reason == "CrashLoopBackOff" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func firstCrashLoopBackOffReason(pods []corev1.Pod) string {
+	for _, pod := range pods {
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Waiting != nil && status.State.Waiting.Reason == "CrashLoopBackOff" {
+				message := strings.Trim(strings.TrimSpace(status.State.Waiting.Reason+": "+status.State.Waiting.Message), ": ")
+				if status.LastTerminationState.Terminated != nil {
+					term := status.LastTerminationState.Terminated
+					if term.ExitCode != 0 {
+						if message != "" {
+							return fmt.Sprintf("%s (exit code %d)", message, term.ExitCode)
+						}
+						return fmt.Sprintf("CrashLoopBackOff (exit code %d)", term.ExitCode)
+					}
+				}
+				if message != "" {
+					return message
+				}
+				return status.State.Waiting.Reason
+			}
+		}
+	}
+	return ""
 }
 
 func latestDeploymentCondition(conditions []appsv1.DeploymentCondition) (string, *metav1.Time) {
@@ -758,7 +841,12 @@ func inspectExposedDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interfac
 		return types.ServiceDeploymentStatus{}, err
 	}
 
-	return deploymentStatusFromDeployment(service, deployment), nil
+	pods, err := backends.ListExposedServicePods(kubeClientset, service.Namespace, service.Name)
+	if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+		return types.ServiceDeploymentStatus{}, err
+	}
+
+	return deploymentStatusFromDeployment(service, deployment, podItems(pods)), nil
 }
 
 func inspectKserveDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interface, service *types.Service) (types.ServiceDeploymentStatus, error) {
@@ -770,5 +858,10 @@ func inspectKserveDeploymentRuntimeStatusOnly(kubeClientset kubernetes.Interface
 		return types.ServiceDeploymentStatus{}, err
 	}
 
-	return deploymentStatusFromDeployment(service, deployment), nil
+	pods, err := backends.ListKserveServicePods(kubeClientset, service.Namespace, service.Name)
+	if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsGone(err) {
+		return types.ServiceDeploymentStatus{}, err
+	}
+	//var pods corev1.PodList
+	return deploymentStatusFromDeployment(service, deployment, podItems(pods)), nil
 }

--- a/pkg/handlers/deployment_test.go
+++ b/pkg/handlers/deployment_test.go
@@ -290,6 +290,225 @@ func TestMakeGetDeploymentStatusHandlerPending(t *testing.T) {
 	}
 }
 
+func TestMakeGetDeploymentStatusHandlerPodInitializingIsInit(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{
+		Name: "svc",
+		Expose: types.Expose{
+			APIPort: []int{8080},
+		},
+		Namespace: "ns",
+	}
+
+	replicas := int32(1)
+	kubeClientset := testclient.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-dpl",
+				Namespace: "ns",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				AvailableReplicas: 0,
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-pod",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app":              "oscar-svc-exp-svc",
+					types.ServiceLabel: "svc",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodPending,
+				Reason: "PodInitializing",
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "PodInitializing",
+								Message: "pod is being initialized",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	r := gin.Default()
+	r.GET("/system/services/:serviceName/deployment", MakeGetDeploymentStatusHandler(back, kubeClientset, &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/system/services/svc/deployment", nil)
+	r.ServeHTTP(w, req)
+
+	var response types.ServiceDeploymentStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.State != types.DeploymentStateInit {
+		t.Fatalf("expected init state for PodInitializing, got %s", response.State)
+	}
+	if !strings.Contains(response.Reason, "initializing") {
+		t.Fatalf("expected initializing reason, got %q", response.Reason)
+	}
+}
+
+func TestMakeGetDeploymentStatusHandlerInitializingWinsOverTimeoutFailure(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{
+		Name: "svc",
+		Expose: types.Expose{
+			APIPort: []int{8080},
+		},
+		Namespace: "ns",
+	}
+
+	replicas := int32(1)
+	now := metav1.NewTime(time.Now().UTC())
+	kubeClientset := testclient.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-dpl",
+				Namespace: "ns",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				AvailableReplicas: 0,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:           appsv1.DeploymentProgressing,
+						Status:         corev1.ConditionFalse,
+						Reason:         "ProgressDeadlineExceeded",
+						Message:        "ReplicaSet \"svc\" has timed out progressing.",
+						LastUpdateTime: now,
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-pod",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app":              "oscar-svc-exp-svc",
+					types.ServiceLabel: "svc",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodPending,
+				Reason: "PodInitializing",
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "PodInitializing",
+								Message: "pod is being initialized",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	r := gin.Default()
+	r.GET("/system/services/:serviceName/deployment", MakeGetDeploymentStatusHandler(back, kubeClientset, &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/system/services/svc/deployment", nil)
+	r.ServeHTTP(w, req)
+
+	var response types.ServiceDeploymentStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.State != types.DeploymentStateInit {
+		t.Fatalf("expected init state while pod is still initializing, got %s", response.State)
+	}
+	if !strings.Contains(response.Reason, "initializing") {
+		t.Fatalf("expected init reason, got %q", response.Reason)
+	}
+}
+
+func TestMakeGetDeploymentStatusHandlerCrashLoopBackOffIsFailed(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	back.Service = &types.Service{
+		Name: "svc",
+		Expose: types.Expose{
+			APIPort: []int{8080},
+		},
+		Namespace: "ns",
+	}
+
+	replicas := int32(1)
+	kubeClientset := testclient.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-dpl",
+				Namespace: "ns",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				AvailableReplicas: 0,
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc-pod",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app":              "oscar-svc-exp-svc",
+					types.ServiceLabel: "svc",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "CrashLoopBackOff",
+								Message: "back-off 5m restarting failed container",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	r := gin.Default()
+	r.GET("/system/services/:serviceName/deployment", MakeGetDeploymentStatusHandler(back, kubeClientset, &types.Config{}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/system/services/svc/deployment", nil)
+	r.ServeHTTP(w, req)
+
+	var response types.ServiceDeploymentStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.State != types.DeploymentStateFailed {
+		t.Fatalf("expected failed state for CrashLoopBackOff, got %s", response.State)
+	}
+	if !strings.Contains(response.Reason, "CrashLoopBackOff") {
+		t.Fatalf("expected CrashLoopBackOff in reason, got %q", response.Reason)
+	}
+}
+
 func TestMakeGetDeploymentStatusHandlerFailed(t *testing.T) {
 	back := backends.MakeFakeBackend()
 	back.Service = &types.Service{

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -19,6 +19,7 @@ package types
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
+	DeploymentStateInit        = "init"
 	DeploymentStatePending     = "pending"
 	DeploymentStateReady       = "ready"
 	DeploymentStateDegraded    = "degraded"

--- a/pkg/types/deployment_test.go
+++ b/pkg/types/deployment_test.go
@@ -61,6 +61,31 @@ func TestServiceDeploymentStatusJSON(t *testing.T) {
 	}
 }
 
+func TestDeploymentStateInitJSON(t *testing.T) {
+	status := ServiceDeploymentStatus{
+		ServiceName: "svc",
+		State:       DeploymentStateInit,
+		Reason:      "service is initializing",
+	}
+
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal init status: %v", err)
+	}
+
+	var decoded ServiceDeploymentStatus
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal init status: %v", err)
+	}
+
+	if decoded.State != DeploymentStateInit {
+		t.Fatalf("expected init state %q, got %q", DeploymentStateInit, decoded.State)
+	}
+	if decoded.Reason != "service is initializing" {
+		t.Fatalf("expected init reason, got %q", decoded.Reason)
+	}
+}
+
 func TestDeploymentLogStreamJSON(t *testing.T) {
 	stream := DeploymentLogStream{
 		ServiceName: "svc",


### PR DESCRIPTION
**Deployment status detection improvements:**

* Added a new deployment state `DeploymentStateInit` to represent when a deployment is initializing, and updated the logic in `deploymentStatusFromDeployment` to detect and report this state based on pod status and initialization conditions. [[1]](diffhunk://#diff-e9df472fa7b5cd63ec34f1381efa51b9f731747171ee4e227cf828688bc93077R22) [[2]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cR312-R314) [[3]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cR323-R326) [[4]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cR337-R348) [[5]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cR398-R405)
* Enhanced detection of `CrashLoopBackOff` and pod initialization by introducing helper functions (`hasPodInitializing`, `hasCrashLoopBackOff`, `firstCrashLoopBackOffReason`) to analyze pod and container statuses for these conditions.

**Status handler and runtime inspection updates:**

* Modified the deployment status handler and related functions to pass pod information to `deploymentStatusFromDeployment`, ensuring that pod-level states are considered in the deployment status. [[1]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cL86-R92) [[2]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cR219-R222) [[3]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cR286-R293) [[4]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cL761-R849) [[5]](diffhunk://#diff-ea600621f4f9d8f9f4bac16a551d9575d000cfd510b6484487c87f6c34584f5cL773-R866)

**Testing improvements:**

* Added new tests to verify that deployments in pod initialization or `CrashLoopBackOff` states are reported as `init` or `failed` respectively, and that the correct reason is included in the status.
* Added a test to ensure the new `init` deployment state is correctly serialized and deserialized in JSON.
_________________________________________
**Downsides**

* The new states add latency to deployment status request, for exposed and kserve services. It is due to the need to make one extra call to K8S API in order to obtain pod's status