### PR TITLE
feat: add support for selecting storage backend (minio or rustfs)

### DIFF
--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -1111,7 +1111,7 @@ else
     echo -e "\n[*] Deploying RustFS storage provider ..."
     STORAGE_ACCESS_KEY="rustfs"
     helm repo add rustfs https://charts.rustfs.com
-    helm install rustfs rustfs/rustfs --namespace rustfs --create-namespace --version 1.0.0-rc.5 \
+    helm install rustfs rustfs/rustfs --namespace rustfs --create-namespace --version 0.12.0 \
     --set secret.rustfs.access_key=$STORAGE_ACCESS_KEY \
     --set secret.rustfs.secret_key=$MINIO_PASSWORD \
     --set storageclass.name=standard \

--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -35,6 +35,7 @@ DEFAULT_MINIO_API_PORT=30300
 DEFAULT_MINIO_CONSOLE_PORT=30301
 DEFAULT_REGISTRY_PORT=5001
 DEFAULT_TRAEFIK_DASHBOARD_PORT=9080
+STORAGE_BACKEND="minio"
 OSCAR_IMAGE_BRANCH="master"
 OSCAR_HELM_IMAGE_OVERRIDES=""
 OSCAR_POST_DEPLOYMENT_IMAGE=""
@@ -52,6 +53,7 @@ OIDC_GROUPS_DEFAULT="/oscar-staff, /oscar-test"
 GATEWAY_CONTROLLER="traefik"
 GATEWAY_CONTROLLER_SET="false"
 USE_DNS_WILDCARDS="true"
+STORAGE_ACCESS_KEY="minio"
 
 usage(){
     cat <<EOF
@@ -63,6 +65,7 @@ Options:
     --oidc                       Enable OIDC support for OSCAR (default: disabled).
     --kueue                      Enable Kueue support for CPU and memory quotas (default: disabled).
     --kserve                     Install KServe using deploy/kind-oscar-kserve.sh (default: disabled).
+    --storage=(minio|rustfs)     Select the storage backend to use (default: minio).
     --minio-quotas               Deploy MinIO with 1 replica and 4 PVCs to support bucket quotas.
     --wildcards[=true|false]     Enable or disable DNS wildcard support for Traefik (default: true).
     --host HOST                  Use HOST as OSCAR host (default: localhost).
@@ -74,7 +77,7 @@ EOF
 
 showInfo(){
     echo "[*] This script will install a Kubernetes cluster using Kind along with all the required OSCAR services (if not installed): "
-    echo -e "\n- MinIO"
+    echo -e "\n- MinIO | RustFS"
     echo -e "- Helm"
     echo -e "- Kubectl\n"
 
@@ -739,6 +742,20 @@ while [ "$#" -gt 0 ]; do
             ENABLE_KSERVE="true"
             shift
             ;;
+        --storage)
+            shift
+            if [ "$#" -eq 0 ]; then
+                echo -e "$RED[!]$END_COLOR Missing value for --storage"
+                usage
+                exit 1
+            fi
+            STORAGE_BACKEND="$1"
+            shift
+            ;;
+        --storage=*)
+            STORAGE_BACKEND="${1#*=}"
+            shift
+            ;;
         --minio-quotas)
             ENABLE_MINIO_QUOTAS="true"
             shift
@@ -794,6 +811,13 @@ done
 
 showInfo
 
+STORAGE_BACKEND=$(echo "$STORAGE_BACKEND" | tr '[:upper:]' '[:lower:]')
+if [ "$STORAGE_BACKEND" != "minio" ] && [ "$STORAGE_BACKEND" != "rustfs" ]; then
+    echo -e "$RED[!]$END_COLOR Invalid storage backend: $STORAGE_BACKEND (expected: minio|rustfs)"
+    usage
+    exit 1
+fi
+
 echo -e "\n[*] Checking prerequisites ..."
 checkDocker
 checkKubectl
@@ -810,8 +834,17 @@ use_kserve="n"
 use_kueue="n"
 use_minio_quotas="n"
 if [ "$SKIP_PROMPTS" == "true" ]; then
-    echo "[*] Running in non-interactive mode: Knative, local registry, and OSCAR devel branch enabled."
+    echo "[*] Running in non-interactive mode: Knative, local registry, OSCAR devel branch, and default storage backend ($STORAGE_BACKEND) enabled."
 else
+    read -p "Choose the storage backend to use [minio/rustfs] (default: minio): " storage_choice </dev/tty
+    storage_choice=$(echo "$storage_choice" | tr '[:upper:]' '[:lower:]')
+    if [ -n "$storage_choice" ]; then
+        if [ "$storage_choice" != "minio" ] && [ "$storage_choice" != "rustfs" ]; then
+            echo -e "$RED[!]$END_COLOR Invalid storage backend: $storage_choice (expected: minio|rustfs)"
+            exit 1
+        fi
+        STORAGE_BACKEND="$storage_choice"
+    fi
     read -p "Do you want to use Knative Serving as Serverless Backend? [y/n] " use_knative </dev/tty
     read -p "Do you want suport for local docker images? [y/n] " local_reg </dev/tty
     read -p "Do you want to install OSCAR from the devel branch? [y/n] (default uses master) " use_devel_branch </dev/tty
@@ -1065,15 +1098,39 @@ fi
 
 deployGatewayController
   
-#Deploy MinIO
-echo -e "\n[*] Deploying MinIO storage provider ..."
-helm repo add --force-update minio https://charts.min.io
-MINIO_HELM_MODE_ARGS="--set mode=standalone"
-if [ "$ENABLE_MINIO_QUOTAS" == "true" ]; then
-    MINIO_HELM_MODE_ARGS="--set mode=distributed --set replicas=1 --set drivesPerNode=4 --set persistence.size=2Gi"
+#Deploy storage backend
+if [ "$STORAGE_BACKEND" == "minio" ]; then
+    echo -e "\n[*] Deploying MinIO storage provider ..."
+    helm repo add --force-update minio https://charts.min.io
+    MINIO_HELM_MODE_ARGS="--set mode=standalone"
+    if [ "$ENABLE_MINIO_QUOTAS" == "true" ]; then
+        MINIO_HELM_MODE_ARGS="--set mode=distributed --set replicas=1 --set drivesPerNode=4 --set persistence.size=2Gi"
+    fi
+    helm install minio minio/minio --namespace minio --set rootUser=minio,rootPassword=$MINIO_PASSWORD,service.type=NodePort,service.nodePort=$HOST_MINIO_API_PORT,consoleService.type=NodePort,consoleService.nodePort=$HOST_MINIO_CONSOLE_PORT,resources.requests.memory=512Mi,environment.MINIO_BROWSER_REDIRECT_URL=http://localhost:$HOST_MINIO_CONSOLE_PORT $MINIO_HELM_MODE_ARGS --create-namespace --version 5.4.0
+else
+    echo -e "\n[*] Deploying RustFS storage provider ..."
+    STORAGE_ACCESS_KEY="rustfs"
+    helm repo add rustfs https://charts.rustfs.com
+    helm install rustfs rustfs/rustfs --namespace rustfs --create-namespace --version 1.0.0-rc.5 \
+    --set secret.rustfs.access_key=$STORAGE_ACCESS_KEY \
+    --set secret.rustfs.secret_key=$MINIO_PASSWORD \
+    --set storageclass.name=standard \
+    --set storageclass.dataStorageSize=100Gi \
+    --set storageclass.logStorageSize=1Gi \
+    --set mode.standalone.enabled=true --set mode.distributed.enabled=false \
+    --set service.console.nodePort=$HOST_MINIO_CONSOLE_PORT \
+    --set service.endpoint.nodePort=$HOST_MINIO_API_PORT \
+    --set service.type=NodePort \
+    --set 'extraEnv[0].name=RUSTFS_BROWSER_REDIRECT_URL' \
+    --set "extraEnv[0].value=http://localhost:$HOST_MINIO_CONSOLE_PORT" \
+    --set 'extraEnv[1].name=RUSTFS_CORS_ALLOWED_ORIGINS' \
+    --set-string 'extraEnv[1].value=*' \
+    --set 'extraEnv[2].name=RUSTFS_OUTBOUND_ALLOW_ORIGINS' \
+    --set-string 'extraEnv[2].value=http://oscar.oscar:8080' 
+    # Set sessionAffinity to None for rustfs-svc to avoid issues with access to the nodePort on localhost
+    # Production deployments should not use NodePort
+    kubectl patch svc rustfs-svc -n rustfs -p '{"spec":{"sessionAffinity":"None"}}'
 fi
-helm install minio minio/minio --namespace minio --set rootUser=minio,rootPassword=$MINIO_PASSWORD,service.type=NodePort,service.nodePort=$HOST_MINIO_API_PORT,consoleService.type=NodePort,consoleService.nodePort=$HOST_MINIO_CONSOLE_PORT,resources.requests.memory=512Mi,environment.MINIO_BROWSER_REDIRECT_URL=http://localhost:$HOST_MINIO_CONSOLE_PORT $MINIO_HELM_MODE_ARGS --create-namespace --version 5.4.0
-
 
 #Deploy NFS server provisioner
 echo -e "\n[*] Deploying NFS server provider ..."
@@ -1119,9 +1176,9 @@ kubectl apply -f https://raw.githubusercontent.com/grycap/oscar/master/deploy/ya
 echo -e "\n[*] Deploying OSCAR ..."
 helm repo add --force-update grycap https://grycap.github.io/helm-charts/
 if [ $(echo $use_knative | tr '[:upper:]' '[:lower:]') == "y" ]; then 
-    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.endpoint=http://host.docker.internal:$HOST_MINIO_API_PORT  --set minIO.TLSVerify=false --set minIO.accessKey=minio --set minIO.secretKey="$MINIO_PASSWORD" --set minIO.quota.enabled="$ENABLE_MINIO_QUOTAS" --set serverlessBackend=knative --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
+    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.object_storage_type="$STORAGE_BACKEND" --set minIO.endpoint=http://host.docker.internal:$HOST_MINIO_API_PORT  --set minIO.TLSVerify=false --set minIO.accessKey=$STORAGE_ACCESS_KEY --set minIO.secretKey="$MINIO_PASSWORD" --set minIO.quota.enabled="$ENABLE_MINIO_QUOTAS" --set serverlessBackend=knative --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
 else
-    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.endpoint=http://host.docker.internal:$HOST_MINIO_API_PORT --set minIO.TLSVerify=false --set minIO.accessKey=minio --set minIO.secretKey="$MINIO_PASSWORD" --set minIO.quota.enabled="$ENABLE_MINIO_QUOTAS" --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
+    helm install --namespace=oscar oscar grycap/oscar $OSCAR_EXPOSURE_HELM_ARGS --set httproute.host="$OSCAR_HOST" --set authPass="$OSCAR_PASSWORD" --set service.type=ClusterIP --set volume.storageClassName=nfs --set minIO.object_storage_type="$STORAGE_BACKEND" --set minIO.endpoint=http://host.docker.internal:$HOST_MINIO_API_PORT --set minIO.TLSVerify=false --set minIO.accessKey=$STORAGE_ACCESS_KEY --set minIO.secretKey="$MINIO_PASSWORD" --set minIO.quota.enabled="$ENABLE_MINIO_QUOTAS" --set resourceManager.enable=true --set kueue.enable="$ENABLE_KUEUE" $OSCAR_HELM_IMAGE_OVERRIDES
 fi
 
 if [ -n "$OSCAR_POST_DEPLOYMENT_IMAGE" ]; then
@@ -1211,10 +1268,11 @@ echo "  - MinIO API NodePort/host port: $HOST_MINIO_API_PORT ($minio_api_url)"
 echo "  - MinIO console NodePort/host port: $HOST_MINIO_CONSOLE_PORT ($minio_console_url)"
 echo "  - MinIO bucket quotas enabled: $ENABLE_MINIO_QUOTAS"
 echo "  - Gateway controller: $GATEWAY_CONTROLLER"
+echo "  - Storage backend: $STORAGE_BACKEND"
 echo "  - KServe enabled: $ENABLE_KSERVE"
 echo "  - OSCAR image branch: $OSCAR_IMAGE_BRANCH"
 echo "  - OSCAR credentials: username='oscar', password='$OSCAR_PASSWORD'"
-echo "  - MinIO credentials: username='minio', password='$MINIO_PASSWORD'"
+echo "  - MinIO credentials: username=$STORAGE_ACCESS_KEY, password='$MINIO_PASSWORD'"
 if [ $(echo $local_reg | tr '[:upper:]' '[:lower:]') == "y" ]; then
     echo "  - Local registry: ${reg_name} (port ${reg_port}, ${registry_status})"
 else


### PR DESCRIPTION
This pull request enhances the `deploy/kind-deploy.sh` script by introducing support for selecting between MinIO and RustFS as the storage backend, instead of only supporting MinIO. The script now accepts a `--storage` option, updates prompts and output to reflect the chosen backend, and adjusts the deployment logic and OSCAR Helm chart configuration accordingly.

**Storage backend selection and deployment:**

* Added support for a new `--storage` option (`minio` or `rustfs`), including validation, interactive prompt, and documentation updates. The script now defaults to MinIO but allows RustFS to be chosen via CLI flag or prompt. [[1]](diffhunk://#diff-259702d9b69295cbf2fcff84dc0748361bc3dc4d50bc0a98de8369203794ebeeR38) [[2]](diffhunk://#diff-259702d9b69295cbf2fcff84dc0748361bc3dc4d50bc0a98de8369203794ebeeR68) [[3]](diffhunk://#diff-259702d9b69295cbf2fcff84dc0748361bc3dc4d50bc0a98de8369203794ebeeL77-R80) [[4]](diffhunk://#diff-259702d9b69295cbf2fcff84dc0748361bc3dc4d50bc0a98de8369203794ebeeR745-R758) [[5]](diffhunk://#diff-259702d9b69295cbf2fcff84dc0748361bc3dc4d50bc0a98de8369203794ebeeR814-R820) [[6]](diffhunk://#diff-259702d9b69295cbf2fcff84dc0748361bc3dc4d50bc0a98de8369203794ebeeL813-R847)
* Deployment logic now provisions either MinIO or RustFS based on the selected backend, with appropriate Helm chart parameters and environment variables for each.

**OSCAR Helm chart integration:**

* The OSCAR deployment now passes the selected storage backend type and credentials to the Helm chart, ensuring OSCAR is configured to use the correct object storage provider.

**Output and credential handling:**

* Script output now includes the selected storage backend and updates credential display to reflect the backend in use (MinIO or RustFS).

**Minor improvements:**

* Added a default value for `STORAGE_ACCESS_KEY` and ensured consistency across deployment scenarios.
