### PR TITLE
feat: add owner-scoped historical service metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,8 @@
 # Metrics reporting
 
-Metrics reporting endpoints include `/system/metrics/{serviceName}`, `/system/metrics`, and
-`/system/metrics/breakdown`. If the `metric` query parameter is omitted from
+Metrics reporting endpoints include `/system/metrics/{serviceName}`, `/system/metrics`,
+`/system/metrics/breakdown`, and the administrative owner catalog at
+`/system/metrics/owners`. If the `metric` query parameter is omitted from
 `/system/metrics/{serviceName}`, the API returns all supported per-service metrics.
 The breakdown endpoint supports CSV output by setting
 `format=csv` and grouping with `group_by` (service, user, country). To include
@@ -10,11 +11,40 @@ the list of users per service, set `include_users=true` (JSON only).
 The `start`/`end` query parameters are optional. If omitted, the API defaults to
 the last 24 hours (end = now, start = end - 24h).
 
-When using OIDC Bearer tokens, metrics are limited to the services visible to
-the authenticated user under the usual service visibility rules (`public`,
-owned services, and `restricted` services where the user is listed in
-`allowed_users`). When using Basic Auth as the OSCAR admin user, metrics remain
-cluster-wide and include all services.
+When using OIDC Bearer tokens, metrics are limited to services owned by the
+authenticated user. Public services owned by other users and restricted
+services where the user is listed in `allowed_users` are not included. When
+using Basic Auth as the OSCAR admin user, metrics remain cluster-wide and
+include all services.
+
+The OSCAR administrator can add the `owner` query parameter to the summary,
+breakdown, and per-service endpoints. The result is then limited to the exact
+namespace owned by that user, including attributable metrics for services that
+have already been deleted. Bearer-authenticated requests cannot select another
+owner.
+
+The `/system/metrics/owners` endpoint is available only with administrator
+Basic Auth. It builds its owner catalog from persistent namespaces managed by
+OSCAR (`app.kubernetes.io/managed-by=oscar`) and the
+`oscar.grycap.upv.es/owner` namespace annotation. Display names are enriched
+from active service metadata when available. The shared `cluster_admin`
+namespace is returned explicitly as `oscar`.
+
+For example:
+
+```text
+GET /system/metrics?owner=user@example.org
+GET /system/metrics/breakdown?group_by=service&owner=user@example.org
+GET /system/metrics/my-service?owner=user@example.org
+```
+
+Owned service metrics are scoped by the user's service namespace. This allows
+OIDC users to query retained metrics for their deleted services without
+exposing services from another user's namespace. Historical OSCAR manager
+request records created before the execution log included the
+service namespace can only be attributed while the service is still active.
+Existing Traefik JSON access logs remain attributable when their `ServiceName`
+field is available.
 
 ### Prometheus usage metrics
 
@@ -22,8 +52,13 @@ CPU/GPU hours are fetched from Prometheus. If `PROMETHEUS_URL` is not set, the
 service defaults to `http://prometheus-server.monitoring.svc.cluster.local`.
 You can override the default Prometheus queries via:
 
-- `PROMETHEUS_CPU_QUERY` (default uses `{{service}}`, `{{range}}`, and `{{services_namespace}}`)
-- `PROMETHEUS_GPU_QUERY` (default uses `{{service}}`, `{{range}}`, and `{{services_namespace}}`)
+- `PROMETHEUS_CPU_QUERY` (default uses `{{service}}`, `{{range}}`, and `{{namespace}}`)
+- `PROMETHEUS_GPU_QUERY` (default uses `{{service}}`, `{{range}}`, and `{{namespace}}`)
+
+Custom Prometheus templates should use `{{namespace}}` so OSCAR can apply an
+exact user namespace for OIDC requests. The legacy `{{services_namespace}}`
+placeholder remains supported for existing installations, but custom templates
+using it should be migrated.
 
 ### Loki request logs (durable breakdowns)
 
@@ -33,6 +68,11 @@ to Kubernetes pod logs.
 
 - `LOKI_URL` (e.g., `http://loki.monitoring.svc.cluster.local:3100`)
 - `LOKI_QUERY` (default uses `{{namespace}}` and `{{app}}`; if you add `{{service}}`, prefer a regex matcher like `service=~"{{service}}"` so summary queries can expand to `.*`)
-- `LOKI_EXPOSED_QUERY` (LogQL query for exposed-service requests; default filters `/system/services/.+/exposed`)
-- `LOKI_EXPOSED_NAMESPACE` (default `ingress-nginx`)
-- `LOKI_EXPOSED_APP` (default `ingress-nginx`)
+- `LOKI_EXPOSED_QUERY` (base selector for gateway access logs; OSCAR adds the service path or DNS host filter)
+- `LOKI_EXPOSED_NAMESPACE` (gateway namespace; default `ingress-nginx`)
+- `LOKI_EXPOSED_APP` (gateway app label; default `ingress-nginx`)
+
+With Traefik HTTPRoutes and DNS subdomains, OSCAR identifies the service from
+`RequestAddr` and obtains its namespace from Traefik's `ServiceName` access-log
+field. The Alloy pipeline must retain the JSON access log body; the provided
+Traefik configuration already does so.

--- a/main.go
+++ b/main.go
@@ -173,6 +173,7 @@ func main() {
 	metricsGroup := r.Group("/system/metrics", auth.GetAuthMiddleware(cfg, kubeClientset))
 	metricsGroup.GET("", handlers.MakeMetricsSummaryHandler(cfg, back, metricsAgg))
 	metricsGroup.GET("/breakdown", handlers.MakeMetricsBreakdownHandler(cfg, back, metricsAgg))
+	metricsGroup.GET("/owners", handlers.MakeMetricsOwnersHandler(cfg, back))
 	metricsGroup.GET("/:serviceName", handlers.MakeMetricValueHandler(cfg, back, metricsAgg))
 
 	// Quotas

--- a/pkg/handlers/job.go
+++ b/pkg/handlers/job.go
@@ -244,6 +244,7 @@ func MakeJobHandler(cfg *types.Config, backendQuota types.QuotaBackend, back typ
 		if minIOSecretKey == "" {
 			minIOSecretKey = service.Owner
 		}
+		auth.SetMetricsServiceContext(c, service.Name, serviceNamespace)
 
 		if minIOSecretKey == service.Owner {
 			minIOSecretKey = "minio"

--- a/pkg/handlers/metrics.go
+++ b/pkg/handlers/metrics.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/grycap/oscar/v4/pkg/metrics"
 	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/grycap/oscar/v4/pkg/utils"
+	"github.com/grycap/oscar/v4/pkg/utils/auth"
 )
 
 type userBreakdownItem struct {
@@ -55,6 +58,7 @@ type serviceBreakdownResponse struct {
 // @Param metric query string false "Metric key"
 // @Param start query string false "RFC3339 start timestamp (defaults to end-24h)"
 // @Param end query string false "RFC3339 end timestamp (defaults to now)"
+// @Param owner query string false "Service owner filter (admin Basic Auth only)"
 // @Success 200 {object} types.MetricValueResponse
 // @Success 200 {object} types.ServiceMetricsResponse
 // @Failure 400 {string} string "Invalid parameters"
@@ -70,7 +74,7 @@ func MakeMetricValueHandler(cfg *types.Config, back types.ServerlessBackend, agg
 			return
 		}
 		if isBearerRequest(c) {
-			if _, ok := getAuthorizedServiceForMetrics(c, back, serviceName); !ok {
+			if !authorizeServiceMetricsQuery(c, back, serviceName) {
 				return
 			}
 		}
@@ -80,7 +84,7 @@ func MakeMetricValueHandler(cfg *types.Config, back types.ServerlessBackend, agg
 			return
 		}
 
-		scopedAgg, ok := scopedMetricsAggregator(c, back, agg)
+		scopedAgg, ok := scopedMetricsAggregator(c, cfg, back, agg)
 		if !ok {
 			return
 		}
@@ -147,6 +151,7 @@ func loadAllServiceMetrics(c *gin.Context, cfg *types.Config, agg *metrics.Aggre
 // @Produce json
 // @Param start query string false "RFC3339 start timestamp (defaults to end-24h)"
 // @Param end query string false "RFC3339 end timestamp (defaults to now)"
+// @Param owner query string false "Service owner filter (admin Basic Auth only)"
 // @Success 200 {object} types.MetricsSummaryResponse
 // @Failure 400 {string} string "Invalid parameters"
 // @Failure 500 {string} string "Internal Server Error"
@@ -160,7 +165,7 @@ func MakeMetricsSummaryHandler(cfg *types.Config, back types.ServerlessBackend, 
 			return
 		}
 
-		scopedAgg, ok := scopedMetricsAggregator(c, back, agg)
+		scopedAgg, ok := scopedMetricsAggregator(c, cfg, back, agg)
 		if !ok {
 			return
 		}
@@ -183,6 +188,7 @@ func MakeMetricsSummaryHandler(cfg *types.Config, back types.ServerlessBackend, 
 // @Param group_by query string true "Breakdown dimension" Enums(service,user,country)
 // @Param include_users query bool false "Include user list when group_by=service"
 // @Param format query string false "Response format" Enums(json,csv) default(json)
+// @Param owner query string false "Service owner filter (admin Basic Auth only)"
 // @Success 200 {object} types.MetricsBreakdownResponse
 // @Success 200 {string} string "CSV response"
 // @Failure 400 {string} string "Invalid parameters"
@@ -210,7 +216,7 @@ func MakeMetricsBreakdownHandler(cfg *types.Config, back types.ServerlessBackend
 		}
 
 		includeUsers := strings.ToLower(strings.TrimSpace(c.DefaultQuery("include_users", "false"))) == "true"
-		scopedAgg, ok := scopedMetricsAggregator(c, back, agg)
+		scopedAgg, ok := scopedMetricsAggregator(c, cfg, back, agg)
 		if !ok {
 			return
 		}
@@ -281,8 +287,69 @@ func MakeMetricsBreakdownHandler(cfg *types.Config, back types.ServerlessBackend
 	}
 }
 
-func scopedMetricsAggregator(c *gin.Context, back types.ServerlessBackend, agg *metrics.Aggregator) (*metrics.Aggregator, bool) {
-	allowedServices, scoped, ok := allowedMetricsServiceIDs(c, back)
+// MakeMetricsOwnersHandler godoc
+// @Summary List owners available for administrative metrics filtering
+// @Tags metrics
+// @Produce json
+// @Success 200 {object} types.MetricsOwnersResponse
+// @Failure 403 {string} string "Forbidden"
+// @Failure 500 {string} string "Internal Server Error"
+// @Security BasicAuth
+// @Router /system/metrics/owners [get]
+func MakeMetricsOwnersHandler(cfg *types.Config, back types.ServerlessBackend) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if isBearerRequest(c) {
+			c.Status(http.StatusForbidden)
+			return
+		}
+
+		managedNamespaces, err := utils.ListManagedUserNamespaces(c.Request.Context(), back.GetKubeClientset())
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		namesByOwner := map[string]string{}
+		services, err := back.ListServices()
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return
+		}
+		for _, service := range services {
+			if service == nil || service.Owner == "" {
+				continue
+			}
+			if ownerName := strings.TrimSpace(service.Labels["owner_name"]); ownerName != "" {
+				namesByOwner[service.Owner] = strings.ReplaceAll(ownerName, "_", " ")
+			}
+		}
+
+		owners := make([]types.MetricsOwner, 0, len(managedNamespaces)+1)
+		owners = append(owners, types.MetricsOwner{
+			ID:        types.DefaultOwner,
+			Name:      "oscar",
+			Namespace: cfg.ServicesNamespace,
+		})
+		for _, namespace := range managedNamespaces {
+			name := namesByOwner[namespace.Owner]
+			if name == "" {
+				name = namespace.Owner
+			}
+			owners = append(owners, types.MetricsOwner{
+				ID:        namespace.Owner,
+				Name:      name,
+				Namespace: namespace.Name,
+			})
+		}
+		sort.Slice(owners, func(i, j int) bool {
+			return strings.ToLower(owners[i].Name) < strings.ToLower(owners[j].Name)
+		})
+		c.JSON(http.StatusOK, types.MetricsOwnersResponse{Owners: owners})
+	}
+}
+
+func scopedMetricsAggregator(c *gin.Context, cfg *types.Config, back types.ServerlessBackend, agg *metrics.Aggregator) (*metrics.Aggregator, bool) {
+	scope, scoped, ok := metricsQueryScope(c, cfg, back)
 	if !ok {
 		return nil, false
 	}
@@ -290,28 +357,95 @@ func scopedMetricsAggregator(c *gin.Context, back types.ServerlessBackend, agg *
 		return agg, true
 	}
 	return &metrics.Aggregator{
-		Sources: metrics.ScopeSources(agg.Sources, allowedServices),
+		Sources: metrics.ScopeSources(agg.Sources, scope),
 	}, true
 }
 
-func allowedMetricsServiceIDs(c *gin.Context, back types.ServerlessBackend) (map[string]struct{}, bool, bool) {
+func metricsQueryScope(c *gin.Context, cfg *types.Config, back types.ServerlessBackend) (metrics.QueryScope, bool, bool) {
+	ownerFilter := strings.TrimSpace(c.Query("owner"))
 	if !isBearerRequest(c) {
-		return nil, false, true
+		if ownerFilter == "" {
+			return metrics.QueryScope{}, false, true
+		}
+		return adminOwnerMetricsQueryScope(c, cfg, back, ownerFilter)
+	}
+	if ownerFilter != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "owner filter is only available with admin authentication"})
+		return metrics.QueryScope{}, false, false
+	}
+	uid, err := auth.GetUIDFromContext(c)
+	if err != nil {
+		c.String(http.StatusUnauthorized, err.Error())
+		return metrics.QueryScope{}, false, false
 	}
 
 	services, ok := listAuthorizedServicesForMetrics(c, back)
 	if !ok {
-		return nil, false, false
+		return metrics.QueryScope{}, false, false
 	}
 
-	allowed := make(map[string]struct{}, len(services))
+	scope := metrics.QueryScope{
+		OwnerNamespace: utils.BuildUserNamespace(cfg, uid),
+		ActiveServices: make([]metrics.ServiceScope, 0, len(services)),
+	}
 	for _, service := range services {
 		if service == nil {
 			continue
 		}
-		allowed[service.Name] = struct{}{}
+		namespace := service.Namespace
+		if namespace == "" {
+			namespace = utils.BuildUserNamespace(cfg, service.Owner)
+		}
+		scope.ActiveServices = append(scope.ActiveServices, metrics.ServiceScope{
+			Name:      service.Name,
+			Namespace: namespace,
+		})
 	}
-	return allowed, true, true
+	return scope, true, true
+}
+
+func adminOwnerMetricsQueryScope(c *gin.Context, cfg *types.Config, back types.ServerlessBackend, owner string) (metrics.QueryScope, bool, bool) {
+	namespace := ""
+	if owner == types.DefaultOwner {
+		namespace = cfg.ServicesNamespace
+	} else {
+		managedNamespaces, err := utils.ListManagedUserNamespaces(c.Request.Context(), back.GetKubeClientset())
+		if err != nil {
+			c.String(http.StatusInternalServerError, err.Error())
+			return metrics.QueryScope{}, false, false
+		}
+		for _, candidate := range managedNamespaces {
+			if candidate.Owner == owner {
+				namespace = candidate.Name
+				break
+			}
+		}
+	}
+	if namespace == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "metrics owner not found"})
+		return metrics.QueryScope{}, false, false
+	}
+
+	services, err := back.ListServices()
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return metrics.QueryScope{}, false, false
+	}
+	scope := metrics.QueryScope{OwnerNamespace: namespace}
+	for _, service := range services {
+		if service == nil || service.Owner != owner {
+			continue
+		}
+		serviceNamespace := service.Namespace
+		if serviceNamespace == "" {
+			serviceNamespace = namespace
+		}
+		scope.ActiveServices = append(scope.ActiveServices, metrics.ServiceScope{
+			Name:      service.Name,
+			Namespace: serviceNamespace,
+		})
+	}
+	return scope, true, true
 }
 
 func parseTimeRange(c *gin.Context) (metrics.TimeRange, bool) {

--- a/pkg/handlers/metrics_test.go
+++ b/pkg/handlers/metrics_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/grycap/oscar/v4/pkg/backends"
 	"github.com/grycap/oscar/v4/pkg/metrics"
 	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/grycap/oscar/v4/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -90,8 +93,23 @@ func setupMetricsRouter(cfg *types.Config, back types.ServerlessBackend, agg *me
 	router.GET("/system/metrics", MakeMetricsSummaryHandler(cfg, back, agg))
 	router.GET("/system/metrics/", MakeMetricsSummaryHandler(cfg, back, agg))
 	router.GET("/system/metrics/breakdown", MakeMetricsBreakdownHandler(cfg, back, agg))
+	router.GET("/system/metrics/owners", MakeMetricsOwnersHandler(cfg, back))
 	router.GET("/system/metrics/:serviceName", MakeMetricValueHandler(cfg, back, agg))
 	return router
+}
+
+func createMetricsOwnerNamespace(t *testing.T, back types.ServerlessBackend, name, owner string) {
+	t.Helper()
+	_, err := back.GetKubeClientset().CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      map[string]string{"app.kubernetes.io/managed-by": "oscar"},
+			Annotations: map[string]string{"oscar.grycap.upv.es/owner": owner},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create metrics owner namespace: %v", err)
+	}
 }
 
 func TestMetricValueHandler(t *testing.T) {
@@ -192,17 +210,19 @@ func TestMetricValueHandlerBasicAuthAllowsDeletedServiceHistory(t *testing.T) {
 	}
 }
 
-func TestMetricValueHandlerOIDCDeletedServiceNotFound(t *testing.T) {
+func TestMetricValueHandlerOIDCDeletedOwnedService(t *testing.T) {
 	back := backends.MakeFakeBackend()
 	back.AddError("ReadService", apierrors.NewNotFound(schema.GroupResource{Resource: "services"}, "deleted-svc"))
+	cfg := &types.Config{ServicesNamespace: "oscar-svc"}
+	ownerNamespace := utils.BuildUserNamespace(cfg, "u1")
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
-				{ServiceID: "deleted-svc", UserID: "u1", Type: metrics.RequestSync},
+				{ServiceID: "deleted-svc", ServiceNamespace: ownerNamespace, UserID: "u1", Type: metrics.RequestSync},
 			}},
 		},
 	}
-	router := setupMetricsRouter(&types.Config{}, back, agg, func(c *gin.Context) {
+	router := setupMetricsRouter(cfg, back, agg, func(c *gin.Context) {
 		c.Set("uidOrigin", "u1")
 		c.Next()
 	})
@@ -212,8 +232,15 @@ func TestMetricValueHandlerOIDCDeletedServiceNotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp types.MetricValueResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unexpected json error: %v", err)
+	}
+	if resp.Value != 1 {
+		t.Fatalf("expected one historical request, got %v", resp.Value)
 	}
 }
 
@@ -349,7 +376,7 @@ func TestMetricsSummaryTimeRangeOrder(t *testing.T) {
 	}
 }
 
-func TestMetricsSummaryHandlerScopesOIDCToVisibleServices(t *testing.T) {
+func TestMetricsSummaryHandlerScopesOIDCToOwnedServices(t *testing.T) {
 	back := backends.MakeFakeBackend()
 	back.Services = []*types.Service{
 		{Name: "svc-public", Owner: "owner@example.org", Visibility: types.PUBLIC},
@@ -406,20 +433,20 @@ func TestMetricsSummaryHandlerScopesOIDCToVisibleServices(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unexpected json error: %v", err)
 	}
-	if resp.Totals.ServicesCountActive != 3 {
-		t.Fatalf("expected 3 visible services, got %d", resp.Totals.ServicesCountActive)
+	if resp.Totals.ServicesCountActive != 1 {
+		t.Fatalf("expected 1 owned service, got %d", resp.Totals.ServicesCountActive)
 	}
-	if resp.Totals.ServicesCountTotal != 3 {
-		t.Fatalf("expected 3 visible services in totals, got %d", resp.Totals.ServicesCountTotal)
+	if resp.Totals.ServicesCountTotal != 1 {
+		t.Fatalf("expected 1 owned service in totals, got %d", resp.Totals.ServicesCountTotal)
 	}
-	if resp.Totals.CPUHoursTotal != 6 {
-		t.Fatalf("expected scoped CPU total 6, got %v", resp.Totals.CPUHoursTotal)
+	if resp.Totals.CPUHoursTotal != 2 {
+		t.Fatalf("expected scoped CPU total 2, got %v", resp.Totals.CPUHoursTotal)
 	}
-	if resp.Totals.RequestsCountTotal != 3 {
-		t.Fatalf("expected scoped request total 3, got %d", resp.Totals.RequestsCountTotal)
+	if resp.Totals.RequestsCountTotal != 1 {
+		t.Fatalf("expected scoped request total 1, got %d", resp.Totals.RequestsCountTotal)
 	}
-	if resp.Totals.UsersCount != 3 {
-		t.Fatalf("expected scoped users count 3, got %d", resp.Totals.UsersCount)
+	if resp.Totals.UsersCount != 1 {
+		t.Fatalf("expected scoped users count 1, got %d", resp.Totals.UsersCount)
 	}
 }
 
@@ -473,16 +500,110 @@ func TestMetricsSummaryHandlerBasicAuthSeesAllServices(t *testing.T) {
 	}
 }
 
-func TestMetricsBreakdownHandlerScopesOIDCToVisibleServices(t *testing.T) {
+func TestMetricsSummaryHandlerAdminOwnerFilterIncludesDeletedServices(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	cfg := &types.Config{ServicesNamespace: "oscar-svc"}
+	ownerNamespace := utils.BuildUserNamespace(cfg, "owner@example.org")
+	otherNamespace := utils.BuildUserNamespace(cfg, "other@example.org")
+	createMetricsOwnerNamespace(t, back, ownerNamespace, "owner@example.org")
+	createMetricsOwnerNamespace(t, back, otherNamespace, "other@example.org")
+	back.Services = []*types.Service{
+		{Name: "active-owned", Owner: "owner@example.org", Namespace: ownerNamespace},
+		{Name: "active-other", Owner: "other@example.org", Namespace: otherNamespace},
+	}
+	agg := &metrics.Aggregator{Sources: metrics.Sources{
+		ServiceInventory: &fakeServiceInventory{services: []metrics.ServiceDescriptor{
+			{ID: "active-owned", Namespace: ownerNamespace},
+			{ID: "active-other", Namespace: otherNamespace},
+		}},
+		RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
+			{ServiceID: "active-owned", ServiceNamespace: ownerNamespace, UserID: "u1", Type: metrics.RequestSync},
+			{ServiceID: "deleted-owned", ServiceNamespace: ownerNamespace, UserID: "u2", Type: metrics.RequestAsync},
+			{ServiceID: "active-other", ServiceNamespace: otherNamespace, UserID: "u3", Type: metrics.RequestSync},
+		}},
+		CountrySource: &fakeCountrySource{},
+	}}
+	router := setupMetricsRouter(cfg, back, agg)
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics?owner=owner%40example.org&start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp types.MetricsSummaryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unexpected json error: %v", err)
+	}
+	if resp.Totals.ServicesCountActive != 1 || resp.Totals.ServicesCountTotal != 2 {
+		t.Fatalf("expected one active and two total owned services, got %+v", resp.Totals)
+	}
+	if resp.Totals.RequestsCountTotal != 2 {
+		t.Fatalf("expected two owned requests, got %d", resp.Totals.RequestsCountTotal)
+	}
+}
+
+func TestMetricsOwnersHandlerListsPersistentNamespaceOwners(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	cfg := &types.Config{ServicesNamespace: "oscar-svc"}
+	namespace := utils.BuildUserNamespace(cfg, "owner@example.org")
+	createMetricsOwnerNamespace(t, back, namespace, "owner@example.org")
+	back.Services = []*types.Service{{
+		Name:      "owned",
+		Owner:     "owner@example.org",
+		Namespace: namespace,
+		Labels:    map[string]string{"owner_name": "Owner_Name"},
+	}}
+	router := setupMetricsRouter(cfg, back, &metrics.Aggregator{})
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics/owners", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp types.MetricsOwnersResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unexpected json error: %v", err)
+	}
+	if len(resp.Owners) != 2 {
+		t.Fatalf("expected cluster admin and persistent owner, got %+v", resp.Owners)
+	}
+	found := false
+	for _, owner := range resp.Owners {
+		if owner.ID == "owner@example.org" {
+			found = owner.Name == "Owner Name" && owner.Namespace == namespace
+		}
+	}
+	if !found {
+		t.Fatalf("expected enriched persistent owner, got %+v", resp.Owners)
+	}
+}
+
+func TestMetricsOwnersHandlerRejectsBearerAuth(t *testing.T) {
+	back := backends.MakeFakeBackend()
+	router := setupMetricsRouter(&types.Config{}, back, &metrics.Aggregator{})
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics/owners", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestMetricsBreakdownHandlerScopesOIDCToOwnedServices(t *testing.T) {
 	back := backends.MakeFakeBackend()
 	back.Services = []*types.Service{
 		{Name: "svc-public", Owner: "owner@example.org", Visibility: types.PUBLIC},
+		{Name: "svc-owned", Owner: "user@example.org", Visibility: types.PRIVATE},
 		{Name: "svc-private", Owner: "owner@example.org", Visibility: types.PRIVATE},
 	}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			RequestLogs: &fakeRequestLogs{records: []metrics.RequestRecord{
 				{ServiceID: "svc-public", UserID: "u1", Type: metrics.RequestSync, Country: "ES"},
+				{ServiceID: "svc-owned", UserID: "u1", Type: metrics.RequestSync, Country: "ES"},
 				{ServiceID: "svc-private", UserID: "u2", Type: metrics.RequestAsync, Country: "FR"},
 			}},
 		},
@@ -508,14 +629,14 @@ func TestMetricsBreakdownHandlerScopesOIDCToVisibleServices(t *testing.T) {
 	if len(resp.Items) != 1 {
 		t.Fatalf("expected 1 visible service in breakdown, got %d", len(resp.Items))
 	}
-	if resp.Items[0].Key != "svc-public" {
-		t.Fatalf("expected only svc-public in breakdown, got %s", resp.Items[0].Key)
+	if resp.Items[0].Key != "svc-owned" {
+		t.Fatalf("expected only svc-owned in breakdown, got %s", resp.Items[0].Key)
 	}
 }
 
-func TestMetricValueHandlerRejectsUnauthorizedOIDCService(t *testing.T) {
+func TestMetricValueHandlerRejectsPublicServiceOwnedByAnotherOIDCUser(t *testing.T) {
 	back := backends.MakeFakeBackend()
-	back.Service = &types.Service{Name: "svc-private", Owner: "owner@example.org", Visibility: types.PRIVATE}
+	back.Service = &types.Service{Name: "svc-public", Owner: "owner@example.org", Visibility: types.PUBLIC}
 	agg := &metrics.Aggregator{
 		Sources: metrics.Sources{
 			UsageMetrics: &fakeUsageMetrics{cpu: 2.5, gpu: 1.0},
@@ -526,7 +647,7 @@ func TestMetricValueHandlerRejectsUnauthorizedOIDCService(t *testing.T) {
 		c.Next()
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/system/metrics/svc-private?metric=cpu-hours&start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
+	req := httptest.NewRequest(http.MethodGet, "/system/metrics/svc-public?metric=cpu-hours&start=2026-01-01T00:00:00Z&end=2026-01-02T00:00:00Z", nil)
 	req.Header.Set("Authorization", "Bearer token")
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)

--- a/pkg/handlers/run.go
+++ b/pkg/handlers/run.go
@@ -129,9 +129,14 @@ func MakeRunHandler(cfg *types.Config, back types.SyncBackend) gin.HandlerFunc {
 			c.String(http.StatusBadRequest, "invalid workload: try to reduce the service resource (cpu, memory, etc.)")
 			return
 		}
+		serviceNamespace := service.Namespace
+		if serviceNamespace == "" {
+			serviceNamespace = utils.BuildUserNamespace(cfg, service.Owner)
+		}
+		auth.SetMetricsServiceContext(c, service.Name, serviceNamespace)
 
 		proxy := &httputil.ReverseProxy{
-			Director: back.GetProxyDirector(service.Name, service.Namespace),
+			Director: back.GetProxyDirector(service.Name, serviceNamespace),
 		}
 		proxy.ServeHTTP(c.Writer, c.Request) // #nosec
 	}

--- a/pkg/handlers/service_access.go
+++ b/pkg/handlers/service_access.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -15,17 +14,8 @@ func isBearerRequest(c *gin.Context) bool {
 	return strings.HasPrefix(c.GetHeader("Authorization"), "Bearer ")
 }
 
-func isServiceAccessibleByUser(service *types.Service, uid string) bool {
-	if service == nil {
-		return false
-	}
-	if service.Visibility == types.PUBLIC {
-		return true
-	}
-	if uid == service.Owner {
-		return true
-	}
-	return service.Visibility == types.RESTRICTED && slices.Contains(service.AllowedUsers, uid)
+func isServiceOwnedByUser(service *types.Service, uid string) bool {
+	return service != nil && service.Owner == uid
 }
 
 func listAuthorizedServicesForMetrics(c *gin.Context, back types.ServerlessBackend) ([]*types.Service, bool) {
@@ -46,35 +36,34 @@ func listAuthorizedServicesForMetrics(c *gin.Context, back types.ServerlessBacke
 
 	filtered := make([]*types.Service, 0, len(services))
 	for _, service := range services {
-		if isServiceAccessibleByUser(service, uid) {
+		if isServiceOwnedByUser(service, uid) {
 			filtered = append(filtered, service)
 		}
 	}
 	return filtered, true
 }
 
-func getAuthorizedServiceForMetrics(c *gin.Context, back types.ServerlessBackend, serviceName string) (*types.Service, bool) {
+// authorizeServiceMetricsQuery permits an OIDC user to query a service that no
+// longer exists. The metrics sources still constrain that query to the user's
+// namespace, so a missing live service cannot expose another user's data.
+func authorizeServiceMetricsQuery(c *gin.Context, back types.ServerlessBackend, serviceName string) bool {
 	service, err := back.ReadService("", serviceName)
 	if err != nil {
 		if errors.IsNotFound(err) || errors.IsGone(err) {
-			c.Status(http.StatusNotFound)
-		} else {
-			c.String(http.StatusInternalServerError, err.Error())
+			return true
 		}
-		return nil, false
-	}
-	if !isBearerRequest(c) {
-		return service, true
+		c.String(http.StatusInternalServerError, err.Error())
+		return false
 	}
 
 	uid, err := auth.GetUIDFromContext(c)
 	if err != nil {
 		c.String(http.StatusUnauthorized, err.Error())
-		return nil, false
+		return false
 	}
-	if !isServiceAccessibleByUser(service, uid) {
+	if !isServiceOwnedByUser(service, uid) {
 		c.Status(http.StatusForbidden)
-		return nil, false
+		return false
 	}
-	return service, true
+	return true
 }

--- a/pkg/handlers/service_access_test.go
+++ b/pkg/handlers/service_access_test.go
@@ -41,7 +41,7 @@ func TestIsBearerRequest(t *testing.T) {
 	}
 }
 
-func TestIsServiceAccessibleByUser(t *testing.T) {
+func TestIsServiceOwnedByUser(t *testing.T) {
 	publicSvc := &types.Service{
 		Name:         "public",
 		Visibility:   types.PUBLIC,
@@ -68,10 +68,10 @@ func TestIsServiceAccessibleByUser(t *testing.T) {
 		expected bool
 	}{
 		{"Nil service", nil, "user", false},
-		{"Public service any user", publicSvc, "anyone", true},
-		{"Public service anonymous", publicSvc, "", true},
+		{"Public service owner", publicSvc, "owner", true},
+		{"Public service other user", publicSvc, "anyone", false},
 		{"Restricted service owner", restrictedSvc, "owner", true},
-		{"Restricted service allowed user", restrictedSvc, "user1", true},
+		{"Restricted service allowed user", restrictedSvc, "user1", false},
 		{"Restricted service not allowed", restrictedSvc, "user3", false},
 		{"Private service owner", privateSvc, "owner", true},
 		{"Private service other", privateSvc, "other", false},
@@ -79,9 +79,9 @@ func TestIsServiceAccessibleByUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isServiceAccessibleByUser(tt.service, tt.uid)
+			result := isServiceOwnedByUser(tt.service, tt.uid)
 			if result != tt.expected {
-				t.Errorf("isServiceAccessibleByUser(%v, %q) = %v, want %v", tt.service, tt.uid, result, tt.expected)
+				t.Errorf("isServiceOwnedByUser(%v, %q) = %v, want %v", tt.service, tt.uid, result, tt.expected)
 			}
 		})
 	}
@@ -127,6 +127,29 @@ func TestListAuthorizedServicesForMetrics(t *testing.T) {
 		}
 		if w.Code != http.StatusInternalServerError {
 			t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+		}
+	})
+
+	t.Run("Bearer request only returns owned services", func(t *testing.T) {
+		back := backends.MakeFakeBackend()
+		back.Services = []*types.Service{
+			{Name: "owned", Visibility: types.PRIVATE, Owner: "user1"},
+			{Name: "public-other", Visibility: types.PUBLIC, Owner: "owner1"},
+			{Name: "restricted-other", Visibility: types.RESTRICTED, Owner: "owner2", AllowedUsers: []string{"user1"}},
+		}
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", "/", nil)
+		c.Request.Header.Set("Authorization", "Bearer token")
+		c.Set("uidOrigin", "user1")
+
+		services, ok := listAuthorizedServicesForMetrics(c, back)
+		if !ok {
+			t.Fatal("expected ok = true")
+		}
+		if len(services) != 1 || services[0].Name != "owned" {
+			t.Fatalf("expected only the owned service, got %v", services)
 		}
 	})
 }

--- a/pkg/metrics/aggregators.go
+++ b/pkg/metrics/aggregators.go
@@ -182,6 +182,14 @@ func (a *Aggregator) sumUsage(ctx context.Context, tr TimeRange, services []Serv
 		}
 		return cpuTotal, gpuTotal, status
 	}
+	if scopedSource, ok := a.Sources.UsageMetrics.(interface {
+		UsageHoursAll(context.Context, TimeRange) (float64, float64, *types.SourceStatus, error)
+	}); ok {
+		cpuTotal, gpuTotal, status, err := scopedSource.UsageHoursAll(ctx, tr)
+		if err == nil || !errors.Is(err, errScopedUsageUnsupported) {
+			return cpuTotal, gpuTotal, status
+		}
+	}
 
 	var cpuTotal float64
 	var gpuTotal float64

--- a/pkg/metrics/aggregators_test.go
+++ b/pkg/metrics/aggregators_test.go
@@ -285,6 +285,26 @@ func TestBuildLokiQuery(t *testing.T) {
 	}
 }
 
+func TestBuildLokiQueryWithUserScope(t *testing.T) {
+	source := LokiRequestLogSource{
+		QueryTemplate:    `{namespace="{{namespace}}", app="{{app}}"}`,
+		Namespace:        "oscar",
+		AppLabel:         "oscar",
+		ServiceFilterAll: `"\\[GIN-EXECUTIONS-LOGGER\\]" |~ "/(job|run)"`,
+		scope: &QueryScope{
+			OwnerNamespace: "oscar-svc-user",
+			ActiveServices: []ServiceScope{{Name: "shared-service"}},
+		},
+	}
+	query := source.buildQuery("")
+	if !strings.Contains(query, "oscar-svc-user") {
+		t.Fatalf("expected owner namespace filter, got %s", query)
+	}
+	if !strings.Contains(query, "shared-service") {
+		t.Fatalf("expected active service fallback, got %s", query)
+	}
+}
+
 func TestParseGinExecutionLogFromGinPrefix(t *testing.T) {
 	line := "[GIN] 2026-01-20T10:00:00Z | 200 |  12.345ms | 10.0.0.1 | POST    /job/test-service | user@example.com"
 	record, ok := parseGinExecutionLog(line, &types.Config{})
@@ -306,6 +326,20 @@ func TestParseGinExecutionLogFromGinPrefix(t *testing.T) {
 	}
 }
 
+func TestParseGinExecutionLogWithServiceNamespace(t *testing.T) {
+	line := "[GIN-EXECUTIONS-LOGGER] 2026-01-20T10:00:00Z | 200 | 12ms | 10.0.0.1 | POST /job/path-service | caller | logged-service | oscar-svc-user"
+	record, ok := parseGinExecutionLog(line, &types.Config{})
+	if !ok {
+		t.Fatal("expected log line to parse")
+	}
+	if record.ServiceID != "logged-service" {
+		t.Fatalf("expected logged service identity, got %s", record.ServiceID)
+	}
+	if record.ServiceNamespace != "oscar-svc-user" {
+		t.Fatalf("expected service namespace, got %s", record.ServiceNamespace)
+	}
+}
+
 func TestParseIngressAccessLog(t *testing.T) {
 	line := "172.18.0.1 - - [23/Jan/2026:18:13:07 +0000] \"GET /system/services/gmolto-nginx/exposed/ HTTP/1.1\" 200 17 \"-\" \"curl/8.7.1\" 109 0.003 [oscar-svc-gmolto-nginx-svc-80] [] 10.244.0.223:80 17 0.002 200 a72c147a794286b864361ecca7a31075"
 	record, ok := parseIngressAccessLog(line, &types.Config{})
@@ -315,8 +349,25 @@ func TestParseIngressAccessLog(t *testing.T) {
 	if record.ServiceID != "gmolto-nginx" {
 		t.Fatalf("expected serviceID gmolto-nginx, got %s", record.ServiceID)
 	}
+	if record.ServiceNamespace != "oscar-svc" {
+		t.Fatalf("expected ingress namespace oscar-svc, got %s", record.ServiceNamespace)
+	}
 	if record.Timestamp.IsZero() {
 		t.Fatal("expected timestamp to be parsed")
+	}
+}
+
+func TestParseTraefikDNSAccessLog(t *testing.T) {
+	line := `{"StartUTC":"15/Aug/2026:12:30:00 +0000","RequestHost":"demo.example.org","RouterName":"oscar-svc-user-demo-route@kubernetesgateway","ServiceName":"oscar-svc-user-demo-svc-80@kubernetesgateway"}`
+	record, ok := parseHTTPAccessLog(line, &types.Config{ExposedServicesUseSubdomainRoute: true})
+	if !ok {
+		t.Fatal("expected Traefik access log to parse")
+	}
+	if record.ServiceID != "demo" {
+		t.Fatalf("expected serviceID demo, got %s", record.ServiceID)
+	}
+	if record.ServiceNamespace != "oscar-svc-user" {
+		t.Fatalf("expected Traefik service namespace, got %s", record.ServiceNamespace)
 	}
 }
 

--- a/pkg/metrics/aggregators_test.go
+++ b/pkg/metrics/aggregators_test.go
@@ -33,6 +33,23 @@ type fakeUsageMetrics struct {
 	err          error
 }
 
+type fakeAggregateUsageMetrics struct {
+	cpu    float64
+	gpu    float64
+	status *types.SourceStatus
+	err    error
+}
+
+func (f *fakeAggregateUsageMetrics) Name() string { return "aggregate-usage" }
+
+func (f *fakeAggregateUsageMetrics) UsageHours(context.Context, TimeRange, string) (float64, float64, *types.SourceStatus, error) {
+	return 0, 0, nil, errors.New("per-service usage should not be called")
+}
+
+func (f *fakeAggregateUsageMetrics) UsageHoursAll(context.Context, TimeRange) (float64, float64, *types.SourceStatus, error) {
+	return f.cpu, f.gpu, f.status, f.err
+}
+
 func (f *fakeUsageMetrics) Name() string {
 	return "usage-metrics"
 }
@@ -42,6 +59,31 @@ func (f *fakeUsageMetrics) UsageHours(ctx context.Context, tr TimeRange, service
 		return 0, 0, missingStatus(f.Name(), f.err), f.err
 	}
 	return f.cpuByService[serviceID], f.gpuByService[serviceID], okStatus(f.Name(), ""), nil
+}
+
+func TestSumUsageUsesScopedAggregateSource(t *testing.T) {
+	wantStatus := &types.SourceStatus{Name: "aggregate-usage", Status: "partial"}
+	agg := Aggregator{Sources: Sources{UsageMetrics: &fakeAggregateUsageMetrics{
+		cpu: 3, gpu: 4, status: wantStatus, err: errors.New("partial query"),
+	}}}
+
+	cpu, gpu, status := agg.sumUsage(t.Context(), TimeRange{}, []ServiceDescriptor{{ID: "svc"}})
+	if cpu != 3 || gpu != 4 || status != wantStatus {
+		t.Fatalf("sumUsage() = (%v, %v, %#v), want (3, 4, %#v)", cpu, gpu, status, wantStatus)
+	}
+}
+
+func TestSumUsageFallsBackWhenScopedAggregateUnsupported(t *testing.T) {
+	source := &scopedUsageMetricsSource{inner: &fakeUsageMetrics{
+		cpuByService: map[string]float64{"svc": 2},
+		gpuByService: map[string]float64{"svc": 1},
+	}}
+	agg := Aggregator{Sources: Sources{UsageMetrics: source}}
+
+	cpu, gpu, status := agg.sumUsage(t.Context(), TimeRange{}, []ServiceDescriptor{{ID: "svc"}})
+	if cpu != 2 || gpu != 1 || status == nil || status.Status != "ok" {
+		t.Fatalf("sumUsage() = (%v, %v, %#v), want (2, 1, ok)", cpu, gpu, status)
+	}
 }
 
 type fakeRequestLogs struct {

--- a/pkg/metrics/scoped.go
+++ b/pkg/metrics/scoped.go
@@ -2,13 +2,31 @@ package metrics
 
 import (
 	"context"
+	"errors"
+	"regexp"
 
 	"github.com/grycap/oscar/v4/pkg/types"
 )
 
+var errScopedUsageUnsupported = errors.New("scoped aggregate usage is not supported by this source")
+
+// ServiceScope identifies an active service owned by the selected metrics owner.
+// Namespace is required to keep services with the same name isolated.
+type ServiceScope struct {
+	Name      string
+	Namespace string
+}
+
+// QueryScope limits metrics to an owner's namespace and active services.
+// An empty OwnerNamespace represents an unscoped admin query.
+type QueryScope struct {
+	OwnerNamespace string
+	ActiveServices []ServiceScope
+}
+
 type scopedServiceInventorySource struct {
-	inner   ServiceInventorySource
-	allowed map[string]struct{}
+	inner ServiceInventorySource
+	scope QueryScope
 }
 
 func (s *scopedServiceInventorySource) Name() string {
@@ -17,11 +35,12 @@ func (s *scopedServiceInventorySource) Name() string {
 
 func (s *scopedServiceInventorySource) ListServices(ctx context.Context, tr TimeRange) ([]ServiceDescriptor, *types.SourceStatus, error) {
 	services, status, err := s.inner.ListServices(ctx, tr)
-	return filterServiceDescriptors(services, s.allowed), status, err
+	return filterServiceDescriptors(services, s.scope), status, err
 }
 
 type scopedUsageMetricsSource struct {
 	inner UsageMetricsSource
+	scope QueryScope
 }
 
 func (s *scopedUsageMetricsSource) Name() string {
@@ -29,12 +48,94 @@ func (s *scopedUsageMetricsSource) Name() string {
 }
 
 func (s *scopedUsageMetricsSource) UsageHours(ctx context.Context, tr TimeRange, serviceID string) (float64, float64, *types.SourceStatus, error) {
-	return s.inner.UsageHours(ctx, tr, serviceID)
+	prom, ok := s.inner.(*PrometheusUsageMetricsSource)
+	if !ok {
+		return s.inner.UsageHours(ctx, tr, serviceID)
+	}
+
+	namespaces := s.namespacesForService(serviceID)
+	return sumPrometheusUsage(ctx, prom, tr, serviceID, namespaces)
+}
+
+// UsageHoursAll lets the aggregator issue one query for all services in the
+// owner's namespace instead of one query per currently deployed service.
+func (s *scopedUsageMetricsSource) UsageHoursAll(ctx context.Context, tr TimeRange) (float64, float64, *types.SourceStatus, error) {
+	prom, ok := s.inner.(*PrometheusUsageMetricsSource)
+	if !ok {
+		return 0, 0, nil, errScopedUsageUnsupported
+	}
+
+	cpu, gpu, status, err := prom.UsageHoursInNamespace(
+		ctx,
+		tr,
+		regexp.QuoteMeta(s.scope.OwnerNamespace),
+		".*",
+	)
+	if err != nil {
+		return cpu, gpu, status, err
+	}
+
+	for _, service := range s.scope.ActiveServices {
+		if service.Namespace == "" || service.Namespace == s.scope.OwnerNamespace {
+			continue
+		}
+		serviceCPU, serviceGPU, serviceStatus, serviceErr := prom.UsageHoursInNamespace(
+			ctx,
+			tr,
+			regexp.QuoteMeta(service.Namespace),
+			regexp.QuoteMeta(service.Name),
+		)
+		status = mergeSourceStatus(status, serviceStatus)
+		if serviceErr != nil {
+			return cpu, gpu, status, serviceErr
+		}
+		cpu += serviceCPU
+		gpu += serviceGPU
+	}
+
+	return cpu, gpu, status, nil
+}
+
+func (s *scopedUsageMetricsSource) namespacesForService(serviceID string) []string {
+	namespaces := []string{s.scope.OwnerNamespace}
+	seen := map[string]struct{}{s.scope.OwnerNamespace: {}}
+	for _, service := range s.scope.ActiveServices {
+		if service.Name != serviceID || service.Namespace == "" {
+			continue
+		}
+		if _, ok := seen[service.Namespace]; ok {
+			continue
+		}
+		seen[service.Namespace] = struct{}{}
+		namespaces = append(namespaces, service.Namespace)
+	}
+	return namespaces
+}
+
+func sumPrometheusUsage(ctx context.Context, prom *PrometheusUsageMetricsSource, tr TimeRange, serviceID string, namespaces []string) (float64, float64, *types.SourceStatus, error) {
+	var cpuTotal float64
+	var gpuTotal float64
+	var combinedStatus *types.SourceStatus
+	for _, namespace := range namespaces {
+		cpu, gpu, status, err := prom.UsageHoursInNamespace(
+			ctx,
+			tr,
+			regexp.QuoteMeta(namespace),
+			regexp.QuoteMeta(serviceID),
+		)
+		combinedStatus = mergeSourceStatus(combinedStatus, status)
+		if err != nil {
+			return cpuTotal, gpuTotal, combinedStatus, err
+		}
+		cpuTotal += cpu
+		gpuTotal += gpu
+	}
+	return cpuTotal, gpuTotal, combinedStatus, nil
 }
 
 type scopedRequestLogSource struct {
-	inner   RequestLogSource
-	allowed map[string]struct{}
+	inner RequestLogSource
+	scope QueryScope
 }
 
 func (s *scopedRequestLogSource) Name() string {
@@ -46,74 +147,104 @@ func (s *scopedRequestLogSource) ListRequests(ctx context.Context, cfg *types.Co
 	if err != nil {
 		return records, status, err
 	}
-	return filterRequestRecords(records, s.allowed), status, nil
+	return filterRequestRecords(records, s.scope), status, nil
 }
 
-func ScopeSources(src Sources, allowedServiceIDs map[string]struct{}) Sources {
-	if allowedServiceIDs == nil {
+func ScopeSources(src Sources, scope QueryScope) Sources {
+	if scope.OwnerNamespace == "" {
 		return src
 	}
 
 	scoped := src
 	if src.ServiceInventory != nil {
-		scoped.ServiceInventory = &scopedServiceInventorySource{
-			inner:   src.ServiceInventory,
-			allowed: cloneAllowedServices(allowedServiceIDs),
-		}
+		scoped.ServiceInventory = &scopedServiceInventorySource{inner: src.ServiceInventory, scope: scope}
 	}
 	if src.UsageMetrics != nil {
-		// Wrap usage metrics so sumUsage falls back to per-service iteration
-		// instead of issuing a cluster-wide wildcard query.
-		scoped.UsageMetrics = &scopedUsageMetricsSource{inner: src.UsageMetrics}
+		scoped.UsageMetrics = &scopedUsageMetricsSource{inner: src.UsageMetrics, scope: scope}
 	}
 	if src.RequestLogs != nil {
-		scoped.RequestLogs = &scopedRequestLogSource{
-			inner:   src.RequestLogs,
-			allowed: cloneAllowedServices(allowedServiceIDs),
-		}
+		inner := scopeLokiSource(src.RequestLogs, scope)
+		scoped.RequestLogs = &scopedRequestLogSource{inner: inner, scope: scope}
 	}
 	if src.ExposedRequestLogs != nil {
-		scoped.ExposedRequestLogs = &scopedRequestLogSource{
-			inner:   src.ExposedRequestLogs,
-			allowed: cloneAllowedServices(allowedServiceIDs),
-		}
+		inner := scopeLokiSource(src.ExposedRequestLogs, scope)
+		scoped.ExposedRequestLogs = &scopedRequestLogSource{inner: inner, scope: scope}
 	}
 	return scoped
 }
 
-func cloneAllowedServices(allowed map[string]struct{}) map[string]struct{} {
-	if allowed == nil {
-		return nil
+func scopeLokiSource(source RequestLogSource, scope QueryScope) RequestLogSource {
+	loki, ok := source.(*LokiRequestLogSource)
+	if !ok {
+		return source
 	}
-	cloned := make(map[string]struct{}, len(allowed))
-	for serviceID := range allowed {
-		cloned[serviceID] = struct{}{}
-	}
-	return cloned
+	cloned := *loki
+	clonedScope := scope
+	cloned.scope = &clonedScope
+	return &cloned
 }
 
-func filterServiceDescriptors(services []ServiceDescriptor, allowed map[string]struct{}) []ServiceDescriptor {
-	if allowed == nil {
+func filterServiceDescriptors(services []ServiceDescriptor, scope QueryScope) []ServiceDescriptor {
+	if scope.OwnerNamespace == "" {
 		return services
 	}
 	filtered := make([]ServiceDescriptor, 0, len(services))
 	for _, service := range services {
-		if _, ok := allowed[service.ID]; ok {
+		if service.Namespace == scope.OwnerNamespace || activeServiceAllowed(scope, service.ID, service.Namespace) {
 			filtered = append(filtered, service)
 		}
 	}
 	return filtered
 }
 
-func filterRequestRecords(records []RequestRecord, allowed map[string]struct{}) []RequestRecord {
-	if allowed == nil {
+func filterRequestRecords(records []RequestRecord, scope QueryScope) []RequestRecord {
+	if scope.OwnerNamespace == "" {
 		return records
 	}
 	filtered := make([]RequestRecord, 0, len(records))
 	for _, record := range records {
-		if _, ok := allowed[record.ServiceID]; ok {
+		if record.ServiceNamespace == scope.OwnerNamespace || activeServiceAllowed(scope, record.ServiceID, record.ServiceNamespace) {
+			filtered = append(filtered, record)
+			continue
+		}
+		// Legacy execution records have no namespace. Preserve access only for
+		// services that are still owned; deleted services require the new field.
+		if record.ServiceNamespace == "" && activeServiceAllowed(scope, record.ServiceID, "") {
 			filtered = append(filtered, record)
 		}
 	}
 	return filtered
+}
+
+func activeServiceAllowed(scope QueryScope, name, namespace string) bool {
+	for _, service := range scope.ActiveServices {
+		if service.Name != name {
+			continue
+		}
+		if namespace == "" || service.Namespace == "" || service.Namespace == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeSourceStatus(left, right *types.SourceStatus) *types.SourceStatus {
+	if left == nil {
+		return right
+	}
+	if right == nil {
+		return left
+	}
+	if left.Status == "missing" || right.Status == "missing" {
+		left.Status = "missing"
+	} else if left.Status == "partial" || right.Status == "partial" {
+		left.Status = "partial"
+	}
+	if right.Notes != "" {
+		if left.Notes != "" {
+			left.Notes += "; "
+		}
+		left.Notes += right.Notes
+	}
+	return left
 }

--- a/pkg/metrics/scoped_test.go
+++ b/pkg/metrics/scoped_test.go
@@ -2,11 +2,43 @@ package metrics
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/grycap/oscar/v4/pkg/types"
 )
+
+func newScopedPrometheusSource(t *testing.T, queries *[]string) *PrometheusUsageMetricsSource {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm() error: %v", err)
+		}
+		query := r.Form.Get("query")
+		*queries = append(*queries, query)
+		value := "1"
+		if strings.Contains(query, "gpu:") {
+			value = "2"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,%q]}]}}`, value)
+	}))
+	t.Cleanup(server.Close)
+	source, err := NewPrometheusUsageMetricsSource(
+		server.URL,
+		"cpu:{{namespace}}:{{service}}:{{range}}",
+		"gpu:{{namespace}}:{{service}}:{{range}}",
+		"unused",
+	)
+	if err != nil {
+		t.Fatalf("NewPrometheusUsageMetricsSource() error: %v", err)
+	}
+	return source
+}
 
 type mockServiceInventorySource struct {
 	services []ServiceDescriptor
@@ -200,6 +232,113 @@ func TestScopedUsageMetricsSource(t *testing.T) {
 	}
 	if mem != 2.0 {
 		t.Errorf("Expected mem=2.0, got %f", mem)
+	}
+}
+
+func TestScopedPrometheusUsageMetricsSource(t *testing.T) {
+	queries := []string{}
+	source := newScopedPrometheusSource(t, &queries)
+	scoped := &scopedUsageMetricsSource{
+		inner: source,
+		scope: QueryScope{
+			OwnerNamespace: "owner.ns",
+			ActiveServices: []ServiceScope{
+				{Name: "svc+one", Namespace: "owner.ns"},
+				{Name: "svc+one", Namespace: "legacy.ns"},
+				{Name: "svc+one", Namespace: "legacy.ns"},
+				{Name: "other", Namespace: "ignored.ns"},
+			},
+		},
+	}
+	tr := TimeRange{Start: time.Unix(0, 0), End: time.Unix(3600, 0)}
+
+	cpu, gpu, status, err := scoped.UsageHours(t.Context(), tr, "svc+one")
+	if err != nil {
+		t.Fatalf("UsageHours() error: %v", err)
+	}
+	if cpu != 2 || gpu != 4 {
+		t.Fatalf("UsageHours() = (%v, %v), want (2, 4); queries: %v", cpu, gpu, queries)
+	}
+	if status == nil || status.Status != "ok" {
+		t.Fatalf("UsageHours() status = %#v, want ok", status)
+	}
+	if len(queries) != 4 {
+		t.Fatalf("query count = %d, want 4", len(queries))
+	}
+	joined := strings.Join(queries, "\n")
+	for _, want := range []string{`owner\.ns`, `legacy\.ns`, `svc\+one`} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("queries do not contain %q: %s", want, joined)
+		}
+	}
+}
+
+func TestScopedPrometheusUsageHoursAll(t *testing.T) {
+	queries := []string{}
+	source := newScopedPrometheusSource(t, &queries)
+	scoped := &scopedUsageMetricsSource{
+		inner: source,
+		scope: QueryScope{
+			OwnerNamespace: "owner-ns",
+			ActiveServices: []ServiceScope{
+				{Name: "same", Namespace: "owner-ns"},
+				{Name: "legacy", Namespace: "legacy-ns"},
+				{Name: "empty"},
+			},
+		},
+	}
+
+	cpu, gpu, status, err := scoped.UsageHoursAll(t.Context(), TimeRange{Start: time.Unix(0, 0), End: time.Unix(60, 0)})
+	if err != nil {
+		t.Fatalf("UsageHoursAll() error: %v", err)
+	}
+	if cpu != 2 || gpu != 4 || status == nil || status.Status != "ok" {
+		t.Fatalf("UsageHoursAll() = (%v, %v, %#v), want (2, 4, ok)", cpu, gpu, status)
+	}
+	if len(queries) != 4 {
+		t.Fatalf("query count = %d, want 4", len(queries))
+	}
+	joined := strings.Join(queries, "\n")
+	if !strings.Contains(joined, "owner-ns:.*") || !strings.Contains(joined, "legacy-ns:legacy") {
+		t.Fatalf("unexpected queries: %s", joined)
+	}
+}
+
+func TestScopedUsageHoursAllUnsupported(t *testing.T) {
+	scoped := &scopedUsageMetricsSource{inner: &mockUsageMetricsSource{}}
+	if _, _, _, err := scoped.UsageHoursAll(t.Context(), TimeRange{}); err != errScopedUsageUnsupported {
+		t.Fatalf("UsageHoursAll() error = %v, want %v", err, errScopedUsageUnsupported)
+	}
+}
+
+func TestScopedUsageHelpers(t *testing.T) {
+	scoped := &scopedUsageMetricsSource{scope: QueryScope{
+		OwnerNamespace: "owner",
+		ActiveServices: []ServiceScope{
+			{Name: "svc", Namespace: ""},
+			{Name: "other", Namespace: "other"},
+			{Name: "svc", Namespace: "owner"},
+			{Name: "svc", Namespace: "legacy"},
+			{Name: "svc", Namespace: "legacy"},
+		},
+	}}
+	namespaces := scoped.namespacesForService("svc")
+	if got := strings.Join(namespaces, ","); got != "owner,legacy" {
+		t.Fatalf("namespacesForService() = %q, want %q", got, "owner,legacy")
+	}
+
+	left := &types.SourceStatus{Status: "ok", Notes: "first"}
+	right := &types.SourceStatus{Status: "partial", Notes: "second"}
+	merged := mergeSourceStatus(left, right)
+	if merged.Status != "partial" || merged.Notes != "first; second" {
+		t.Fatalf("mergeSourceStatus() = %#v", merged)
+	}
+	if mergeSourceStatus(nil, right) != right || mergeSourceStatus(left, nil) != left {
+		t.Fatal("mergeSourceStatus() should preserve non-nil status")
+	}
+	missing := mergeSourceStatus(&types.SourceStatus{Status: "ok"}, &types.SourceStatus{Status: "missing"})
+	if missing.Status != "missing" {
+		t.Fatalf("mergeSourceStatus() status = %q, want missing", missing.Status)
 	}
 }
 

--- a/pkg/metrics/scoped_test.go
+++ b/pkg/metrics/scoped_test.go
@@ -49,7 +49,7 @@ func TestScopeSourcesNilAllowed(t *testing.T) {
 		ServiceInventory: &mockServiceInventorySource{},
 	}
 
-	result := ScopeSources(src, nil)
+	result := ScopeSources(src, QueryScope{})
 	if result.ServiceInventory == nil {
 		t.Error("Expected ServiceInventory to be unchanged")
 	}
@@ -68,11 +68,12 @@ func TestScopeSourcesWithAllowed(t *testing.T) {
 		ExposedRequestLogs: &mockRequestLogSource{},
 	}
 
-	allowed := map[string]struct{}{
-		"svc1": {},
+	scope := QueryScope{
+		OwnerNamespace: "oscar-svc-user",
+		ActiveServices: []ServiceScope{{Name: "svc1"}},
 	}
 
-	result := ScopeSources(src, allowed)
+	result := ScopeSources(src, scope)
 	if result.ServiceInventory == nil {
 		t.Error("Expected ServiceInventory to be set")
 	}
@@ -87,43 +88,18 @@ func TestScopeSourcesWithAllowed(t *testing.T) {
 	}
 }
 
-func TestCloneAllowedServices(t *testing.T) {
-	allowed := map[string]struct{}{
-		"svc1": {},
-		"svc2": {},
-	}
-
-	cloned := cloneAllowedServices(allowed)
-	if cloned == nil {
-		t.Fatal("Expected non-nil")
-	}
-	if _, ok := cloned["svc1"]; !ok {
-		t.Error("Expected svc1 in cloned")
-	}
-	if _, ok := cloned["svc2"]; !ok {
-		t.Error("Expected svc2 in cloned")
-	}
-}
-
-func TestCloneAllowedServicesNil(t *testing.T) {
-	cloned := cloneAllowedServices(nil)
-	if cloned != nil {
-		t.Error("Expected nil for nil input")
-	}
-}
-
 func TestFilterServiceDescriptors(t *testing.T) {
 	services := []ServiceDescriptor{
-		{ID: "svc1"},
-		{ID: "svc2"},
-		{ID: "svc3"},
+		{ID: "svc1", Namespace: "oscar-svc-user"},
+		{ID: "svc2", Namespace: "oscar-svc-other"},
+		{ID: "svc3", Namespace: "oscar-svc-shared"},
 	}
-	allowed := map[string]struct{}{
-		"svc1": {},
-		"svc3": {},
+	scope := QueryScope{
+		OwnerNamespace: "oscar-svc-user",
+		ActiveServices: []ServiceScope{{Name: "svc3", Namespace: "oscar-svc-shared"}},
 	}
 
-	filtered := filterServiceDescriptors(services, allowed)
+	filtered := filterServiceDescriptors(services, scope)
 	if len(filtered) != 2 {
 		t.Errorf("Expected 2 services, got %d", len(filtered))
 	}
@@ -140,7 +116,7 @@ func TestFilterServiceDescriptorsNilAllowed(t *testing.T) {
 		{ID: "svc1"},
 	}
 
-	filtered := filterServiceDescriptors(services, nil)
+	filtered := filterServiceDescriptors(services, QueryScope{})
 	if len(filtered) != 1 {
 		t.Errorf("Expected 1 service, got %d", len(filtered))
 	}
@@ -148,21 +124,21 @@ func TestFilterServiceDescriptorsNilAllowed(t *testing.T) {
 
 func TestFilterRequestRecords(t *testing.T) {
 	records := []RequestRecord{
-		{ServiceID: "svc1"},
-		{ServiceID: "svc2"},
-		{ServiceID: "svc3"},
+		{ServiceID: "deleted", ServiceNamespace: "oscar-svc-user"},
+		{ServiceID: "svc2", ServiceNamespace: "oscar-svc-other"},
+		{ServiceID: "svc3", ServiceNamespace: "oscar-svc-shared"},
 	}
-	allowed := map[string]struct{}{
-		"svc1": {},
-		"svc3": {},
+	scope := QueryScope{
+		OwnerNamespace: "oscar-svc-user",
+		ActiveServices: []ServiceScope{{Name: "svc3", Namespace: "oscar-svc-shared"}},
 	}
 
-	filtered := filterRequestRecords(records, allowed)
+	filtered := filterRequestRecords(records, scope)
 	if len(filtered) != 2 {
 		t.Errorf("Expected 2 records, got %d", len(filtered))
 	}
-	if filtered[0].ServiceID != "svc1" {
-		t.Errorf("Expected svc1, got %s", filtered[0].ServiceID)
+	if filtered[0].ServiceID != "deleted" {
+		t.Errorf("Expected deleted, got %s", filtered[0].ServiceID)
 	}
 	if filtered[1].ServiceID != "svc3" {
 		t.Errorf("Expected svc3, got %s", filtered[1].ServiceID)
@@ -174,7 +150,7 @@ func TestFilterRequestRecordsNilAllowed(t *testing.T) {
 		{ServiceID: "svc1"},
 	}
 
-	filtered := filterRequestRecords(records, nil)
+	filtered := filterRequestRecords(records, QueryScope{})
 	if len(filtered) != 1 {
 		t.Errorf("Expected 1 record, got %d", len(filtered))
 	}
@@ -189,18 +165,14 @@ func TestScopedServiceInventorySource(t *testing.T) {
 
 	inner := &mockServiceInventorySource{
 		services: []ServiceDescriptor{
-			{ID: "svc1"},
-			{ID: "svc2"},
+			{ID: "svc1", Namespace: "oscar-svc-user"},
+			{ID: "svc2", Namespace: "oscar-svc-other"},
 		},
 	}
 
-	allowed := map[string]struct{}{
-		"svc1": {},
-	}
-
 	src := &scopedServiceInventorySource{
-		inner:   inner,
-		allowed: allowed,
+		inner: inner,
+		scope: QueryScope{OwnerNamespace: "oscar-svc-user"},
 	}
 
 	services, _, _ := src.ListServices(ctx, tr)
@@ -220,7 +192,7 @@ func TestScopedUsageMetricsSource(t *testing.T) {
 	}
 
 	inner := &mockUsageMetricsSource{}
-	src := &scopedUsageMetricsSource{inner: inner}
+	src := &scopedUsageMetricsSource{inner: inner, scope: QueryScope{OwnerNamespace: "oscar-svc-user"}}
 
 	cpu, mem, _, _ := src.UsageHours(ctx, tr, "svc1")
 	if cpu != 1.0 {
@@ -245,13 +217,12 @@ func TestScopedRequestLogSource(t *testing.T) {
 		},
 	}
 
-	allowed := map[string]struct{}{
-		"svc1": {},
-	}
-
 	src := &scopedRequestLogSource{
-		inner:   inner,
-		allowed: allowed,
+		inner: inner,
+		scope: QueryScope{
+			OwnerNamespace: "oscar-svc-user",
+			ActiveServices: []ServiceScope{{Name: "svc1"}},
+		},
 	}
 
 	records, _, _ := src.ListRequests(ctx, &types.Config{}, tr, "svc1")

--- a/pkg/metrics/sources.go
+++ b/pkg/metrics/sources.go
@@ -29,9 +29,10 @@ type TimeRange struct {
 }
 
 type ServiceDescriptor struct {
-	ID    string
-	Name  string
-	Image string
+	ID        string
+	Name      string
+	Image     string
+	Namespace string
 }
 
 type RequestType string
@@ -42,12 +43,13 @@ const (
 )
 
 type RequestRecord struct {
-	ServiceID  string
-	UserID     string
-	Country    string
-	AuthMethod string
-	Type       RequestType
-	Timestamp  time.Time
+	ServiceID        string
+	ServiceNamespace string
+	UserID           string
+	Country          string
+	AuthMethod       string
+	Type             RequestType
+	Timestamp        time.Time
 }
 
 type ServiceInventorySource interface {
@@ -117,7 +119,7 @@ func DefaultSources(cfg *types.Config, back types.ServerlessBackend, kubeClients
 
 				if cfg.ExposedServicesUseSubdomainRoute {
 					serviceFilterTemplate = "`RequestHost\":\"%s." + cfg.IngressHost + "`"
-					serviceFilterAll = "\"[a-zAZ0-9-]+." + cfg.IngressHost + "\" != \"minio." + cfg.IngressHost + "\""
+					serviceFilterAll = "\"[A-Za-z0-9-]+." + cfg.IngressHost + "\" != \"minio." + cfg.IngressHost + "\""
 				} else {
 					serviceFilterTemplate = "\"/system/services/%s/exposed\""
 					serviceFilterAll = "\"/system/services/.+/exposed\""
@@ -185,9 +187,10 @@ func (s *BackendServiceInventorySource) ListServices(ctx context.Context, tr Tim
 			continue
 		}
 		result = append(result, ServiceDescriptor{
-			ID:    service.Name,
-			Name:  service.Name,
-			Image: service.Image,
+			ID:        service.Name,
+			Name:      service.Name,
+			Image:     service.Image,
+			Namespace: service.Namespace,
 		})
 	}
 	status := okStatus(s.Name(), "")
@@ -231,6 +234,17 @@ func (s *PrometheusUsageMetricsSource) Name() string {
 }
 
 func (s *PrometheusUsageMetricsSource) UsageHours(ctx context.Context, tr TimeRange, serviceID string) (float64, float64, *types.SourceStatus, error) {
+	serviceMatcher := serviceID
+	if serviceMatcher != ".*" {
+		serviceMatcher = regexp.QuoteMeta(serviceMatcher)
+	}
+	return s.UsageHoursInNamespace(ctx, tr, regexp.QuoteMeta(s.ServicesNamespace)+".*", serviceMatcher)
+}
+
+// UsageHoursInNamespace returns usage for a service constrained to a namespace
+// matcher. serviceID and namespaceMatcher are regular expressions used by the
+// configured Prometheus query templates.
+func (s *PrometheusUsageMetricsSource) UsageHoursInNamespace(ctx context.Context, tr TimeRange, namespaceMatcher, serviceID string) (float64, float64, *types.SourceStatus, error) {
 	if s.API == nil {
 		err := errors.New("prometheus client not configured")
 		return 0, 0, missingStatus(s.Name(), err), err
@@ -243,8 +257,8 @@ func (s *PrometheusUsageMetricsSource) UsageHours(ctx context.Context, tr TimeRa
 	}
 	rangeLiteral := fmt.Sprintf("%ds", rangeSeconds)
 
-	cpuValue, cpuErr := s.queryValue(ctx, s.CPUQuery, serviceID, rangeLiteral, tr.End)
-	gpuValue, gpuErr := s.queryValue(ctx, s.GPUQuery, serviceID, rangeLiteral, tr.End)
+	cpuValue, cpuErr := s.queryValue(ctx, s.CPUQuery, namespaceMatcher, serviceID, rangeLiteral, tr.End)
+	gpuValue, gpuErr := s.queryValue(ctx, s.GPUQuery, namespaceMatcher, serviceID, rangeLiteral, tr.End)
 
 	status := okStatus(s.Name(), "")
 	if cpuErr != nil || gpuErr != nil {
@@ -262,17 +276,18 @@ func (s *PrometheusUsageMetricsSource) UsageHours(ctx context.Context, tr TimeRa
 	return cpuValue, gpuValue, status, nil
 }
 
-func (s *PrometheusUsageMetricsSource) queryValue(ctx context.Context, template, serviceID, rangeLiteral string, ts time.Time) (float64, error) {
+func (s *PrometheusUsageMetricsSource) queryValue(ctx context.Context, template, namespaceMatcher, serviceID, rangeLiteral string, ts time.Time) (float64, error) {
 	if template == "" {
 		return 0, errors.New("prometheus query template not configured")
 	}
 	query := strings.ReplaceAll(template, "{{service}}", serviceID)
 	query = strings.ReplaceAll(query, "{{range}}", rangeLiteral)
+	query = strings.ReplaceAll(query, "{{namespace}}", namespaceMatcher)
 	if strings.Contains(query, "{{services_namespace}}") {
-		if s.ServicesNamespace == "" {
+		if namespaceMatcher == "" {
 			return 0, errors.New("prometheus services namespace not configured")
 		}
-		query = strings.ReplaceAll(query, "{{services_namespace}}", s.ServicesNamespace)
+		query = strings.ReplaceAll(query, "{{services_namespace}}", namespaceMatcher)
 	}
 
 	result, warnings, err := s.API.Query(ctx, query, ts)
@@ -348,6 +363,7 @@ type LokiRequestLogSource struct {
 	SourceName            string
 	ServiceFilterTemplate string
 	ServiceFilterAll      string
+	scope                 *QueryScope
 }
 
 func (s *LokiRequestLogSource) Name() string {
@@ -368,37 +384,9 @@ func (s *LokiRequestLogSource) ListRequests(ctx context.Context, cfg *types.Conf
 		return nil, missingStatus(s.Name(), err), err
 	}
 
-	values := url.Values{}
-	values.Set("query", query)
-	values.Set("start", strconv.FormatInt(tr.Start.UTC().UnixNano(), 10))
-	values.Set("end", strconv.FormatInt(tr.End.UTC().UnixNano(), 10))
-	values.Set("limit", "5000")
-	values.Set("direction", "forward")
-
-	endpoint := strings.TrimRight(s.BaseURL, "/") + "/loki/api/v1/query_range?" + values.Encode()
 	client := s.Client
 	if client == nil {
 		client = http.DefaultClient
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, missingStatus(s.Name(), err), err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, missingStatus(s.Name(), err), err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("loki query failed: %s", resp.Status)
-		return nil, missingStatus(s.Name(), err), err
-	}
-
-	result, err := decodeLokiResponse(resp.Body)
-	if err != nil {
-		return nil, missingStatus(s.Name(), err), err
 	}
 
 	parseFn := s.ParseFunc
@@ -407,33 +395,84 @@ func (s *LokiRequestLogSource) ListRequests(ctx context.Context, cfg *types.Conf
 	}
 
 	records := make([]RequestRecord, 0)
-	for _, stream := range result {
-		for _, entry := range stream.Values {
-			lokiTime := time.Unix(0, entry.Timestamp)
-			record, ok := parseFn(entry.Line, cfg)
-			if !ok {
-				continue
-			}
-			if record.Country == "" || strings.EqualFold(record.Country, "unknown") {
-				if country := countryFromLokiLabels(stream.Labels); country != "" {
-					record.Country = country
-				}
-			}
-			if record.Timestamp.IsZero() {
-				record.Timestamp = lokiTime
-			}
-			if record.Timestamp.Before(tr.Start) && record.Timestamp.After(tr.End) {
-				continue
-			}
-			if serviceID != "" && record.ServiceID != serviceID {
-				continue
-			}
-			records = append(records, record)
+	pageStart := tr.Start.UTC().UnixNano()
+	end := tr.End.UTC().UnixNano()
+	for pageStart <= end {
+		result, entryCount, lastTimestamp, err := s.fetchLokiPage(ctx, client, query, pageStart, end)
+		if err != nil {
+			return nil, missingStatus(s.Name(), err), err
 		}
+		for _, stream := range result {
+			for _, entry := range stream.Values {
+				lokiTime := time.Unix(0, entry.Timestamp)
+				record, ok := parseFn(entry.Line, cfg)
+				if !ok {
+					continue
+				}
+				if record.Country == "" || strings.EqualFold(record.Country, "unknown") {
+					if country := countryFromLokiLabels(stream.Labels); country != "" {
+						record.Country = country
+					}
+				}
+				if record.Timestamp.IsZero() {
+					record.Timestamp = lokiTime
+				}
+				if record.Timestamp.Before(tr.Start) || record.Timestamp.After(tr.End) {
+					continue
+				}
+				if serviceID != "" && record.ServiceID != serviceID {
+					continue
+				}
+				records = append(records, record)
+			}
+		}
+		if entryCount < 5000 || lastTimestamp < pageStart {
+			break
+		}
+		pageStart = lastTimestamp + 1
 	}
 
 	status := okStatus(s.Name(), "")
 	return records, status, nil
+}
+
+func (s *LokiRequestLogSource) fetchLokiPage(ctx context.Context, client *http.Client, query string, start, end int64) ([]lokiStream, int, int64, error) {
+	values := url.Values{}
+	values.Set("query", query)
+	values.Set("start", strconv.FormatInt(start, 10))
+	values.Set("end", strconv.FormatInt(end, 10))
+	values.Set("limit", "5000")
+	values.Set("direction", "forward")
+
+	endpoint := strings.TrimRight(s.BaseURL, "/") + "/loki/api/v1/query_range?" + values.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, 0, fmt.Errorf("loki query failed: %s", resp.Status)
+	}
+
+	result, err := decodeLokiResponse(resp.Body)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	entryCount := 0
+	lastTimestamp := int64(0)
+	for _, stream := range result {
+		entryCount += len(stream.Values)
+		for _, entry := range stream.Values {
+			if entry.Timestamp > lastTimestamp {
+				lastTimestamp = entry.Timestamp
+			}
+		}
+	}
+	return result, entryCount, lastTimestamp, nil
 }
 
 func parseTraefik(serviceID string, tr TimeRange, result []lokiStream, s *LokiRequestLogSource, parseFn func(string) (RequestRecord, bool)) ([]RequestRecord, *types.SourceStatus, error) {
@@ -483,7 +522,7 @@ func (s *LokiRequestLogSource) buildQuery(serviceID string) string {
 			serviceReplacement = ".*"
 		}
 		query = strings.ReplaceAll(query, "{{service}}", serviceReplacement)
-		return query
+		return s.appendScopeFilter(query)
 	}
 
 	if serviceID != "" && s.ServiceFilterTemplate != "" {
@@ -491,7 +530,40 @@ func (s *LokiRequestLogSource) buildQuery(serviceID string) string {
 	} else if serviceID == "" && s.ServiceFilterAll != "" {
 		query += fmt.Sprintf(" |~ %s", s.ServiceFilterAll)
 	}
-	return query
+	return s.appendScopeFilter(query)
+}
+
+func (s *LokiRequestLogSource) appendScopeFilter(query string) string {
+	if s.scope == nil || s.scope.OwnerNamespace == "" {
+		return query
+	}
+
+	ownerNamespace := regexp.QuoteMeta(s.scope.OwnerNamespace)
+	patterns := []string{
+		`\|\s*` + ownerNamespace + `\s*$`,
+		`"ServiceName"\s*:\s*"` + ownerNamespace + `-`,
+	}
+	activeNames := make([]string, 0, len(s.scope.ActiveServices))
+	seen := make(map[string]struct{}, len(s.scope.ActiveServices))
+	for _, service := range s.scope.ActiveServices {
+		if service.Name == "" {
+			continue
+		}
+		if _, ok := seen[service.Name]; ok {
+			continue
+		}
+		seen[service.Name] = struct{}{}
+		activeNames = append(activeNames, regexp.QuoteMeta(service.Name))
+	}
+	if len(activeNames) > 0 {
+		services := strings.Join(activeNames, "|")
+		patterns = append(patterns,
+			`/(?:job|run)/(?:`+services+`)(?:[/?\s]|$)`,
+			`/system/services/(?:`+services+`)/exposed(?:[/?\s]|$)`,
+			`"(?:RequestAddr|RequestHost)"\s*:\s*"(?:`+services+`)\.`,
+		)
+	}
+	return query + " |~ " + strconv.Quote(strings.Join(patterns, "|"))
 }
 
 type lokiStreamEntry struct {
@@ -704,14 +776,22 @@ func parseGinExecutionLog(line string, cfg *types.Config) (RequestRecord, bool) 
 	path = strings.Trim(path, "\"")
 	path = strings.SplitN(path, "?", 2)[0]
 	serviceID, reqType := parseServiceFromPath(path)
+	serviceNamespace := ""
+	if len(parts) >= 8 {
+		if loggedServiceID := strings.TrimSpace(parts[6]); loggedServiceID != "" {
+			serviceID = loggedServiceID
+		}
+		serviceNamespace = strings.TrimSpace(parts[7])
+	}
 
 	return RequestRecord{
-		ServiceID:  serviceID,
-		UserID:     strings.TrimSpace(parts[5]),
-		Country:    "",
-		AuthMethod: "",
-		Type:       reqType,
-		Timestamp:  timestamp.UTC(),
+		ServiceID:        serviceID,
+		ServiceNamespace: serviceNamespace,
+		UserID:           strings.TrimSpace(parts[5]),
+		Country:          "",
+		AuthMethod:       "",
+		Type:             reqType,
+		Timestamp:        timestamp.UTC(),
 	}, ip != ""
 }
 
@@ -748,17 +828,15 @@ func parseExposedServiceFromPath(path string) (string, bool) {
 
 func parseHTTPAccessLog(line string, cfg *types.Config) (RequestRecord, bool) {
 	var jsonformat map[string]interface{}
-	err := json.Unmarshal([]byte(line), &jsonformat)
-	if err != nil {
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			return RequestRecord{}, false
-		}
+	if err := json.Unmarshal([]byte(line), &jsonformat); err != nil {
+		return RequestRecord{}, false
 	}
 	var timestamp time.Time
-	parsed, err := time.Parse("02/Jan/2006:15:04:05 -0700", jsonformat["StartUTC"].(string))
-	if err == nil {
-		timestamp = parsed
+	if timestampRaw, ok := jsonformat["StartUTC"].(string); ok {
+		parsed, err := time.Parse("02/Jan/2006:15:04:05 -0700", timestampRaw)
+		if err == nil {
+			timestamp = parsed
+		}
 	}
 
 	serviceID, good := extractServiceFromExposedPath(jsonformat, cfg.ExposedServicesUseSubdomainRoute)
@@ -766,13 +844,43 @@ func parseHTTPAccessLog(line string, cfg *types.Config) (RequestRecord, bool) {
 		return RequestRecord{}, false
 	}
 	return RequestRecord{
-		ServiceID:  serviceID,
-		UserID:     "",
-		Country:    "",
-		AuthMethod: "",
-		Type:       "",
-		Timestamp:  timestamp,
+		ServiceID:        serviceID,
+		ServiceNamespace: traefikServiceNamespace(jsonformat, serviceID),
+		UserID:           "",
+		Country:          "",
+		AuthMethod:       "",
+		Type:             "",
+		Timestamp:        timestamp,
 	}, true
+}
+
+func traefikServiceNamespace(fields map[string]interface{}, serviceID string) string {
+	serviceName, _ := fields["ServiceName"].(string)
+	serviceName = strings.TrimSpace(serviceName)
+	if serviceName == "" || serviceID == "" {
+		return ""
+	}
+	pattern := `^(.+)-` + regexp.QuoteMeta(serviceID) + `-svc(?:-|@)`
+	match := regexp.MustCompile(pattern).FindStringSubmatch(serviceName)
+	if len(match) != 2 {
+		return ""
+	}
+	return match[1]
+}
+
+func ingressServiceNamespace(line, serviceID string) string {
+	if serviceID == "" {
+		return ""
+	}
+	// The default ingress-nginx upstream field is
+	// [<namespace>-<service>-<port>]. Use the service parsed from the request
+	// path to isolate the namespace without depending on a fixed log layout.
+	pattern := `\[([^]]+)-` + regexp.QuoteMeta(serviceID) + `-[^]]+\]`
+	match := regexp.MustCompile(pattern).FindStringSubmatch(line)
+	if len(match) != 2 {
+		return ""
+	}
+	return match[1]
 }
 
 func parseIngressAccessLog(line string, cfg *types.Config) (RequestRecord, bool) {
@@ -813,25 +921,30 @@ func parseIngressAccessLog(line string, cfg *types.Config) (RequestRecord, bool)
 	}
 
 	return RequestRecord{
-		ServiceID:  serviceID,
-		UserID:     "",
-		Country:    "",
-		AuthMethod: "",
-		Type:       "",
-		Timestamp:  timestamp,
+		ServiceID:        serviceID,
+		ServiceNamespace: ingressServiceNamespace(line, serviceID),
+		UserID:           "",
+		Country:          "",
+		AuthMethod:       "",
+		Type:             "",
+		Timestamp:        timestamp,
 	}, true
 }
 
 func extractServiceFromExposedPath(path map[string]interface{}, expose_service_user_subdomine_route bool) (string, bool) {
 	if expose_service_user_subdomine_route {
-		reqAddrRaw, ok := path["RequestAddr"]
-		if !ok {
+		var dns string
+		for _, key := range []string{"RequestHost", "RequestAddr"} {
+			value, ok := path[key].(string)
+			if ok && strings.TrimSpace(value) != "" {
+				dns = strings.TrimSpace(value)
+				break
+			}
+		}
+		if dns == "" {
 			return "", false
 		}
-		dns, ok := reqAddrRaw.(string)
-		if !ok || dns == "" {
-			return "", false
-		}
+		dns = strings.SplitN(dns, ":", 2)[0]
 		routerNameRaw, ok := path["RouterName"]
 		if !ok {
 			return "", false
@@ -848,7 +961,10 @@ func extractServiceFromExposedPath(path map[string]interface{}, expose_service_u
 			return "", false
 		}
 	} else {
-		pathString := path["RequestPath"].(string)
+		pathString, ok := path["RequestPath"].(string)
+		if !ok || pathString == "" {
+			return "", false
+		}
 		pathString = strings.SplitN(pathString, "?", 2)[0]
 		const prefix = "/system/services/"
 		if !strings.HasPrefix(pathString, prefix) {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -272,10 +272,10 @@ type Config struct {
 	// PrometheusBaseURL base URL for Prometheus HTTP API
 	PrometheusBaseURL string `json:"-"`
 
-	// PrometheusCPUQuery query template for CPU hours (use {{service}}, {{range}}, and {{services_namespace}})
+	// PrometheusCPUQuery query template for CPU hours (use {{service}}, {{range}}, and {{namespace}})
 	PrometheusCPUQuery string `json:"-"`
 
-	// PrometheusGPUQuery query template for GPU hours (use {{service}}, {{range}}, and {{services_namespace}})
+	// PrometheusGPUQuery query template for GPU hours (use {{service}}, {{range}}, and {{namespace}})
 	PrometheusGPUQuery string `json:"-"`
 
 	// LokiBaseURL base URL for Loki HTTP API
@@ -382,11 +382,11 @@ var configVars = []configVar{
 	{"JobListingLimit", "JOB_LISTING_LIMIT", false, intType, "70"},
 	{"KserveEnable", "KSERVE_ENABLE", false, boolType, "false"},
 	{"PrometheusBaseURL", "PROMETHEUS_URL", false, urlType, ""},
-	{"PrometheusCPUQuery", "PROMETHEUS_CPU_QUERY", false, stringType, "sum(increase(container_cpu_usage_seconds_total{namespace=~\"{{services_namespace}}.*\",service=~\"{{service}}\"}[{{range}}])) / 3600"},
-	{"PrometheusGPUQuery", "PROMETHEUS_GPU_QUERY", false, stringType, "sum(increase(container_gpu_usage_seconds_total{namespace=~\"{{services_namespace}}.*\",service=~\"{{service}}\"}[{{range}}])) / 3600"},
+	{"PrometheusCPUQuery", "PROMETHEUS_CPU_QUERY", false, stringType, "sum(increase(container_cpu_usage_seconds_total{namespace=~\"{{namespace}}\",service=~\"{{service}}\"}[{{range}}])) / 3600"},
+	{"PrometheusGPUQuery", "PROMETHEUS_GPU_QUERY", false, stringType, "sum(increase(container_gpu_usage_seconds_total{namespace=~\"{{namespace}}\",service=~\"{{service}}\"}[{{range}}])) / 3600"},
 	{"LokiBaseURL", "LOKI_URL", false, urlType, ""},
 	{"LokiQuery", "LOKI_QUERY", false, stringType, "{namespace=\"{{namespace}}\", app=\"{{app}}\"} |~ \"/(job|run)/\""},
-	{"LokiExposedQuery", "LOKI_EXPOSED_QUERY", false, stringType, "{namespace=\"{{namespace}}\", app=\"{{app}}\"} |~ \"/system/services/.+/exposed\""},
+	{"LokiExposedQuery", "LOKI_EXPOSED_QUERY", false, stringType, "{namespace=\"{{namespace}}\", app=\"{{app}}\"}"},
 	{"LokiExposedNamespace", "LOKI_EXPOSED_NAMESPACE", false, stringType, "ingress-nginx"},
 	{"LokiExposedAppLabel", "LOKI_EXPOSED_APP", false, stringType, "ingress-nginx"},
 	{"MinIOQuotaEnabled", "MINIO_QUOTA_ENABLED", false, boolType, "false"},

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -112,3 +112,13 @@ type MetricsBreakdownResponse struct {
 	GroupBy string          `json:"group_by"`
 	Items   []BreakdownItem `json:"items"`
 }
+
+type MetricsOwner struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type MetricsOwnersResponse struct {
+	Owners []MetricsOwner `json:"owners"`
+}

--- a/pkg/utils/auth/auth.go
+++ b/pkg/utils/auth/auth.go
@@ -29,6 +29,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	metricsServiceNameContextKey      = "metricsServiceName"
+	metricsServiceNamespaceContextKey = "metricsServiceNamespace"
+)
+
+// SetMetricsServiceContext adds the resolved service identity to the execution
+// log without changing the public request path.
+func SetMetricsServiceContext(c *gin.Context, serviceName, serviceNamespace string) {
+	c.Set(metricsServiceNameContextKey, serviceName)
+	c.Set(metricsServiceNamespaceContextKey, serviceNamespace)
+}
+
 // GetAuthMiddleware returns the appropriate gin auth middleware
 func GetAuthMiddleware(cfg *types.Config, kubeClientset kubernetes.Interface) gin.HandlerFunc {
 	if !cfg.OIDCEnable {
@@ -140,8 +152,10 @@ func GetLoggerMiddleware() gin.HandlerFunc {
 			clientIP, _ = IPAddress.(string)
 		}
 
-		log.Printf("[GIN-EXECUTIONS-LOGGER] %s | %3d | %13v | %s | %-7s %s | %s", // #nosec
-			logTime, status, latency, clientIP, method, path, user) // #nosec
+		serviceName := c.GetString(metricsServiceNameContextKey)
+		serviceNamespace := c.GetString(metricsServiceNamespaceContextKey)
+		log.Printf("[GIN-EXECUTIONS-LOGGER] %s | %3d | %13v | %s | %-7s %s | %s | %s | %s", // #nosec
+			logTime, status, latency, clientIP, method, path, user, serviceName, serviceNamespace) // #nosec
 	}
 }
 

--- a/pkg/utils/auth/auth_test.go
+++ b/pkg/utils/auth/auth_test.go
@@ -27,6 +27,17 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func TestSetMetricsServiceContext(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	SetMetricsServiceContext(c, "service", "namespace")
+
+	service, serviceExists := c.Get(metricsServiceNameContextKey)
+	namespace, namespaceExists := c.Get(metricsServiceNamespaceContextKey)
+	if !serviceExists || service != "service" || !namespaceExists || namespace != "namespace" {
+		t.Fatalf("unexpected metrics service context: service=%v namespace=%v", service, namespace)
+	}
+}
+
 func TestGetAuthMiddleware(t *testing.T) {
 	cfg := &types.Config{
 		OIDCEnable: false,

--- a/pkg/utils/auth/oidc.go
+++ b/pkg/utils/auth/oidc.go
@@ -117,15 +117,9 @@ func getOIDCMiddleware(kubeClientset kubernetes.Interface, objectStorageIAM obje
 		if oidcConfig != nil {
 			issuerManager.config = oidcConfig
 		}
-		if err != nil {
-			return func(c *gin.Context) {
-				c.AbortWithStatus(http.StatusUnauthorized)
-				return
-			}
+		if err == nil {
+			ClusterOidcManagers[iss] = issuerManager
 		}
-
-		ClusterOidcManagers[iss] = issuerManager
-
 	}
 
 	mc := NewMultitenancyConfig(kubeClientset, cfg.OIDCSubject)

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/grycap/oscar/v4/pkg/types"
@@ -48,6 +49,41 @@ const (
 )
 
 var sanitizeRegexp = regexp.MustCompile(namespaceSanitizePattern)
+
+type ManagedUserNamespace struct {
+	Name  string
+	Owner string
+}
+
+// ListManagedUserNamespaces returns the persistent OSCAR namespace-to-owner
+// mappings. The shared cluster-admin namespace is intentionally omitted because
+// it does not store owner information.
+func ListManagedUserNamespaces(ctx context.Context, kubeClientset kubernetes.Interface) ([]ManagedUserNamespace, error) {
+	if kubeClientset == nil {
+		return nil, fmt.Errorf("kubernetes clientset cannot be nil")
+	}
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	namespaces, err := kubeClientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: namespaceManagedByLabel + "=" + namespaceManagedByValue,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]ManagedUserNamespace, 0, len(namespaces.Items))
+	for _, namespace := range namespaces.Items {
+		owner := strings.TrimSpace(namespace.Annotations[namespaceOwnerLabel])
+		if owner == "" {
+			continue
+		}
+		result = append(result, ManagedUserNamespace{Name: namespace.Name, Owner: owner})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Owner < result[j].Owner })
+	return result, nil
+}
 
 // BuildUserNamespace returns the namespace name that should be used to deploy
 // services owned by the provided user. When no owner is provided (i.e. cluster admin)

--- a/pkg/utils/namespaces_test.go
+++ b/pkg/utils/namespaces_test.go
@@ -513,6 +513,25 @@ func TestListManagedUserNamespaces(t *testing.T) {
 	}
 }
 
+func TestListManagedUserNamespacesInputHandling(t *testing.T) {
+	if _, err := ListManagedUserNamespaces(t.Context(), nil); err == nil {
+		t.Fatal("ListManagedUserNamespaces() with nil clientset should return an error")
+	}
+
+	clientset := fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:        "oscar-svc-user",
+		Labels:      map[string]string{namespaceManagedByLabel: namespaceManagedByValue},
+		Annotations: map[string]string{namespaceOwnerLabel: " user "},
+	}})
+	namespaces, err := ListManagedUserNamespaces(nil, clientset)
+	if err != nil {
+		t.Fatalf("ListManagedUserNamespaces() error: %v", err)
+	}
+	if len(namespaces) != 1 || namespaces[0].Owner != "user" {
+		t.Fatalf("ListManagedUserNamespaces() = %+v, want trimmed owner", namespaces)
+	}
+}
+
 func TestNamespaceConstants(t *testing.T) {
 	// Test that constants have expected values
 	if maxNamespaceLength != 18 {

--- a/pkg/utils/namespaces_test.go
+++ b/pkg/utils/namespaces_test.go
@@ -483,6 +483,36 @@ func TestEnsureUserNamespaceBasic(t *testing.T) {
 	})
 }
 
+func TestListManagedUserNamespaces(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:        "oscar-svc-user-b",
+			Labels:      map[string]string{namespaceManagedByLabel: namespaceManagedByValue},
+			Annotations: map[string]string{namespaceOwnerLabel: "user-b"},
+		}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:        "oscar-svc-user-a",
+			Labels:      map[string]string{namespaceManagedByLabel: namespaceManagedByValue},
+			Annotations: map[string]string{namespaceOwnerLabel: "user-a"},
+		}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   "oscar-svc",
+			Labels: map[string]string{namespaceManagedByLabel: namespaceManagedByValue},
+		}},
+	)
+
+	namespaces, err := ListManagedUserNamespaces(t.Context(), clientset)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(namespaces) != 2 {
+		t.Fatalf("expected two user namespaces, got %+v", namespaces)
+	}
+	if namespaces[0].Owner != "user-a" || namespaces[1].Owner != "user-b" {
+		t.Fatalf("expected owners sorted by id, got %+v", namespaces)
+	}
+}
+
 func TestNamespaceConstants(t *testing.T) {
 	// Test that constants have expected values
 	if maxNamespaceLength != 18 {


### PR DESCRIPTION
## Rationale
Currently, OSCAR only shows metrics for active services. This PR allows to show metrics from deployed services that are no longer active.

## Summary

- scope OIDC metrics to services owned by the authenticated user instead of including public or authorized restricted services
- preserve the service name and namespace in execution logs so retained metrics remain attributable after a service is deleted
- derive exposed-service namespaces from Traefik access logs and support both path-based and DNS-based routes
- add namespace-aware Prometheus queries and paginated Loki queries for complete scoped results
- add an administrator-only owner catalog and an `owner` filter for summary, breakdown, and per-service metrics endpoints
- document authorization, historical-data behavior, owner filtering, and metrics source configuration

## Authorization behavior

Bearer-authenticated users only receive metrics for their own service namespace. Basic-authenticated OSCAR administrators retain cluster-wide access and can optionally select an exact owner namespace. Historical records without namespace metadata remain available only while their service can still be matched to an active owned service.

## API changes

- add `GET /system/metrics/owners` for administrator Basic Auth
- accept `owner` on `GET /system/metrics`, `GET /system/metrics/breakdown`, and `GET /system/metrics/{serviceName}` for administrators

## Validation

- `go test ./...`
- `git diff --check`