### PR TITLE
Fix knative service overhead

### DIFF
--- a/pkg/backends/knative.go
+++ b/pkg/backends/knative.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grycap/oscar/v4/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -470,6 +471,13 @@ func (kn *KnativeBackend) createKNServiceDefinition(service *types.Service, name
 	podSpec, err := service.ToPodSpec(kn.config)
 	if err != nil {
 		return nil, err
+	}
+
+	// Subtract 25m CPU for the queue-proxy sidecar container, which is added by Knative automatically.
+	// This prevents the pod from being evicted due to CPU limit exceeded.
+	if cpuLimit, ok := podSpec.Containers[0].Resources.Limits[v1.ResourceCPU]; ok {
+		cpuLimit.Sub(resource.MustParse("25m"))
+		podSpec.Containers[0].Resources.Limits[v1.ResourceCPU] = cpuLimit
 	}
 
 	// fix ContainerConcurrency to 1 to avoid parallel invocations in the same container

--- a/pkg/handlers/create_test.go
+++ b/pkg/handlers/create_test.go
@@ -847,6 +847,7 @@ func TestValidateServiceCreation(t *testing.T) {
 			service: types.Service{
 				Name:           "svc",
 				Image:          "img",
+				CPU:            "0.2",
 				Visibility:     "public",
 				IsolationLevel: types.IsolationLevelService,
 			},
@@ -858,6 +859,7 @@ func TestValidateServiceCreation(t *testing.T) {
 			service: types.Service{
 				Name:           "svc",
 				Image:          "img",
+				CPU:            "0.2",
 				Visibility:     "invalid",
 				IsolationLevel: types.IsolationLevelService,
 			},
@@ -869,6 +871,7 @@ func TestValidateServiceCreation(t *testing.T) {
 			service: types.Service{
 				Name:           "svc",
 				Image:          "img",
+				CPU:            "0.2",
 				Visibility:     "public",
 				IsolationLevel: types.IsolationLevelUser,
 			},

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -362,6 +362,8 @@ func (s *Service) UnmarshalJSON(data []byte) error {
 	aux := Alias{
 		IsolationLevel: IsolationLevelService,
 		Visibility:     PRIVATE,
+		CPU:            "0.2",
+		Memory:         "256Mi",
 	}
 
 	if err := json.Unmarshal(data, &aux); err != nil {

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -422,6 +422,10 @@ func (s Service) Validate() error {
 		return fmt.Errorf("service Image is required")
 	}
 
+	if cpu, err := resource.ParseQuantity(s.CPU); err != nil || cpu.Cmp(resource.MustParse("0.2")) < 0 {
+		return fmt.Errorf("service CPU must be greater than or equal to 0.2")
+	}
+
 	if s.IsKserve() {
 		return s.Kserve.Validate()
 	}


### PR DESCRIPTION
This pull request introduces improvements to resource management and validation for Knative services. The main changes focus on ensuring that CPU resource limits account for Knative's queue-proxy sidecar and enforcing a minimum CPU requirement during service validation.

**Resource Management Updates:**

* Adjusted CPU resource limits in `createKNServiceDefinition` to subtract 25m CPU for the Knative queue-proxy sidecar, preventing pod eviction due to CPU limit exceedance. (`pkg/backends/knative.go`)
* Imported the `k8s.io/apimachinery/pkg/api/resource` package to support resource quantity parsing and manipulation. (`pkg/backends/knative.go`)

**Validation Enhancements:**

* Added a check in `Service.Validate()` to ensure the CPU value is at least 0.2, improving reliability by preventing under-provisioned services. (`pkg/types/service.go`)