### PR TITLE
Fix exposed service Kueue admission race

### DIFF
--- a/pkg/utils/kueue.go
+++ b/pkg/utils/kueue.go
@@ -620,61 +620,9 @@ func buildVerificationWorkloadName(serviceName string) string {
 }
 
 func CheckWorkloadAdmited(service types.Service, namespace string, cfg *types.Config, kubeClientset kubernetes.Interface, templateFunction func(types.Service, string, *types.Config) *apps.Deployment) error {
-	restCfg, err := rest.InClusterConfig()
-	if err != nil {
-		KueueLogger.Printf("error building in-cluster config for kueue: %v", err)
-		return err
-	}
-
-	kueueClient, err := kueueclientset.NewForConfig(restCfg)
-	if err != nil {
-		KueueLogger.Printf("error building kueue clientset: %v", err)
-		return err
-	}
-	factory := kueueinformers.NewSharedInformerFactory(kueueClient, 0)
-	workloadsInformer := factory.Kueue().V1beta2().Workloads().Informer()
-
-	resource, err := workloadsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			_, ok := newObj.(*kueuev1.Workload)
-			if !ok {
-				KueueLogger.Printf("error: unexpected type in workload informer")
-				return
-			}
-		},
-	})
-	if err != nil {
-		KueueLogger.Printf("error adding event handler to workload informer: %v, %v", err, resource)
-	}
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	factory.Start(stopCh)
-
-	if !cache.WaitForCacheSync(stopCh, workloadsInformer.HasSynced) {
-		return fmt.Errorf("failed to sync workload informer")
-	}
-	obj, exists, err := workloadsInformer.GetIndexer().GetByKey(namespace + "/" + service.Name)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("workload not found")
-	}
-
-	wl := obj.(*kueuev1.Workload)
-	admitted := false
-	for _, c := range wl.Status.Conditions {
-		if c.Type == kueuev1.WorkloadAdmitted &&
-			c.Status == metav1.ConditionTrue {
-			admitted = true
-			break
-		}
-	}
-	if !admitted {
+	if !onlyCheckWorkloadAdmited(namespace, service.Name, defaultKueueAdmissionTimeout) {
 		DeleteWorkload(service.Name, namespace, cfg)
-		return fmt.Errorf("workload for exposed service '%s' is NOT admitted", service.Name)
+		return fmt.Errorf("workload for exposed service '%s' was not admitted within %s", service.Name, defaultKueueAdmissionTimeout)
 	} else {
 		KueueLogger.Printf("workload for exposed service '%s' is admitted", service.Name)
 		deployment := templateFunction(service, namespace, cfg) //getDeploymentSpec
@@ -708,7 +656,7 @@ func VerifyWorkload(service types.Service, namespace string, cfg *types.Config) 
 	if !CreateWorkload(service, namespace, cfg, getPodTemplateSpec) {
 		return false
 	}
-	check := onlyCheckWorkloadAdmited(service.Name, defaultKueueAdmissionTimeout)
+	check := onlyCheckWorkloadAdmited(namespace, service.Name, defaultKueueAdmissionTimeout)
 	delete := DeleteWorkload(service.Name, namespace, cfg)
 	return check && delete
 }
@@ -761,7 +709,7 @@ func VerifyWorkloadByResources(service types.Service, cfg *types.Config) bool {
 		return false
 	}
 
-	check := onlyCheckWorkloadAdmited(workloadName, 1*time.Second)
+	check := onlyCheckWorkloadAdmited(namespace, workloadName, 1*time.Second)
 	delete := DeleteWorkload(workloadName, namespace, cfg)
 	return check && delete
 }
@@ -789,7 +737,7 @@ func getPodTemplateSpec(service types.Service, namespace string, cfg *types.Conf
 	}
 }
 
-func onlyCheckWorkloadAdmited(serviceName string, timeout time.Duration) bool {
+func onlyCheckWorkloadAdmited(namespace, serviceName string, timeout time.Duration) bool {
 	restCfg, err := rest.InClusterConfig()
 	if err != nil {
 		KueueLogger.Printf("error building in-cluster config for kueue: %v", err)
@@ -809,7 +757,7 @@ func onlyCheckWorkloadAdmited(serviceName string, timeout time.Duration) bool {
 	resource, err := workloadsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			newWL := newObj.(*kueuev1.Workload)
-			if newWL.Name != serviceName {
+			if newWL.Namespace != namespace || newWL.Name != serviceName {
 				return
 			}
 			if workloadIsAdmitted(newWL) {
@@ -833,7 +781,7 @@ func onlyCheckWorkloadAdmited(serviceName string, timeout time.Duration) bool {
 	}
 
 	for _, obj := range workloadsInformer.GetStore().List() {
-		if wl, ok := obj.(*kueuev1.Workload); ok && wl.Name == serviceName && workloadIsAdmitted(wl) {
+		if wl, ok := obj.(*kueuev1.Workload); ok && wl.Namespace == namespace && wl.Name == serviceName && workloadIsAdmitted(wl) {
 			KueueLogger.Printf("Workload %s admitted", serviceName)
 			return true
 		}

--- a/pkg/utils/kueue.go
+++ b/pkg/utils/kueue.go
@@ -34,6 +34,13 @@ const (
 var (
 	defaultCpuRequest    = resource.MustParse("0.2")
 	defaultMemoryRequest = resource.MustParse("256Mi")
+	newKueueClient       = func() (kueueclientset.Interface, error) {
+		restCfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		return kueueclientset.NewForConfig(restCfg)
+	}
 )
 
 var KueueLogger = log.New(os.Stdout, "[KUEUE-SERVICE] ", log.Flags())
@@ -738,12 +745,7 @@ func getPodTemplateSpec(service types.Service, namespace string, cfg *types.Conf
 }
 
 func onlyCheckWorkloadAdmited(namespace, serviceName string, timeout time.Duration) bool {
-	restCfg, err := rest.InClusterConfig()
-	if err != nil {
-		KueueLogger.Printf("error building in-cluster config for kueue: %v", err)
-		return false
-	}
-	kueueClient, err := kueueclientset.NewForConfig(restCfg)
+	kueueClient, err := newKueueClient()
 	if err != nil {
 		KueueLogger.Printf("error building kueue clientset: %v", err)
 		return false

--- a/pkg/utils/kueue_test.go
+++ b/pkg/utils/kueue_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grycap/oscar/v4/pkg/types"
 	apps "k8s.io/api/apps/v1"
@@ -15,6 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	kueuev1 "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	kueueclientset "sigs.k8s.io/kueue/client-go/clientset/versioned"
+	kueuefake "sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
 )
 
 func newTestConfig() *types.Config {
@@ -628,6 +631,80 @@ func TestWorkloadIsAdmitted(t *testing.T) {
 				t.Fatalf("workloadIsAdmitted() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOnlyCheckWorkloadAdmitedFromInitialState(t *testing.T) {
+	originalNewKueueClient := newKueueClient
+	t.Cleanup(func() { newKueueClient = originalNewKueueClient })
+
+	admittedWorkload := func(namespace string) *kueuev1.Workload {
+		return &kueuev1.Workload{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-service", Namespace: namespace},
+			Status: kueuev1.WorkloadStatus{Conditions: []metav1.Condition{{
+				Type:   string(kueuev1.WorkloadAdmitted),
+				Status: metav1.ConditionTrue,
+			}}},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		workloadNamespace string
+		want              bool
+	}{
+		{name: "matching namespace", workloadNamespace: "test-ns", want: true},
+		{name: "different namespace", workloadNamespace: "other-ns", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := kueuefake.NewSimpleClientset(admittedWorkload(tt.workloadNamespace))
+			newKueueClient = func() (kueueclientset.Interface, error) { return client, nil }
+
+			if got := onlyCheckWorkloadAdmited("test-ns", "test-service", 10*time.Millisecond); got != tt.want {
+				t.Fatalf("onlyCheckWorkloadAdmited() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnlyCheckWorkloadAdmitedFromUpdate(t *testing.T) {
+	originalNewKueueClient := newKueueClient
+	t.Cleanup(func() { newKueueClient = originalNewKueueClient })
+
+	client := kueuefake.NewSimpleClientset(&kueuev1.Workload{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-service", Namespace: "test-ns"},
+	})
+	newKueueClient = func() (kueueclientset.Interface, error) { return client, nil }
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- onlyCheckWorkloadAdmited("test-ns", "test-service", time.Second)
+	}()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case got := <-result:
+			if !got {
+				t.Fatal("onlyCheckWorkloadAdmited() = false, want true")
+			}
+			return
+		case <-ticker.C:
+			workload, err := client.KueueV1beta2().Workloads("test-ns").Get(context.Background(), "test-service", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("getting workload: %v", err)
+			}
+			workload.Status.Conditions = []metav1.Condition{{
+				Type:   string(kueuev1.WorkloadAdmitted),
+				Status: metav1.ConditionTrue,
+			}}
+			if _, err := client.KueueV1beta2().Workloads("test-ns").UpdateStatus(context.Background(), workload, metav1.UpdateOptions{}); err != nil {
+				t.Fatalf("updating workload status: %v", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- wait for exposed-service Kueue workloads to transition to `Admitted=True` instead of treating the first non-admitted snapshot as a definitive rejection
- reuse the existing 30-second workload admission watcher and timeout
- scope workload matching by namespace as well as name to avoid cross-namespace collisions
- return an explicit timeout error when admission does not complete

## Problem

The issue was detected while running the OSCAR metrics population Robot suite against a local cluster. The suite created four regular services successfully, but creation of the exposed nginx service intermittently returned HTTP 500.

Manager logs showed the generic message:

```
Error checking workload admission: change the cpu/memory requests
```

The Kueue events showed that the workload was initially `Pending` while the controller evaluated or waited for quota. OSCAR checked the workload immediately after creating it and interpreted the absence of `Admitted=True` as a permanent rejection. It then deleted the workload and failed service creation before Kueue could publish a later admission update.

This is a race between the synchronous exposed-service creation path and Kueue's asynchronous status reconciliation. A workload that is not admitted in the first snapshot is not necessarily rejected.

## Root cause

`CheckWorkloadAdmited` started and synchronized an informer, read the workload once, and returned an error whenever that snapshot did not already contain `Admitted=True`. The update handler did not wait for or act on subsequent status transitions.

The codebase already had `onlyCheckWorkloadAdmited`, which checks the initial informer store and then waits for an admission update until a configurable timeout. The exposed-service path was not using it.

## Change

`CheckWorkloadAdmited` now delegates admission waiting to `onlyCheckWorkloadAdmited` with the existing 30-second default timeout. If admission succeeds, deployment activation continues as before. If it does not complete within the timeout, the workload is cleaned up and the returned error identifies the timeout.

The shared helper now receives the workload namespace and requires both namespace and name to match, preventing an admitted workload with the same name in another user namespace from satisfying the check.

## Impact

Exposed-service creation continues immediately when Kueue has already admitted the workload. When Kueue reconciliation takes longer, the API waits only for the actual delay, up to 30 seconds, instead of returning a premature HTTP 500.

Requests that remain pending because quota is genuinely unavailable still fail after the timeout and preserve the existing cleanup behavior.

## Validation

- `go test ./...`
- rebuilt and deployed OSCAR in a local cluster
- reran the metrics population suite and confirmed that exposed-service creation waits for Kueue admission instead of failing on the first pending snapshot
