### PR TITLE
fix: preserve visibility of existing mounted buckets

### DIFF
--- a/pkg/handlers/create.go
+++ b/pkg/handlers/create.go
@@ -900,18 +900,16 @@ func createBuckets(service *types.Service, cfg *types.Config, minIOAdminClient *
 
 				if visibility != types.PRIVATE {
 					return nil, fmt.Errorf("the bucket \"%s\" must be private to be used as mount", minio.BucketName)
-				} else {
-					err := minIOAdminClient.CreateS3Path(s3Client, splitPath, true)
-					minIOBuckets = append(minIOBuckets, types.MinIOBucket{
-						BucketName:   splitPath[0],
-						AllowedUsers: service.AllowedUsers,
-						Visibility:   service.Visibility,
-						Owner:        service.Owner})
-					if err != nil && !isUpdate {
-						return nil, err
-					}
-					return minIOBuckets, nil
 				}
+
+				// The bucket already exists and is only being mounted. Creating the
+				// folder is part of the mount operation, but the bucket itself is
+				// owned by another resource and must not inherit this service's
+				// visibility or policies.
+				if err := minIOAdminClient.CreateS3Path(s3Client, splitPath, true); err != nil && !isUpdate {
+					return nil, err
+				}
+				return minIOBuckets, nil
 			}
 
 			// Create mount bucket


### PR DESCRIPTION
## Summary
- Prevent an existing MinIO bucket used only through `mount` from inheriting the visibility of the service being created.
- Keep the mount-folder creation and private-bucket validation unchanged.
- Leave existing bucket policy management to the resource that owns the bucket.

## Root cause
When `createBuckets` found an existing private mount bucket, it added that bucket to the list of buckets managed by the new service, using the new service's visibility. The service creation handler subsequently applied those policies, changing a private bucket to `restricted` when the new service was restricted.

## Fix
Existing mount-only buckets are no longer returned as service-managed buckets. OSCAR still creates the requested mount folder, but does not apply the new service's visibility or policies to the existing bucket.

## Verification
- `go test ./pkg/handlers ./pkg/backends/object_storage ./pkg/types`
- `git diff --check`
- Deployed with `make deploy KUBE_CONTEXT=kind-oscar-test-zgf`
- Verified rollout with image `localhost:5001/oscar:devel` and `1/1` ready replicas.
- Reproduced the scenario in the local cluster with a private bucket and a restricted service mounting it; the bucket remained private.

## Related issue
- grycap/issue-tracker#472
